### PR TITLE
docker: address startup warnings for mysql container

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -33,6 +33,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: start mysql
+      run: sudo service mysql start
     - name: Run Tests
       env:
         DATABASE_ENGINE: django.db.backends.mysql

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:8.4
         ports:
           - 3306:3306
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD} # Add a root password
     ports:
       - "3307:3306"
+    command: --pid-file=/var/run/mysql/mysqld.pid
     volumes:
       - mysql_data:/var/lib/mysql
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_DATABASE: ${DATABASE_NAME}
       MYSQL_USER: ${DATABASE_USERNAME}


### PR DESCRIPTION
## Changelog

- Updated mysql image version from 8.0 to 8.4 (removes Warning: The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.)
- Added command to remove Warning: Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.

[Differences between 8.0 and 8.4](https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html)
I don't believe there is anything breaking 👀 (We could update to latest 9.0+ too..)

Closes #11 