### PR TITLE
coverage: add ml_app to coverage source

### DIFF
--- a/config/test/.coveragerc
+++ b/config/test/.coveragerc
@@ -1,3 +1,3 @@
 [run]
-source = myapp
+source = myapp, ml_service/ml_app
 omit = */migrations/*


### PR DESCRIPTION
Does what it says on the tin.

Not sure whether we want coverage of the `ml_service` directory as a whole or just `ml_app`, as we are only using `myapp` as a source too & settings.py etc _should_ be covered by Django's internal testing.

This does reduce coverage and reveals areas of testing we need for the ml_service, for a future PR.