### PR TITLE
Bugfix: Add inputs for password reset

### DIFF
--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -1,28 +1,27 @@
 {% extends "base_generic.html" %}
 
 {% block content %}
+{% load widget_tweaks %}
+
     {% if validlink %}
         <p>Please choose a new password</p>
         <form action="" method="post">
             {% csrf_token %}
-            <table>
-                <tr>
-                    <td>
-                        {{ form.new_password1.errors }}
-                        <label for="id_new_password1">New password:</label>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        {{ form.new_password2.errors }}
-                        <label for="id_new_password2">Confirm password:</label>
-                    </td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <td><input type="submit" value="Change password"></td>
-                </tr>
-            </table>
+            
+            <div class="form-group">
+                {{ form.new_password1.errors }}
+                <label for="id_new_password1">New password:</label>
+                {% render_field form.new_password1 class="form-control" %}
+            </div>
+
+            <div class="form-group">
+                {{ form.new_password2.errors }}
+                <label for="id_new_password2">Confirm password:</label>
+                {% render_field form.new_password2 class="form-control" %}
+            </div>
+                
+            <button type="submit" class="btn btn-primary mt-2 mb-2">Reset Password</button>
+            <input type="hidden" name="next" value="{{ next }}">
         </form>
     {% else %}
         <h1>Password reset failed</h1>


### PR DESCRIPTION
Closes #87 
When I made the password reset page I forgot to add the fields for the new password... This PR adds them.