### PR TITLE
 actions: use codecov for coverage reporting

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -50,4 +50,4 @@ jobs:
     - name: Coverage Report
       uses: py-cov-action/python-coverage-comment-action@v3
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -47,7 +47,8 @@ jobs:
         DATABASE_PORT: ${{ secrets.DATABASE_PORT }}
       run: |
         coverage run --rcfile ./config/test/.coveragerc manage.py test
-    - name: Coverage Report
-      uses: py-cov-action/python-coverage-comment-action@v3
+        coverage xml
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
       with:
-        GITHUB_TOKEN: ${{ github.token }}
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -47,8 +47,11 @@ jobs:
         DATABASE_PORT: ${{ secrets.DATABASE_PORT }}
       run: |
         coverage run --rcfile ./config/test/.coveragerc manage.py test
+    - name: Generate and output coverage report
+      run: |
+        coverage report -m
         coverage xml
-    - name: Upload coverage reports to Codecov
+    - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -23,10 +23,6 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
 
-    permissions:
-      pull-requests: write
-      contents: write
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -23,6 +23,10 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
 
+    permissions:
+      pull-requests: write
+      contents: write
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -33,6 +37,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install coverage
     - name: Run Tests
       env:
         DATABASE_ENGINE: django.db.backends.mysql
@@ -41,4 +46,8 @@ jobs:
         DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
         DATABASE_PORT: ${{ secrets.DATABASE_PORT }}
       run: |
-        python manage.py test
+        coverage run --rcfile ./config/test/.coveragerc manage.py test
+    - name: Coverage Report
+      uses: py-cov-action/python-coverage-comment-action@v3
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -22,6 +22,7 @@ jobs:
           - 3306:3306
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
     - uses: actions/checkout@v4

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+# Config file for Codecov (https://docs.codecov.com/docs/codecov-yaml)
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto # Default
+        threshold: 10% # Allows 10% drop from previous commit coverage - more lenient
+        base: auto
+        informational: true # See status checks but prevent from blocking
+
+comment:
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false  # If true: only post the comment if coverage changes
+  require_base: false        # [true :: must have a base report to post]
+  require_head: true       # [true :: must have a head report to post]
+  hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]]
+
+github_checks:
+  annotations: false # [true :: post annotations to GitHub] Install Codecov browser extension for annotations

--- a/config/test/.coveragerc
+++ b/config/test/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+relative_files = True
+source = myapp
+omit = */migrations/*

--- a/config/test/.coveragerc
+++ b/config/test/.coveragerc
@@ -1,4 +1,3 @@
 [run]
-relative_files = False
 source = myapp
 omit = */migrations/*

--- a/config/test/.coveragerc
+++ b/config/test/.coveragerc
@@ -1,4 +1,4 @@
 [run]
-relative_files = True
+relative_files = False
 source = myapp
 omit = */migrations/*


### PR DESCRIPTION
## Changelog
- Use coveragepy in actions to generate code coverage report.
- Upload report to Codecov to generate PR comments of coverage, and can be used to generate badges / graphs.

Closes #61

Opening second PR from branch in repo to check if opening PR from Fork is causing errors...