### PR TITLE
fix: save soft clustering pipeline correctly

### DIFF
--- a/dataset/soft_clustering.ipynb
+++ b/dataset/soft_clustering.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -499,7 +499,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -1012,7 +1012,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -1527,7 +1527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1565,7 +1565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -1604,7 +1604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -1645,13 +1645,7 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 1: Best model is GradientBoostingRegressor with CV MAE -1.71\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 2)\n",
-      "FeatureStacker - Combined features shape: (860, 12)\n",
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n",
-      "FeatureStacker - Transformer 'gmm' output shape: (3437, 3)\n",
-      "FeatureStacker - Combined features shape: (3437, 13)\n"
+      "FeatureStacker - Combined features shape: (860, 12)\n"
      ]
     },
     {
@@ -1660,6 +1654,18 @@
      "text": [
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
       "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n",
+      "FeatureStacker - Transformer 'gmm' output shape: (3437, 3)\n",
+      "FeatureStacker - Combined features shape: (3437, 13)\n"
      ]
     },
     {
@@ -1784,9 +1790,7 @@
       "\n",
       "Categorical columns: []\n",
       "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n",
-      "FeatureStacker - Transformer 'gmm' output shape: (3437, 5)\n",
-      "FeatureStacker - Combined features shape: (3437, 15)\n"
+      "Target column: SettlementValue\n"
      ]
     },
     {
@@ -1795,6 +1799,14 @@
      "text": [
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
       "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FeatureStacker - Transformer 'gmm' output shape: (3437, 5)\n",
+      "FeatureStacker - Combined features shape: (3437, 15)\n"
      ]
     },
     {
@@ -2195,7 +2207,11 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 7: Best model is GradientBoostingRegressor with CV MAE -1.24\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 6)\n",
-      "FeatureStacker - Combined features shape: (860, 16)\n"
+      "FeatureStacker - Combined features shape: (860, 16)\n",
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n"
      ]
     },
     {
@@ -2210,10 +2226,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 9)\n",
       "FeatureStacker - Combined features shape: (3437, 19)\n"
      ]
@@ -2335,11 +2347,7 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 8: Best model is Ridge with CV MAE -0.30\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 9)\n",
-      "FeatureStacker - Combined features shape: (860, 19)\n",
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n"
+      "FeatureStacker - Combined features shape: (860, 19)\n"
      ]
     },
     {
@@ -2354,6 +2362,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 9)\n",
       "FeatureStacker - Combined features shape: (3437, 19)\n"
      ]
@@ -2475,11 +2487,7 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 8: Best model is Ridge with CV MAE -0.30\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 9)\n",
-      "FeatureStacker - Combined features shape: (860, 19)\n",
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n"
+      "FeatureStacker - Combined features shape: (860, 19)\n"
      ]
     },
     {
@@ -2494,6 +2502,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 11)\n",
       "FeatureStacker - Combined features shape: (3437, 21)\n"
      ]
@@ -2974,21 +2986,7 @@
       "\n",
       "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "  warnings.warn(\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
       "5 fits failed out of a total of 50.\n",
       "The score on these train-test partitions for these parameters will be set to nan.\n",
@@ -3028,6 +3026,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "No valid model found for cluster 9.\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
@@ -3040,11 +3040,7 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 11: Best model is GradientBoostingRegressor with CV MAE -0.47\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 12)\n",
-      "FeatureStacker - Combined features shape: (860, 22)\n",
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n"
+      "FeatureStacker - Combined features shape: (860, 22)\n"
      ]
     },
     {
@@ -3059,6 +3055,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 12)\n",
       "FeatureStacker - Combined features shape: (3437, 22)\n"
      ]
@@ -3634,7 +3634,11 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 13: Best model is Ridge with CV MAE -0.42\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 14)\n",
-      "FeatureStacker - Combined features shape: (860, 24)\n"
+      "FeatureStacker - Combined features shape: (860, 24)\n",
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n"
      ]
     },
     {
@@ -3649,10 +3653,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 14)\n",
       "FeatureStacker - Combined features shape: (3437, 24)\n"
      ]
@@ -3823,7 +3823,21 @@
       "\n",
       "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
       "1 fits failed out of a total of 10.\n",
       "The score on these train-test partitions for these parameters will be set to nan.\n",
@@ -3853,21 +3867,7 @@
       "\n",
       "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "  warnings.warn(\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
       "5 fits failed out of a total of 50.\n",
       "The score on these train-test partitions for these parameters will be set to nan.\n",
@@ -4252,11 +4252,7 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 13: Best model is Ridge with CV MAE -0.42\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 14)\n",
-      "FeatureStacker - Combined features shape: (860, 24)\n",
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n"
+      "FeatureStacker - Combined features shape: (860, 24)\n"
      ]
     },
     {
@@ -4271,6 +4267,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 14)\n",
       "FeatureStacker - Combined features shape: (3437, 24)\n"
      ]
@@ -4441,7 +4441,21 @@
       "\n",
       "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
       "1 fits failed out of a total of 10.\n",
       "The score on these train-test partitions for these parameters will be set to nan.\n",
@@ -4471,21 +4485,7 @@
       "\n",
       "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "  warnings.warn(\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
       "5 fits failed out of a total of 50.\n",
       "The score on these train-test partitions for these parameters will be set to nan.\n",
@@ -4711,6 +4711,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
      ]
     },
@@ -4783,8 +4784,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n"
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "No valid model found for cluster 9.\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
      ]
     },
     {
@@ -4830,8 +4832,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "No valid model found for cluster 9.\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
@@ -4895,7 +4895,11 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 16: Best model is Ridge with CV MAE -0.25\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 18)\n",
-      "FeatureStacker - Combined features shape: (860, 28)\n"
+      "FeatureStacker - Combined features shape: (860, 28)\n",
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n"
      ]
     },
     {
@@ -4910,10 +4914,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 18)\n",
       "FeatureStacker - Combined features shape: (3437, 28)\n"
      ]
@@ -5118,9 +5118,7 @@
      "output_type": "stream",
      "text": [
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "No valid model found for cluster 9.\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n"
      ]
     },
     {
@@ -5166,6 +5164,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "No valid model found for cluster 9.\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
@@ -5444,21 +5444,7 @@
       "\n",
       "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "  warnings.warn(\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
       "5 fits failed out of a total of 50.\n",
       "The score on these train-test partitions for these parameters will be set to nan.\n",
@@ -5498,6 +5484,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "No valid model found for cluster 9.\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
@@ -5563,7 +5551,11 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 16: Best model is Ridge with CV MAE -0.25\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 18)\n",
-      "FeatureStacker - Combined features shape: (860, 28)\n"
+      "FeatureStacker - Combined features shape: (860, 28)\n",
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n"
      ]
     },
     {
@@ -5578,10 +5570,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 18)\n",
       "FeatureStacker - Combined features shape: (3437, 28)\n"
      ]
@@ -5786,9 +5774,7 @@
      "output_type": "stream",
      "text": [
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "No valid model found for cluster 9.\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n"
      ]
     },
     {
@@ -5834,6 +5820,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "No valid model found for cluster 9.\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
@@ -5897,7 +5885,11 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 16: Best model is Ridge with CV MAE -0.25\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 18)\n",
-      "FeatureStacker - Combined features shape: (860, 28)\n"
+      "FeatureStacker - Combined features shape: (860, 28)\n",
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n"
      ]
     },
     {
@@ -5912,10 +5904,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 18)\n",
       "FeatureStacker - Combined features shape: (3437, 28)\n"
      ]
@@ -6231,7 +6219,11 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 16: Best model is Ridge with CV MAE -0.25\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 18)\n",
-      "FeatureStacker - Combined features shape: (860, 28)\n"
+      "FeatureStacker - Combined features shape: (860, 28)\n",
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n"
      ]
     },
     {
@@ -6246,10 +6238,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 18)\n",
       "FeatureStacker - Combined features shape: (3437, 28)\n"
      ]
@@ -6257,674 +6245,6 @@
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3gAAAHWCAYAAAAl5yv5AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAnr5JREFUeJzs3Qd4U+UaB/B/undLoYu995INAoJM2QiKoDJEUFQE4Yo4AcdFcIELXCBcURkqICKCIIhMAdkby2xLgdIBpTPnPu+XpiRt2gZoe9L2/3uew0nO+ZLz5eSk5M37DYOmaRqIiIiIiIioyHPSuwJERERERESUPxjgERERERERFRMM8IiIiIiIiIoJBnhERERERETFBAM8IiIiIiKiYoIBHhERERERUTHBAI+IiIiIiKiYYIBHRERERERUTDDAIyIiIiIiKiYY4BERFTOVK1fG8OHD9a4G6eDrr7+GwWDA6dOnUVJ06NBBLcXl2CXxPSSi/MUAj4hKlE8//VR9eWrZsmWOZWT/M888k217fHw8pk2bhkaNGsHHxweenp6oX78+XnjhBURERKCokddpuXh7e6Nu3bp48803kZiYaFVWAkZ5zbb89NNPuO+++1CmTBm4ubmhbNmyePDBB7Fhw4Zcjy/HmDp1KjZu3Jivr0u+GFu+LldXV1W3Nm3a4KWXXsLZs2dv+7kLqs7FhaZp+N///of27dsjICAAXl5eaNCgAV5//XVcv379tp/38OHD6rwX5aAnPT0d8+fPVwFhYGAg3N3d1Y8xI0aMwK5duwqtHqtXr1bnkoiKLxe9K0BEVJgWLVqkvlTt3LkTJ0+eRPXq1e163L///ovOnTur4OCBBx7A6NGjVTCzf/9+fPXVVyrIOX78OIqaLl26YOjQoer2tWvXsHnzZrz66qvYt28fli5dmueX+ccee0xlHO666y5MmDABoaGhiIyMVOejU6dO2LJliwqscgqWJGAWBZGBGTx4MHr06AGj0YirV6/i77//xqxZszB79mz1nj300EO3/JwFXec79eijj6rXJcGDHgHMkCFDsGTJErRr104FERLgyTUl50yup99//x0hISG3FeDJc8g5l8+vpbVr18LR3bhxA/fffz/WrFmjgl/5oUGCPAlY5XwtWLBA/W0pX758oQR4n3zyCYM8omKMAR4RlRjh4eHYunUrfvzxRzzxxBMq2JsyZUqej0tLS1Nfzi5evKgyN23btrXa/9Zbb2HGjBkoimrWrIlHHnkk8/6TTz6JlJQUdY6SkpLg4eGR42Pfe+89FdyNHz8e77//vsqWmb388ssqk+Piot9/M02aNLF6beLMmTPo2rUrhg0bhjp16qhsrCOQ7JZkUO+Us7OzWvQwc+ZMFaz85z//wTvvvJO5XX4MkYxuv379VCb4119/zdfjyg8tju75559Xwd0HH3ygPi+W5G+QbC/K5Mce+XshrRqIyAFoREQlxBtvvKGVKlVKS05O1saMGaPVqFHDZjn50/j0009n3v/+++/Vtrfeeuu2j3369Gl1zJo1a2oeHh5aYGCgNnDgQC08PNyq3Pz589Wx/vrrL+25557TypQpo3l5eWn9+vXToqOjrcoajUb1msqVK6d5enpqHTp00A4ePKhVqlRJGzZsWJ51yvo6zZ555hnN2dlZS01Nzdwmz+ft7Z15PzExUb2G2rVra2lpabd8PuR1y/GzLlOmTMkss379eq1t27bq9fv7+2t9+vTRDh8+bPdzv/POOzb3b926Ve0fMmSI1farV69q48aN08qXL6+5ublp1apV095++20tPT3d7jofOXJEGzBggLrO3N3dtaZNm2orVqyw+R5v3LhRXRNBQUFaQECA2nfPPfdo9erV0/bt26e1b99eva9Sj6VLl6r98pgWLVqoa0iupXXr1tl8bsvrSq6Hnj17aps3b9aaN2+u6lWlShVtwYIF2c5NXucgJ3I9yGuWOlleN5ZGjBih6rZt27Zsdfvtt9+0Ro0aqbrVqVNH++GHH7K9pqzLH3/8kXnOZDGT7bJ/8eLF2tSpU7WyZctqPj4+6n2JjY3VkpKS1GuU8y7X9PDhw9U2S/PmzdM6duyoysh5kDp9+umn2V5T1mPbcu7cOc3FxUXr0qVLruVyew+zXmeW58/ys56SkqJec/Xq1dW5lM/o3Xffra1du1btl7K2zqWZvM8ffPCBVrduXfX44OBgbfTo0VpMTEy248r7tmbNGnWNS1l5nJBjyTHlMyvnV66JF1980a7XTkT5gxk8IioxJGMnmTj5xV+a782ZM0c122vevHmuj1u5cmVm87fbJceR7KE0n5NmWNI0S44vTc6k+Zk0ZbM0duxYlCpVSv26L2WlaaH0C1y8eHFmmddee031l5NmiLLs2bNHZackA2cv+dX98uXLmVkkaVIpzcWkqV1u2be//voLMTExKhtxOxmjoKAg9frHjBmD/v37q/dFNGzYUK2lKZ/066tatapqSiZN3D766CPcfffd6nVmbaZ3K1q3bo1q1aph3bp1Vk0v77nnHly4cEFldytWrKjerxdffFE1OZXzn1edDx06pOpXrlw5TJ48WWXkJKMlmasffvhBPcbSU089pZ5T3kfL/mnSnLRXr17qWpHmwHJMuS3Xr5xvybLK+yNZsoEDB+LcuXPw9fXN9TVLc2QpO3LkSJW9nDdvnsqmNW3aFPXq1bP7HOR2PUi9x40bl+N1I02BpQ/aqlWr0KpVq8ztJ06cwKBBg9TrkrpJGXndkvGSJsTSpPHZZ5/Fhx9+qJo2SuZVmNc5mT59usooyXshr1+uH+mP6eTkpOoq19X27dtVFrpKlSrqfTCTcy7npU+fPur1/Pzzz+r9kua+Tz/9NG6FZCylFcCd/P2wl7wmed2PP/44WrRoofoNS/8++czIuZT3VfoLy7UvGfasZL+cD+kXKOdcWj18/PHH+Oeff9TfBjl/ZseOHVN/R+Uxo0aNQq1atdRnQK5d+UxIv0tpKiznXh5LRIUonwJFIiKHtmvXLvVLtTnjIdkvyVLIL/l5Zbbuuusu9Wv0nZAMR1aSyZBjLVy4MNuv9507d1Z1NJNsnmTVJAMhJJsnmQX5Fd2y3EsvvaQeb28Gz9Yi2cKsGY2sGbzZs2ersj/99JN2uy5dupRjZqJx48Yqe3DlypXMbZLVcnJy0oYOHXpHGTzRt29fVSYuLk7dl0yovL7jx49blZs8ebI672fPns2zzp06ddIaNGhgde7kvWnTpo1Vttj8Hkt2Mmv2U7JBsu/bb7/N3Hb06FG1TV779u3bM7dL1ku2y/PllcGTbX/++WfmNrl+JOsyceLEzG32ngNbZs2alef1IFkgKXP//fdnq5tlxk7ek7CwMPW5M5MMpmXWLus5s5XBq1+/vspomQ0ePFgzGAzafffdZ/X41q1bq3rk9Xnt1q2bVrVq1VyPbYt8dqU+//zzj1bQGTzJgsrfhNzI3zZbX/8kwyvbFy1aZLVdsnRZt5vfN9lnSbJ4sl0+J0SkH46iSUQlgmQ/ZHCHjh07qvvSX0yyBt9//70aHCI38it4XhmSvFj2TUlNTcWVK1fUAC8y0qD8up6V9Fuy7NMmg1ZIPaUPmTnDJZk6yfRZlsvavycvffv2Vb/my7JixQqVrZHMiWSITN8rcz4n4k7Piy2SLdq7d6/KMMlAFGaSFZAshAwScafMI4ImJCSotQwAIudYsqaS0TQvMrCOnPc///wz1+eTbKaMGip9zeQ5zY+X97lbt24qSyWZMUuS9bCV/ZS6WQ4AI5kRuU4kY2U5+qv5tgwAlBcZHVVen5lkDuV5LR97J+fAfB5zux7M+8zXjpmMumqZ3fTz81PZPskaRUVF4XbJc1hmnOR8mQcGsiTbJQsqWTZbn9e4uDh1HiS7KedL7t+KgvysZCXXiWTR5Hq7VfL++/v7q8+Y5fsvWV65Jv/44w+r8pL1lGs76/GF/C2RbCcR6YNNNImo2JMvpxLISXAnTY4sv9jJQCHr169XTRtzIl847fkSnRtpYihNp6T5mXzRtwyebH1hlOZxluRLt5CmZcIc6NWoUcOqnHxxN5e1hzQXlS/wZtIkrXTp0mqgDGlK17t37xzPieUX+/xkfm0SgGQlQc5vv/12x4OSyIihll+65QuxjIgq58+W6OjoXJ9PmqHJeyojkMqS03NI803LL8g5vSeWQbuQL94VKlTIts3ymshN1utJyHVi+dg7OQfm85jb9ZBTECg/dGR9vTL4j5DmyTIy6+3I+prN58vWeZRgRD6Hcu0LaVIozaO3bduWbcoQKWd+LnsU5GclK2kWKT/ayPmTKVy6d++umoaamxHnRt5/eW3BwcF2vf+2rl/50ezLL79UTUSlaayMpCtNmaV5sDSNJaLCwQCPiIo9yaxIVkiCPFlsZfdyC/Bq166tsgnyK3/WL4f2kkybBHeSYZM+YPIFUb7USqbG1i/dOfVryy2rll/kS5mQjE1OAZ6cE3HgwAHVx6yoOXjwoPoia/7yLe+BZC4mTZpks7w54MiJ+T2UwDhrVsMs65QcOY04mNN7fyfXhD2PvZNzYO4PJwFiTteD7DNnEwvD7Z7HU6dOqc+AXOMyOqx85qXfrmSOZbTLW81MWX5WGjdujPyUtfWB9FeU+ksGTaaPkGBL6jx37lwVdOVGXpd8JuTvoS1ZA39b169sk78bku375ZdfVGsA6Td87733qvroNcIrUUnDAI+Iij35wiJfXGTup6xkOgCZs02+AOX0hVuCnO+++w7ffPONasJ4O5YtW6YGkJCMoeUAJ7Gxsbf1fJUqVcr81V0GIjG7dOmSXRmd3JibqpmzXLbIVBGSAZLzIgNf3M4Xt6xZm6yvTQZxyOro0aNq0vI7yd5JVka+BFtOoSCDrsjrtcxm3kqdze+BNAnM6zkclb3nIKfrQZrnffvtt2qKDFvXw8KFC9VaBuGwlf20PLfmOSXNg+nkdN4LggyokpycrAZXsswCZm2iaC8ZLEjOh/z9uN2BVuSzlvVvhTTRlh+uspJmzTJIiizyfkrQJ4OvmAO8nM6lvP/S9FsGCrqT6Q4kUycBsiwSIP/3v/9V14Scv6L62SAqapgvJ6JiTZpGShAnXyqlmVDWRUamlKZT5pEybZFyDRo0UPPdSXCQlTxevsDkRr7gZc20yKh+efX/y4l8UZJgQp7D8nlzG+nwVr7gitzmiJNRP1944QUcOXJErW1lkeQLrUwon9tziKxfXMPCwlSmQ0bztNwnWTfJAsiIoXfS/FP69klGRuYmM5O+c/LeSvPPrKQO5qA3pzrLDwgyIupnn31m80u3BN6Ozt5zYIucF8leSlBu67Mg2RwZnVGym5YjaAoZ1VF+ZLHssybBoFwD5uaZ5oD+dn8QuRXm4DRrM2rJwN8OyQBKf0u5duXzaitzJj/8nD9/PsfnkOArax/Izz//PNvfD+nzaUn6zknmWAJWs5zOpbz/8nxvvPFGtuPLe2/PuZe+qFmZs5aWdSCigsUMHhEVaxK4SQAmfctskS+b0vRIsnzSf8QWCaQkSJSgSn4Nly9C8iu3bJcBDSRrIb+wSwCYEwkwZVhyaZopTdTki7T8Wm7u83OrpM7yhVr69clzS9AjzUhlSHbJcNlLMiUSiAnpayTDxktgJV8K88o2SIAkr1++nMqv8xIIyxdyGRhj+fLlKriTYfZzIlkCORfShEua/0nmQfoNySJTAEjmQ5qzytD+5mkS5PxJNsIeMniNvDb5Ai1fTmWqCpmuQDIY8l5Y9kuS1yLXipxL8/QB0s9PmtVJ9lX6gsl5za3OkiGWTJb8GCBf6CWrd/HiRfVey5f3ffv2wZHZew5yIn2u5BqcMWOGes0DBgxQ50umUJD3QZpxyrWVlZxHeY/l/ZGBkGQKBzlvlgGVBAkSeMlzS7Alw+9Ls7+c+ovdCWmuLT8ASOZepgCQLNgXX3yhjmUreLeHfEYkayxTD5h/cJK/GWfPnlWDm0hm2nJgnawk+ybTSMg5lWa0ci1JIJ71/ZBrU35okPdOrk2ZIkHeO/khy0z2CamLBNxyXuXYMoiMvF75myKDHMl5kL9x0kpA6jh79mz1Gc+rD6AEoj179lSZeOm39+mnn6p+pfLZIKJCouMInkREBa53795qUujr16/nWEYmOnZ1ddUuX76c6wTgMgn0a6+9pobCl8m35XllKHaZxDcyMjLXeshjZaJnmbhcJl2WIddl+Pusw5ybh0j/+++/rR5vHvrdcph4mZR42rRpakj5253o3HKRofBl6giZ2PjixYu5TpNgadmyZVrXrl3VpMoyobPUZ9CgQWpS7rzIpOMyUbJM+ZB1KPjff/9dTZgsr83Pz0+9l7cy0bl5kTpJ3Vq2bKneqzNnzth8XEJCgtovk0RLfeS9kikO3n33Xavh9nOr86lTp9Q0DqGhoeqakknoe/Xqpc5RXu+x5UTnWZknls4q67Wa20Tnto6VdYh/e89BTuSalDrI+ybvmXxG5PXIdXrt2rUcX5dM+dCwYUM1dUPt2rUzJ3a39MUXX6hpCuQ6tWei86zPkdN5l/cv69D+K1euVPWR+leuXFmbMWOGmvw867m1Z5oEM5kS48svv9TatWunpl2R60Nev/xdsJxCwdZ7KOf1hRdeUO+H/O2Rvx8nT57M9ll/8803tRYtWmgBAQHqcyPn8q233rJ676QeY8eOVZO4y7QRWb8Kfv755+r6lsf7+vqqv3eTJk3SIiIisr1vWa1fv15NQSKTy8v1I2uZniLr1BtEVLAM8k9hBZNEREREZtLHTrKfMmIrERHlD/bBIyIiIiIiKiYY4BERERERERUTDPCIiIiIiIiKCfbBIyIiIiIiKiaYwSMiIiIiIiomGOAREREREREVE5zo3IHJ5LwRERHw9fVVE/MSEREREVHJpGkaEhISULZsWTg55ZynY4DnwCS4q1Chgt7VICIiIiIiB3Hu3DmUL18+x/0M8ByYZO7Mb6KnpyfWrl2Lrl27wtXVVe+qUQmTmprK6490w+uP9MTrj/TE648sxcfHq+SPOUbICQM8B2Zulunn56cCPC8vL3WbH3DS4z8YXn+kF15/pCdef6QnXn9kS15dtzjIChERERERUTHBAI+IiIiIiKiYYIBHRERERERUTLAPHhERERERFdpQ/2lpaUhPT9e7Kg7H2dkZLi4udzw9GgM8IiIiIiIqcCkpKYiMjERiYqLeVXFYMqhOWFgY3Nzcbvs5GOAREREREVGBMhqNCA8PV1kqmahbApg7zVQVt8xmSkoKLl26pM5TjRo1cp3MPDcM8IiIiIiIqEBJ8CJBnszjJlkqyk6mRZPpMM6cOaPOl4eHB24HB1khIiIiIqJCcbtZqZLCKR/OD88wERERERFRMcEmmpQ3YzpwZitw7SLgEwJUagM4OetdKyIiIiIiyoIBHuXu8EpgzQtAfMTNbX5lge4zgLp99KwZEREREZVA6UYNO8NjEJ2QhGBfD7SoEghnJw7YYsYmmpR7cLdkKDTL4E5G+YmPVNvVfiIiIiKiQrLmYCTaztiAwV9sx7jv96q13JftBW3btm1qFNCePXtabT99+rQaEXTv3r1W23/44Qd06NAB/v7+8PHxQcOGDfH6668jJiamQOvJAI9ybpa55gVo0JD19xCD2iqfsMmmckREREREBUyCuDHf7EFkXJLV9qi4JLW9oIO8r776CmPHjsWff/6JiAjrBEhWL7/8MgYNGoTmzZvj119/xcGDB/Hee+9h3759+N///leg9WQTTbJN+tzFR2QL7iyDPMRfMJWr0q6QK0dERERExWHutxup6XY3y5yy8pApyZD1edR3U2DqysO4u3oZu5prero639I8fNeuXcPixYuxa9cuREVF4euvv8ZLL71ks+zOnTvx3//+F7NmzcK4ceMyt1euXBldunRBbGwsChIDPLLJmBBlV3rX3nJERERERJYkuKv72m/58lwS5EXFJ6HB1LV2lT/8ejd4udkfCi1ZsgS1a9dGrVq18Mgjj2D8+PF48cUXbQaJixYtUk0yn3rqKZvPFRAQgILE7+Zk05EEr3wtR0RERERUVH311VcqsBPdu3dHXFwcNm3aZLPsiRMnULVqVTVpuR6YwSObTno1QCktEKGIga0st6YBl+CvytXTo4JEREREVKRJM0nJpNlDRs0cPv/vPMt9PaK5GlXTnmPb69ixY6rZ5U8//aTuu7i4qP51EvTJICq2mp7qiQEe2RTs541pqUMxx3UWjBqsgjy5ZiUb7aslombCTgAV9awqERERERVB0rzR3maS7WoEIczfQw2oYit8kq+qof4eqlx+T5kggVxaWhrKli1rFcS5u7vj448/zla+Zs2a+Ouvv5CamqpLFo9NNMkm+eVjv297PJU6HlGw/hUkCqVwLL08PA2pqP3HKGDHZ7rVk4iIiIiKPwnapvSuq25nH+HdRPY753NwJ4HdwoUL1QiYMg2CeZHRMCXg++6777I9ZsiQIWpQlk8//dTmc3KQFdL1QzTmmySsS26G5k5HEYxYRCMAO4214Qwj3tTmYZDLRuDXScDlE0D3twFnXlJERERElP+61w/DnEeaYNrPh62mSpDMnXxvlf35bdWqVbh69SpGjhyp5rOzNGDAAJXdkz55llq2bIlJkyZh4sSJuHDhAvr376+CwZMnT2Lu3Llo27at1eia+Y3fxsmuD9H2ONMvJkLS4w81r4g3/xqDf1PD8ILr93D6+wvgajgwcB7gYX3xExERERHl1/fTLnVDVZ+86IQkBPt6qJZn+Z25M5MArnPnztmCO3OAN3PmTMTHx2fbN2PGDDRt2hSffPKJCuqMRiOqVauGgQMHYtiwYShIDPDotj9E3euHYtg8V5y+ForZbp/A4+TvwFfdgCGLgVKV9K46ERERERVD8j20dbXShXKsn3/+Ocd9LVq0yBxQxdbAKg8++KBaChv74JHdH6K+jcuptfkXklqhvvjp6TY4HXQvBia/hmitFHDpCPBlJ+CcDL5CRERERESFiQFeAZO0rMxa7+HhodrjyhCrxUmYvyeWPNkaPlWaoU/y6zhsrARcvwR83Qs4sEzv6hERERERlSgM8ArQ4sWLMWHCBEyZMgV79uxBo0aN0K1bN0RHR6M48fd0xYLHWqBZw/oYmDIF69KbAunJwA8jgY0zTPMqEBERERFRgWOAV4Def/99jBo1CiNGjEDdunVVB0svLy/MmzcPxY27izM+fOguPNyuDp5IfQ6fp/U07dj4X+DHUUDqzZGOiIiIiIioYHCQlQKSkpKC3bt348UXX8zc5uTkpEbh2bZtm83HJCcnq8XMPCKPTJLo4uKSeduRTepaA8G+bvjvrw/jXy0Mb7rOh8uBpTBePYP0gQsA7yC9q0i3wXzdOfr1R8UTrz/SE68/0lNxuv7kNchAJDKapCxkm5wbOU9yvpydna322XsdGDRbQ77QHYuIiEC5cuWwdetWtG7dOnO7zImxadMm7NixI9tjpk6dimnTpmXb/u2336rMX1HyzxUDvjnhhBaGQ/jcbRZ8kIjrbmWwo+pEJHiW07t6RERERFSIJFkRGhqKChUqwM3NTe/qOHSS6Ny5c4iKilKTrFtKTExUk6jHxcXBz88vx+dgBs+BSLZP+uxZZvDkQ9C1a1d4enpi3bp16NKlC1xdXeHoegDocjoGYxa5om/yNCz0eA/lUqLQMfy/SL9/HrSqHfWuIt0C+cWoKF1/VLzw+iM98fojPRWn6y8pKUkFLj4+PmrwQcr5PMn3/vbt22c7T7bm27OFAV4BKVOmjEqrXrx40Wq73JdfL2xxd3dXS1bygTZ/qC1vO7q7a4Rg2Zg2GD7PBb3ipuIrj9loknwELt8/BPSYCTR/XO8q0i0qStcfFT+8/khPvP5IT8Xh+ktPT4fBYFBdlmQh2+TcyHmy9Z7bew3w7BYQST3L7PXr16+3alMr9y2bbBZ3NUN88eNTdyMktBweSpqMFVp7QEsHfpkI/DoZMKbrXUUiIiIiomKDAV4BkuaWX3zxBRYsWIAjR45gzJgxuH79uhpVsyQJ9fdQc+U1qxaKcclP4L20QaYdO+YA3w0GkhP0riIRERERFRWSIAjfbJpzWdZMGFhhgFeABg0ahHfffRevvfYaGjdujL1792LNmjUICQlBSePn4YqvR7RA38bl8FFaXzyV8izSnNyBE78B87oDsef0riIRERERObrDK4FZ9YEFvUxzLsta7sv2AjJ8+HDVbNK8lC5dGt27d8f+/fszy8j25cuXWz3ujz/+QI8ePVR5GTBRpk2bOHEiLly4gILEAK+APfPMMzhz5oya/kBGzmzZsiVKKjcXJ3zwYGM8cU9VrDa2woAbLyPBJRC4eBD44l7g/G69q0hEREREjkqCuCVDgfgI6+3xkabtBRjkde/eHZGRkWqRLlcyKmivXr1yLP/ZZ5+p6dFk7I0ffvgBhw8fVnNiywiY7733HgoSB1mhQuXkZMCL99VBmJ8Hpq0Cul2biiW+H6D89XDg6x5A/8+Aev30riYRERERFTSZrS010b6y0gzz10nyIFtPJDk0YM0LQNUOgJP1/HE2uXpJ2s3uqspAiOaBEmU9efJktGvXDpcuXUJQkPU8z+fPn8ezzz6rlg8++CBze+XKldXomLGxsShIDPBIF8PvroIQPw+MW7wX3RJewQK/uWiW8jewdBhw5VWg3cRb+tARERERUREjwd1/y+bTk2mmzN7bFewr/lIE4OZ9W0e6du0avvnmG1SvXl01v8xq6dKlaj47mf/aloCAABQkBnikm/sahKGMrzseX7ALD8aPw0zfxRiY+jOw4Q3gyimg9yzAxd30i82ZrcC1i4BPCFCpjX2/zBARERER5YNVq1apOfyEDJoYFhamttma8uHEiRNqInIpowcGeKSr5pUD8cOY1hg272/8J3YwTniFYrI2D4Z93wJXTwN3PQL88aZ1W2u/skD3GUDdPnpWnYiIiIjuhDSTlEyaPeTH/kUD8y738DJTMsCeY9+Cjh07Ys6cOer21atX8emnn+K+++7Dzp07UalSJauymqapQVf0wkFWSHfVg33x01NtUDfMD58ldsTo9ElIc/UBzm4FVjylS0daIiIiIipgEgRJM0l7lmr3mn7kl752tp8M8CtnKmfP891iAObt7a2aZMrSvHlzfPnllyqTJ1OiZVWzZk01mIoMyKIHBnjkEIL9PLD4iVZoW70M1qU0QJ/EV2DM8fLM6Fy7hhOlExEREZUI0j1HWnApWYOzjPvd3y60bjySoZPmmTdu3Mi2b+DAgXBzc8PMmTNtPragB1lhgEcOw9fDFfOGN8f9d5WDn3YNTjDm0ZH2gildT0RERETFn3TPeXAh4Jelb5tk9mR7AXbfSU5ORlRUlFqOHDmCsWPHqsFWevfuna1shQoV1OiZs2fPxsiRI7Fp0yY1bdqWLVvwxBNP4I033kBBYh88cri58t57sBFWpW4CTtrxABl4hYiIiIhKBgniavcs9AH41qxZkzloiq+vL2rXrq1Gy+zQoYPN8k899ZRqqvnuu++if//+KtMn0yTI3HkTJkwo0LoywCOHIynvHm3usivAS/cOBsfTJCIiIipBJJir0q7QDvf111+rJTcysEpWMtG5LIWNTTTJIe1Mr40ILRBGLYe5LjUgQiutyhERERERkQkDPHJI0ddTMS11qLptK8iTrrSzUu9X5YiIiIiIyIQBHjmkYF8P/GZsgTGp4xGFQKt9aZqTGtl2qMs6hHqk6VZHIiIiIiJHwz545JBaVAlEmL8H1sa1wLrkZmjhdBTBiEU0AhCllcIyt2mo73Qa2s7xQPXFgIub3lUmIiIiItIdM3jkkJydDJjSu666rcEJ2411sdLYRq1Pa2EYkTIJKU6eMPy7AVg5Vnq26l1lIiIiIsqDrcFIKH/PDwM8cljd64dhziNNEOrvYbXdw9UJB7SqGG8cD83gDOz/Hlj/um71JCIiIqLcubq6qnViYqLeVXFo5vNjPl+3g000yeGDvC51Q7EzPAbRCUmqb17D8v545KsdWH22AWb4jcHklI+Bv943TXLZYpTeVSYiIiKiLJydnREQEIDo6Gh138vLS02NRTczdxLcyfmR8yTn63YxwKMi0VyzdbXSVtu+GNoM/T/dgrkxbVCpdCwGX/8GWP084BsK1OmtW12JiIiIyLbQ0FC1Ngd5lJ0Ed+bzdLsY4FGRVMbHHfOHN8f9n27Fi1fuQ4WQWLSNWwX88DgwdAVQsZXeVSQiIiIiC5KxCwsLQ3BwMFJTOdVVVtIs804yd2YM8KjIqh7si7mPNsXQr3Zi2MVB+C0sDtWvbga+HQSMXAsE1dK7ikRERESUhQQx+RHIkG0cZIWKtDbVymD6/Q2QDmf0inwMVwIaAkmxwDcDgPhIvatHRERERFSoGOBRkfdAswoYe291JMEd3aOfxg3fykDcOWDRA0BSvN7VIyIiIiIqNAzwqFiY0KUm+jQqi0tGX9yfMBFpnmWAiweAxY8AaSl6V4+IiIiIqFAwwKNi02l35sCGaFapFI4klcYTxsnQXL2A8E3AiqcBo1HvKhIRERERFTgGeFRseLg64/OhzVCptBfWx5XFNK/J0JxcgANLgPXT9K4eEREREVGBY4BHxUqgt5uaPsHf0xVfX6yOhWUmmnZsmQXs+Ezv6hERERERFSgGeFTsVA3yweePNoWrswFTzjbCpvJPmHb8+gJweIXe1SMiIiIiKjAM8KhYalm1tOqTJ4adbI8TFR4EoAE/jALObNW7ekREREREBYIBHhVb/e8qj/Gda8gQLOhxqi8ul+8MpCcD3w0Goo/qXT0iIiIionzHAI+KtXGdaqD/XeWQajSg+7lhuBHS1GIi9Ai9q0dERERElK8Y4FGxnz7h7QEN0KJKIC4nO+P+2GeRVqo6EH8+YyL0OL2rSERERESUbxjgUbHn7uKsBl2pWsYbR+Jc8SReguYdAlw8CHz/MJCWrHcViYiIiIjyBQM8KhECvNwwb3hzlPJyxe+RHngjYBo0Nx/g9GZg+VOcCJ2IiIiIigUGeFRiVC7jjS+GNoObsxPmnfLDd5XeBGQi9IPLgN+n6F09IiIiIqI7xgCPSpRmlQPxzgOm6RNeOhCMv+pNNe3Y+iGwfY6+lSMiIiIiukMM8KjE6du4HP7Ttaa6PXRXVZxq+B/TjjUvAod+0rdyRERERER3gAEelUhPd6yOgU3Lw6gBffY2Q0zdYaaJ0H8cDZz+S+/qERERERHdFgZ4VGKnT/hv/wZoXbU0rqcY0etELyRV7wGkpwDfDQEuHta7ikRERERExTfAe+utt9CmTRt4eXkhICDAZpmzZ8+iZ8+eqkxwcDCef/55pKWlWZXZuHEjmjRpAnd3d1SvXh1ff/11tuf55JNPULlyZXh4eKBly5bYuXOn1f6kpCQ8/fTTKF26NHx8fDBgwABcvHjxlutC+nJzccLcR5qiWpA3IhJSMfjKSKSXawEkxwGLBgJxF/SuIhERERFR8QzwUlJS8MADD2DMmDE296enp6uASspt3boVCxYsUMHba6+9llkmPDxclenYsSP27t2L8ePH4/HHH8dvv/2WWWbx4sWYMGECpkyZgj179qBRo0bo1q0boqOjM8s899xz+Pnnn7F06VJs2rQJERERuP/++2+pLuQY/L1cMX94C5T2dsM/kcl4zukFaGVqAvEXTEHejVjAmA6EbwYOLDOt5T4RERERkQMyaJqmoQiRQEkCs9jYWKvtv/76K3r16qWCrZCQELVt7ty5eOGFF3Dp0iW4ubmp27/88gsOHjyY+biHHnpIPdeaNWvUfcnYNW/eHB9//LG6bzQaUaFCBYwdOxaTJ09GXFwcgoKC8O2332LgwIGqzNGjR1GnTh1s27YNrVq1sqsu9oiPj4e/v786pqenJ1avXo0ePXrA1dU1n84mme05exWDP9+O5DQjxjV1x3NnngauRQFBdYCkOCAh4mZhv7JA9xlA3T4oKVJTU3n9kW54/ZGeeP2Rnnj9UU6xgZ+fH3LigmJCgqsGDRpkBlRCMm+S8Tt06BDuuusuVaZz585Wj5MyEjAKybjt3r0bL774YuZ+Jycn9Rh5rJD98mGzfJ7atWujYsWKmQGePXWxJTk5WS2Wb6KQ47m4uGTepvzXIMwH7wyoj2cX78fs3cmo1O599P/nMRguHZGhV2CwKKvFRwJLhiJ9wHxotXuhJDBfd7z+SA+8/khPvP5IT7z+yJK910GxCfCioqKsAiphvi/7cisjgdSNGzdw9epV1bzSVhnJ0pmfQzJwWfsBSpm8jmNZF1umT5+OadOmZdu+du1a1ZdPrFu3Ls9zQbevd0UDfj7rjOc3p6Oblyu8kGQV3AkDNBX0paycgHWnZEORael8x3j9kZ54/ZGeeP2Rnnj9kUhMTITDB3jS5HHGjBm5ljly5IjKkJUEkjmU/n9mEnhK89CuXbuqJpry4e7SpQtT9AXoPk2D54rDOPvPOngbE3IsJ0GfV2oMetYPgFapLUrCL0a8/kgvvP5IT7z+SE+8/siSuXWfQwd4EydOxPDhw3MtU7VqVbueKzQ0NNtol+aRLWWfeZ11tEu5L21YJYBydnZWi60yls8hTTml355lFi9rmbzqYouM7ClLVvKBNn+oLW9TwXjr/ob4PHINEJN3WZcbV+RNQUnB64/0xOuP9MTrj/TE64+EvdeArm3LZLASyc7lttg7IEnr1q1x4MABq9Eu5RcPCd7q1q2bWWb9+vVWj5Mysl3IsZo2bWpVRgZZkfvmMrJfTq5lmWPHjqlpEcxl7KkLOS5XZycM79bSvsI+1k1xiYiIiIj0VGT64EkAFRMTo9bST06mORAyl53MRSfNGCV4evTRRzFz5kzV1+2VV15R89WZs2JPPvmkGh1z0qRJeOyxx7BhwwYsWbJEjaxpJk0khw0bhmbNmqFFixaYNWsWrl+/jhEjRqj9MnLNyJEjVbnAwEAVtMkImxLUyQArwp66kGPzqNYOF1EaQdoVOGXthCcDrWjARUNpBFVoDWc9KkhEREREVJQDPJlDTuaTMzOPRPnHH3+gQ4cOqmnlqlWr1EiVEmx5e3urQO3111/PfEyVKlVUMCfz2M2ePRvly5fHl19+qUa4NBs0aJCaykCOJ4FZ48aN1RQKloOmfPDBB2p0TZngXEa9lMd/+umnmfvtqQs5tp1n4vB1yqOY4zoLRg02g7zlqa3R6EwcWlcrrUcViYiIiIiK/jx4JQnnwdPPir0XMO77vejmtBNTXBeirOFmh7xEzR1ehmSkaM7Y0/pjtOo+BMUd5+EhPfH6Iz3x+iM98fqjEj0PHlF+Cvb1UOvfjC2wLrkZWjgdRTBiEY0A7DLWxPuuc9DHeRta7BwH1AgFqt2rd5WJiIiIiBjgEdnSokogwvw9EBWXBCOcsN1oPTjOhNQx8HM1ooNxB/DdEOCRZUDl4j9dAhERERE5tpIzQzPRLXB2MmBKb1NQZ6P7HdLggm13vQPU6Aak3QAWPQic3VHo9SQiIiIissQAjygH3euHYc4jTRDqb2quaeblZho3c972C9jc5H2gagcg9TqwaCBwYY9OtSUiIiIiYhNNojyDvC51Q7EzPAbRCUmqb17TSqXw3OK9+OVAJEZ/exDfDvsUd6WPAs5sAf7XHxi+CghtoHfViYiIiKgEYgaPyI7mmjIVQt/G5dTazcUJ7w9qhHY1yuBGajqGfXMQx+79EijfHEiKBRb2A6KP6l1tIiIiIiqBGOAR3QZ3F2d89mhTNKkYgPikNDz8v8M4e99CIKwxkHgZWNgHuHJK72oSERERUQnDAI/oNnm5uWD+8BaoHeqLy9eSMeSbo7jY9zsgpD5w7SKwoDdw9bTe1SQiIiKiEoQBHtEd8PdyxcKRLVCptBfOX72BR749gdgBS4AytYD4C6YgL+683tUkIiIiohKCAR7RHZKBV74Z2RIhfu44EX0Nw5aE4/rgH4HAqkDsWVOQlxCldzWJiIiIqARggEeUDyoEeqkgr5SXK/adj8OoH88j6eHlQEBFIOZfYEEf4NolvatJRERERMUcAzyifFIjxBdfj2gBbzdnbD11Bc/+cglpj6wE/MoBl48B/+sHJMboXU0iIiIiKsYY4BHlo0YVAvDFsGZqKoW1hy9i0oY4GB9dAfiEABcPmubJS4rTu5pEREREVEwxwCPKZ22qlcHHg+9S8+f9uOcCXt+WAm3oCsCrNBC5F/hmIJCcoHc1iYiIiKgYYoBHVAC61gvFzAEN1e2vt57G7P3OgAR5HgHA+Z3At4OAlES9q0lERERExQwDPKICMqBpeUzpXVfdnvX7Ccw/5QM8+iPg7gec2QJ8PwRITdK7mkRERERUjDDAIypAI+6ugvGda6jb034+jB+iQoCHlwGu3sC/fwBLhgJpKXpXk4iIiIiKCQZ4RAVsXKcaGHF3ZXV70g/7sTahEvDwEsDFEzjxG7BsBJCeqnc1iYiIiKgYYIBHVMAMBgNe7VkXA5qUR7pRwzPf/YOt6bWBwd8Czu7A0VXAT08AxnS9q0pERERERRwDPKJC4ORkwIwBDdC1bghS0owYtWAX9rk1AR5cCDi5AAd/AFaOBYxGvatKREREREUYAzyiQuLi7IQPB9+FNtVK43pKOobN34kTAXcDA+cBBmdg7yLglwmApuldVSIiIiIqohjgERUiD1dnfD60mZoQPTYxFY98tQPnQrsA938ujTmB3fOBNS8yyCMiIiKi28IAj6iQ+bi74OvhzVEj2AcX45NVkBdduRfQ9xNTgR1zgN+nMMgjIiIiolvGAI9IB6W83fC/kS1RvpQnzlxJxNCvdiKu1oNArw9MBbbMBja+bbotg6+EbwYOLDOtORgLEREREeXAJacdRFSwQv09sOjxlhg4dxuORiVgxNc78c3jQ+GVlgysmQxsehuI+Rc48xcQH3HzgX5lge4zgLp99Kw+ERERETkgZvCIdFSptDcWPtYCfh4u2HM2Fk/8bzeSm40GOk81FTiwxDq4E/GRpgnSD6/Upc5ERERE5LgY4BHprE6YH+aPaAFPV2dsPnEZzy3ei/RWYwF33xwekdE3T7J8bK5JRERERBYY4BE5gKaVSuHzoU3h6mzA6gNR+PKbRUByQi6P0ID4C8CZrYVYSyIiIiJydAzwiBxEuxpBmP3QXXAyAIeOH7fvQdcuFnS1iIiIiKgIYYBH5EB6NAjD9PsbIBoB9j3AJ6Sgq0RERERERQgDPCIHM6h5RXTu1g8RWiCMOUyFpzZLH73yLQq5dkRERETkyBjgETmgx++pgZ/DnlW3swZ5Mv+5QW5IH72FvYGrZ3SpIxERERE5HgZ4RA4o3ahh/tWGGJM6HlEItNoXidL4KrU7rsELOLcDmNvWNAk6EREREZV4nOicyAHtDI9BVFwSotAC65KboYXTUQQjVvXN22msDSOcMN/YHavL/w9+l3YDP4wETv4O9Hgnl+kViIiIiKi4YwaPyAFFJyRl3pZgbruxLlYa26i13BfntWBsbD0fuGcyYHAC9n1nyuad36VjzYmIiIhITwzwiBxQsK+HXeWC/H2Aji8Cw1cD/hWBq6eBr7oCf77DSdCJiIiISiAGeEQOqEWVQIT5e5gGU8nF3nNXYZRRWCq1Bp7cDNQfAGjpwIY3gQW9gbjzhVRjIiIiInIERSLAO336NEaOHIkqVarA09MT1apVw5QpU5CSkmJVbv/+/WjXrh08PDxQoUIFzJw5M9tzLV26FLVr11ZlGjRogNWrV1vt1zQNr732GsLCwtSxOnfujBMnTliViYmJwcMPPww/Pz8EBASoul27du2W60KUE2cnA6b0rqtuZw3yLO/PWHMMo/+3C7GJKYBnADDgK6DfXMDNBzizBZjTBjj0U6HWnYiIiIj0UyQCvKNHj8JoNOKzzz7DoUOH8MEHH2Du3Ll46aWXMsvEx8eja9euqFSpEnbv3o133nkHU6dOxeeff55ZZuvWrRg8eLAKyP755x/069dPLQcPHswsI4HYhx9+qJ5/x44d8Pb2Rrdu3ZCUdLNPlAR3Uo9169Zh1apV+PPPPzF69OhbqgtRXrrXD8OcR5og1N+6uabcn/NwE7zVvz7cnJ3w+5Fo9PzwL/xz9ipgMACNB5uyeeWaAklxwNLhwIqngWTrHyGIiIiIqBjSiqiZM2dqVapUybz/6aefaqVKldKSk5Mzt73wwgtarVq1Mu8/+OCDWs+ePa2ep2XLltoTTzyhbhuNRi00NFR75513MvfHxsZq7u7u2nfffafuHz58WGYl0/7+++/MMr/++qtmMBi0Cxcu2F0Xe8TFxaljyTolJUVbvny5WlPJkpZu1LaevKwt/+e8Wst9swPnY7V2MzZolV5YpVV/6Rdt3l//quvY9MAUTfv9dU2b4q9pU/w0bfZdmnZ+923Vgdcf6YnXH+mJ1x/pidcf5RQb5KbITpMQFxeHwMCb84Nt27YN7du3h5ubW+Y2ybzNmDEDV69eRalSpVSZCRMmWD2PlFm+fLm6HR4ejqioKNUs08zf3x8tW7ZUj33ooYfUWpplNmvWLLOMlHdyclIZv/79+9tVF1uSk5PVYpkJFKmpqXBxccm8TSVPs4p+AGSRsVPSMsdPqRXsheVjWuLFnw7ht8PRmPbzYWw/dRnT+9eDr4cr0H4yDJXawXnFGBhiTkH7qguMHV6CsdUzppE37WS+7nj9kR54/ZGeeP2Rnnj9kSV7r4MiGeCdPHkSH330Ed59993MbRKYSR89SyEhIZn7JKiStXmbZRnZbi5n+bicygQHB1vtl+BLgk3LMnnVxZbp06dj2rRp2bavXbsWXl5e6rY0CyXK6j4/wLuyASvOOKlAb/epixhRKx3lvU37XSu/gkbn5qNc7N9w3vA6YnYuw55Ko5HkZj2Jel54/ZGeeP2Rnnj9kZ54/ZFITEyEwwd4kydPVlmt3Bw5ckQNimJ24cIFdO/eHQ888ABGjRqF4uTFF1+0yjBKBk8GaJH+fDLgi3y4u3TpAldXV13rSY6pJ4DB52IxbvF+RMQlYfZhN7zSoxYealYeBumbpz2AtH2L4Lz2JQRdO4yu/05Des/Z0Gr1sOsXI15/pBdef6QnXn+kJ15/ZMncus+hA7yJEydi+PDhuZapWrVq5u2IiAh07NgRbdq0yTZgSWhoKC5evGi1zXxf9uVWxnK/eZuMomlZpnHjxplloqOjrZ4jLS1NjayZ13Esj2GLu7u7WrKSD7T5Q215myir5lWDsHpcO0xcsg/rj0bjtZVHsPtsHP7bvwG83V2B5iOAKm2BH0bCELkPLsuGAk1HAN3+C7iZssS54fVHeuL1R3ri9Ud64vVHwt5rQNdRNIOCglR2LrfF3I9NMncdOnRA06ZNMX/+fNXnzVLr1q3VaJaWbVPlF49atWplNomUMuvXr7d6nJSR7UKaVUoAZllGImXpW2cuI+vY2Fg1OqbZhg0b1Cif0lfP3roQFZQALzd8MbQZJt9XW023sGJvBHp//BeORmX86lOmBjDyd+Ducab7u+cDn98DRO7Ttd5EREREVEKmSTAHdxUrVlT97i5duqT6spn7vIkhQ4aoYFCmQJApDBYvXozZs2dbNXkcN24c1qxZg/fee09NvSBTF+zatQvPPPOM2i/N2MaPH48333wTK1euxIEDBzB06FCULVtWTacg6tSpo5qISvPQnTt3YsuWLerxMgCLlLO3LkQFycnJgCfvqYbvR7dCiJ87/r10Hf0+2YKlu86ZCri4AV1eBx5dDviEApePA190ArZ+DBiNelefiIiIiIpzgCfZLxlYRTJr5cuXV80nzYvlaJcyGImMhClZPmn+KROWW85PJ007v/32W9W8s1GjRli2bJkaQbN+/fqZZSZNmoSxY8eqxzVv3lxNYC5BoUxYbrZo0SKVXezUqRN69OiBtm3bWjUZtacuRIWheeVArH62HdrVKIOkVCOeX7Yfzy/dhxspGcNwVusIjNkK1OoJGFOBtS8DiwYACTd/PJEhOw1n/kK5mG1qnTmEJxERERE5HIPMlaB3Jcg2aR4qwaJMCSGDrKxevVoFlGyDTbcq3ajhkz9OYtbvx2HUgFohvvj0kSaoFuRjKiB/BnbNA357GUi7AXiVBvp+CqSnAGteAOIjbj6ZX1mg+wygbh/dXg+VLNLcnX//SC+8/khPvP4op9jAz880fVaRzeAR0Z2RvnjPdqqBb0a2RBkfdxy7mIDeH/2FFXsvmArIKJvNRwKjNwIhDYDEK8B3g4Alj1oHdyI+ElgyFDi8UpfXQkREREQ5Y4BHVIK0qV4Gq59ti1ZVA5GYko5x3+/Fyz8dQFJqRrPL4NrAqPVAyzG5PEtG0n/NZDbXJCIiInIwDPCISphgPw+VyRt7b3V1f9GOsxgwZyvOXLluKuDiDtSWWfVyowHxF4AzWwu+wkRERERkNwZ4RCWQi7MTJnatha9HNEcpL1cciohHrw//wpqDkaYC16znccyRveWIiIiIqFAwwCMqwTrUCsYvz7ZD00qlkJCchie/2YNpPx9CqmewfU/gE1LQVSQiIiKiW8AAj6iEKxvgqebLG92+qro/f8tpPLgGSPORaUgMOT/QNwyo1KbwKkpEREREeWKAR0RwdXbCSz3q4PNHm8LPwwX/nE/ApGsPQ4OGrNOe35xXxWDqh0dEREREDoMBHhFl6lovVDXZbFTeHz8mNcGTKeMRpQValbmk+eOq5gMkRABfdgYi9+lWXyIiIiKy5pLlPhGVcBUCvfDd6FZo9ubv+C2lBdYlN0MLp6MIRiyiEYCdxtoIwVV84/kOql07C8zvATy4AKjeWe+qExEREZV4zOARUTb7zsWpefKEEU7YbqyLlcY2ai33I1Ea/W68hrjQ1kDKNWDRg8A/3+hdbSIiIqISjwEeEWUTnZCUZ5kEeGFTizlAgwcBLR1Y8TTwx3RAu9lLj4iIiIgKFwM8Isom2NfDrnJB/n7A/Z8DbSeYNmx6G1jxDJCeWrAVJCIiIiKbGOARUTYtqgQizN8jt0kSEODlqsrBYAA6TwF6fQAYnIC93wDfDgKSEwqxxkREREQkGOARUTbOTgZM6V1X3c4pyItNTMWiHWdubmj2GPDQd4CrF3BqvWnwlYSowqkwERERESkM8IjIpu71wzDnkSYI9bdurimZvXtqBqnbr604hFm/H4dm7ndXqzswfBXgVQaI2g982QW4dEyP6hMRERGVSJwmgYhyDfK61A3FtpPRWLt5B7q2a4nW1YPhZABm/X4Cs9efUOur11MwpXc9OMmOck2Bx9cB3wwEYk4BX3UBBn8PVGqj98shIiIiKvaYwSOiPJtrtqwSiKZlNLWW+waDAc91qYlpfeqpMgu2ncH4xXuRkmY0PSiwKjByHVC+BZAUByzsCxz8Ud8XQkRERFQCMMAjots2rE1lzH6oMVycDFi5LwKjFu5CYkqaaad3aWDYSqB2LyA9BVg2Atj6EadRICIiIipADPCI6I70bVwOXwxrBg9XJ2w6fgmPfrUTcYkZ0yS4egIPLgRaPGG6v/YVYM1kwGiaRJ2IiIiI8hcDPCK6Yx1rBWPR4y3h5+GC3Weu4sHPtuFifMZk6U7OwH0zgK5vmu7vmAssGQqk3tC1zkRERETFEQM8IsoXTSsFYsmTrRHs645jFxMwcO5WnL583bRT5sprMxYYOA9wdgOOrgIW9AGuX9G72kRERETFCgM8Iso3tUP98MOYNqhU2gvnYm5g4NxtOBQRd7NA/QHAo8sBD3/g/E7TCJsx4XpWmYiIiKhYYYBHRPmqQqAXlj3ZBnXC/HD5WjIe+mw7dvxrkamrfDfw2FrAv8LNaRQu7NazykRERETFBgM8Isp3Qb7uWPxEK7SoEoiE5DQMnbcTvx++eLNAcG3g8d+B0IbA9UvA172AY2v0rDIRERFRscAAj4gKhJ+HKxY+1gKd6wQjOc2IJ77ZjR92n79ZwDcUGLEaqNYJSE0Evh8M7JqnZ5WJiIiIijwGeERUYDxcnTH3kaYY0KQ80o0aJi7dhy83/3uzgLsvMGQx0PgRQDMCq54D1r/uWHPlyZQO4ZuBA8tMa07xQERERA7MRe8KEFHx5uLshHcGNkQpL1d8+Vc43vzlCK4mpuA/XWvBIKNrOrsCfT8GAioAG6cDm98D4s4DfT4GXNz0rfzhlcCaF4D4iJvb/MoC3WcAdfvoWTMiIiIim5jBI6IC5+RkwMs962BS91rq/id/nMJLPx1UWT1FAr0Ok01BncEZ2L8YWDQQSIrTL4MmwZ3M12cZ3In4SNN22U9ERETkYJjBI6JCIdm6pzpURykvN7z80wF8t/Ms4m6k4INBjeHu4mwq1ORRwC8MWDIMCN8EfHo3YEwBrl0s3AyaBJGSuYOtpqKyzQCsmQzU7mmayJ2IiIjIQTDAI6JCNbhFRQR4umLc93ux+kAU4m78jc8ebQYf94w/R9U7mwZfWdAbiD+X/QnMGbQHF+Yc5BmNQOp1IPkakHIdSEkwrdV985LL/YTI7Jk7KxoQfwHYNR+ofz/gFZg/J4eIiIjoDjHAI6JCd1+DMPh6uGL0/3Zhy8krePiL7Zg/ogUCvTP63IXUB1w8AFhMkp4pI6v242hg9wJTICdBWWYwd800KmdhWD3RtHgEAIFVrZfS1Uxrr9KmJqh3kk08s9WUxfQJASq1YdaQiIiIcsQAj4h00bZGGXw7qhVGzN+Jfefj8MDcrfjfyJYoG+B5M6DJTdoN4NTvuZcxOAFuvoC7D+DmDbhlrGX0zhzv+wCxZ4ANb+T9IrzKAImXgaRYIGKPacnK3S/n4M87KPfgj4O8EBER0S1igEdEumlcIQBLn2yNR7/aiVOXrmPgnK1YOLIlqucV3Jk1HQFU7ZARwPlkD9gkC3g72TPJmu36ytQc1GY/PIMp0Bp/AEhLBq6eBmL+zVhOZazDTaOBJscDkXtNS1ZS38AqQGC17AHguR2mvohZj29PE1UiIiIqsRjgEZGuqgf7YtmYNnj0qx3499J1lclb2t0b1e15cP0BQJV2+V8paQIpWTIJpCSYswqyMgLG7m+byrl5ASF1TUtWqUlZgj+LAFCCP2lOGnXAtGST9bhmHOSFiIiIcsYAj4h0Vy7AE0ufaI0RX/+N/efj0H+VAbt8QuGeeDH3DJr0Rysokh17cCG0NS/AYNFEUvMrC4MEd/Zkz1w9gODapiUryfzFngWunMoe/F09k8PrzjLIizRlLYgAl4iIiIosBnhE5BBK+7irPnmjF+7C1lNXMDF+CD5yeV+FOZYTdhozclsqyCrg7NUaY3O8kTQbFVL2IRixiEYAziU1wqvGBuh+p0/u4g6UqWFastr7PbD8ibyfw96mrERERFRicKJzInIYMlXC/BHN0b1eKFalNcOTKeMRpVlPQRCllcaYlHEq+CpIaw5GYsw3e3AhPhXbjXWx0thGrSPiU9V22V9g/MvZV05G1SQiIiIqigFenz59ULFiRXh4eCAsLAyPPvooIiKs56nav38/2rVrp8pUqFABM2fOzPY8S5cuRe3atVWZBg0aYPXq1Vb7NU3Da6+9po7h6emJzp0748SJE1ZlYmJi8PDDD8PPzw8BAQEYOXIkrl27dst1IaLsZNLzDwffBU83Z/xmbIG2yR/ioZRX8GzKM2rdNnm22j7t58NIN+bWjPH2yfNO/flwjj3gREEeXzU9lSao5v5+NpuolivYJqpERERUJBWZJpodO3bESy+9pAKvCxcu4D//+Q8GDhyIrVu3qv3x8fHo2rWrCsjmzp2LAwcO4LHHHlMB2OjRo1UZKTt48GBMnz4dvXr1wrfffot+/fphz549qF+/viojgdiHH36IBQsWoEqVKnj11VfRrVs3HD58WAVrQoK7yMhIrFu3DqmpqRgxYoQ6hjyfvXUhopztPnMVN1LS1W0jnFTmLKvIuCR0fn8TPF2dYdQ0aBrUOt3itlqMFrdlu9Hittp/87Y8Th6fV+CmZRx/84lL6FAruJAHeclQCE1UiYiIqOgpMgHec889l3m7UqVKmDx5sgrOJMBydXXFokWLkJKSgnnz5sHNzQ316tXD3r178f7772cGVbNnz0b37t3x/PPPq/tvvPGGCtI+/vhjFYhJ9m7WrFl45ZVX0LdvX1Vm4cKFCAkJwfLly/HQQw/hyJEjWLNmDf7++280a9ZMlfnoo4/Qo0cPvPvuuyhbtqxddSGinEUnJNlVLvzydehp+Py/UbWMN2qH+aJOqB9qh/mhTpivGjTGcCeTm1sM8pJtHjwnV2DgPE6RQEREREU7wMvaRFKCqDZt2qjgTmzbtg3t27dXAZWZZN5mzJiBq1evolSpUqrMhAkTrJ5LykjwJsLDwxEVFaUyb2b+/v5o2bKleqwEeLKWTJw5uBNS3snJCTt27ED//v3tqostycnJajGTTKCQINbFxSXzNlFhM193hXX9lfay70/Tf7pUR90wPxVMOTsBTgaDmvZO1qbl5m3Z7uxk2maw3J+xzfIxe8/F4Znv99lVh38vX1fL6gNRmdt8PVxQK8QHtUN91SK3a4b4wMvtFv/k1rgP6VW64MSudUiNPoHGB96EkzEVqaWqyZuBkqKwrz8iS7z+SE+8/siSvddBkQrwXnjhBZVtS0xMRKtWrbBq1arMfRKYSZNKS5J5M++ToErW5m2WZWS7uZzl43IqExxs3SRLgq/AwECrMnnVxRZpOjpt2rRs29euXQsvLy91WzKORHoprOtPWkgGuDkjNkXu2cqEaQhwA8olHEXCNf2O/1z9dETdMCAiEbhwXdYGXLwBJCSlYdeZWLWYGaChjAdQzktDWW8NZb2Act4aSrnlPBf7visG/HjaCbEp0hSzNr50bYTOzv9g+3dvI6baQJQ0/PtHeuL1R3ri9UdCYqACD/CkGaJkvapVq5aZYboV0sxSslq5kSaRMiiKkKaVMqDJmTNnVCA0dOhQFeTdcVMoB/Hiiy9aZRglgycDtEh/PhnwRT7cXbp0ycxaEhXmL0aFff25Vr6IsRlZtOzTjBvw5v2N0K1eiMMdPyXNqDJ6R6MSMpZrOHYxAZevpeBSEnApyYC9Mcgz27f5xBXM37bP6tjL09uqAK9y7DbEVXwL3eqHoSTQ4/ojMuP1R3ri9UeWzK37CiTAk+hx7NixaiAScfz4cVStWlVtK1eunArc7DFx4kQMHz481zLyvGZlypRRS82aNVGnTh0V/Gzfvh2tW7dGaGgoLl60nhPKfF/2mde2yljuN2+TwVwsyzRu3DizTHR0tNVzpKWlqWajeR3H8hi2uLu7qyUr+UCbP9SWt4kKW2Fef70al4eLi7MarVIGNDEL9ffAlN510b2Ag5vbPb6cngYV3NGggvX0DpcSknE0Kh5HIuNxNDIBhyPjcerSNZvZPiHNSbMOrfK7sQkSNE9UcLqEN1evxH2NnlblSgr+/SM98fojPfH6I2HvNeByu5mmffv2YePGjWrQEsu+aFOnTrU7wAsKClLL7TDK0HgZ/daEBHkvv/xy5qArQn7xqFWrVmaTSCmzfv16jB8/PvN5pIxsF9KsUgIwKWMO6CRSlr51Y8aMyXyO2NhY7N69G02bNlXbNmzYoOojffXsrQsR5U2CqC51Q7EzPEYNvBLs64EWVQILLajJz+MH+bojyDcI7WoEWWX7JMgzBX4JKviT9eVryTZH8kyCO9akN8cDLn+i/Y0N2Bk+GK2rlb7j10lERETFx20FeDIoyeLFi1U/OMvmkTJa5KlTp5DfJMCSUSvbtm2rAiQ5hkxfIE1DzcHZkCFDVLNNacIpffUOHjyoRs384IMPMp9n3LhxuOeee/Dee++hZ8+e+P7777Fr1y58/vnnar+8Fgn+3nzzTdSoUSNzmgQZGVNG7BSSOZSgdtSoUWrkTQninnnmGTUAi5Szty5EZB8JpvQMYgry+G4uTqijRt70Q/+7bm7/ZvsZvLL8oM3H/GRsiwfwJ3o6b8fmWGmqwQCPiIiI7nCi80uXLmUbaERcv369QPrDyQAjP/74Izp16qSyYBI4NWzYEJs2bcps0iijXcpgJNInUDJr0vxTJiy3nJZARt2UueokoGvUqBGWLVumglXzHHhi0qRJqqmpPK558+ZqAnOZFsE8B56QETylX6DUR6ZHkMDTHCTaWxciopxUC/LJcZ/MCRillUKA4TpqxG8v1HoRERFRMc3gyRQBv/zyiwqEhDmo+/LLLzMzavmpQYMGqhlkXiTo27x5c65lHnjgAbXkRF7L66+/rpacyIiZ5knN76QuRES2SDPQMH8PRMUlZeuHJxO/r0xvg9Euv6BW9GoAg3WqJRERERWbAO+///0v7rvvPhw+fFgNMCLND+X21q1bVVaNiIjurFmoDOQy5ps9atTOrEGejKYpAZ7h+G/AjVjAM0CnmhIREVGxaKIpTRJlkBUJ7iS7Js0RpcmmTPBtHniEiIjubICXOY80UaN2WnJ3ccKzQ/oBQXWA9GTgyErd6khERETFIIMng4o88cQTavCRL774omBqRUREVqN47j13FTPWHIPRqKF1tSAg9kFg/TRg/xKgyVC9q0pERERFNYMnw/7/8MMPBVMbIiKyOYrnmA7V1UToqUYNvx6MBBpk9CU+vRmIPad3NYmIiKgoN9GUKQNk9EkiIio8fRuXU+vley8AARWASm1NOw4u07diREREVLQHWZE54mSUyS1btqg+d97e3lb7n3322fyqHxERZejdKAwz1hzFjvAYRMbdQFjDB4EzfwH7FgN3j5dhgPWuIhERERXFAO+rr75CQEAAdu/erZas0wwwwCMiyn/lS3mhReVA7Dwdg5/3RWB0877A6v8Al44AFw8CoQ30riIREREVxQBPJvAmIqLC16dxWRXgrdgbgdHtqwE1u5tG0pTBVhjgERERlXi31QfPkqZpaiEiooLXs0EYXJwMOBQRj5PRCYA00xQHlgHGdL2rR0REREU1wFu4cKGaA8/T01MtDRs2xP/+97/8rR0REVkp5e2Ge2oGqdvL/4kAanQFPPyBhAjg9F96V4+IiIiKYoD3/vvvY8yYMejRoweWLFmilu7du+PJJ5/EBx98kP+1JCKiTH3vMo2muWLfBWjObkC9/qYd0kyTiIiISrTb6oP30UcfYc6cORg69Obkun369EG9evUwdepUPPfcc/lZRyIistClTgi83JxxLuYG9pyNRdOGg4DdXwOHVwA93wVcPfWuIhERERWlDF5kZCTatGmTbbtsk31ERFRwPN2c0a1eqLq9UubEq9AK8K8IpCQAx37Vu3pERERU1AK86tWrq2aZWS1evFjNkUdERAWrb+Oyar1qfyRSZZyrhg+YdrCZJhERUYl2W000p02bhkGDBuHPP//E3XffrbbJpOfr16+3GfgREVH+alu9DEp7u+HK9RRsOXkZHRo8CGx+Dzi5Drh+BfAurXcViYiIqKhk8AYMGIAdO3agTJkyWL58uVrk9s6dO9G/f0ZnfyIiKjAuzk7o1TBM3ZY58RBcGwhtCBjTgMM/6V09IiIiKkoZPNG0aVN88803+VsbIiKyW5/G5bBg2xn8digKiSlp8JLBVqL2m5ppNn9c7+oRERFRUcngrV69Gr/99lu27bLt11/ZwZ+IqDA0qRiAioFeSExJx+9HooH6AwCDE3BuBxATrnf1iIiIqKgEeJMnT0Z6enq27ZqmqX1ERFTwDAZD5mArK/65APiFAVXuMe08sFTfyhEREVHRCfBOnDiBunXrZtteu3ZtnDx5Mj/qRUREdjAHeJuOX8LV6ymANNMU+xfLr276Vo6IiIiKRoDn7++Pf//9N9t2Ce68vb3zo15ERGSH6sG+qFfWD2lGDb8ciATq9AJcPIErJ4GIPXpXj4iIiIpCgNe3b1+MHz8ep06dsgruJk6ciD59+uRn/YiIyM4s3koZTdPdF6jd07SDc+IRERGVOLcV4M2cOVNl6qRJZpUqVdQit0uXLo133303/2tJREQ56t2oLAwGYOfpGJy/mnizmebBH4D0NL2rR0RERI4+TYI00dy6dSvWrVuHffv2wdPTE40aNUK7du3yv4ZERJSrMH9PtKwSiO3/xmDlvgg81a4j4FUauH4J+HcjUKOz3lUkIiIiR8zgbdu2DatWrcocva1r164IDg5WWTuZ/Hz06NFITk4uqLoSEVEO+jUud7OZprOracoE82ArREREVGLcUoD3+uuv49ChQ5n3Dxw4gFGjRqFLly5qeoSff/4Z06dPL4h6EhFRLu6rHwY3ZyccjUrA0aj4m800j64Ckq/pXT0iIiJyxABv79696NSpU+b977//Hi1atMAXX3yBCRMm4MMPP8SSJezUT0RU2Py9XNGhVpC6vUKyeOWaAoFVgdRE4OgvelePiIiIHDHAu3r1KkJCQjLvb9q0Cffdd1/m/ebNm+PcuXP5W0MiIrJLv7tuNtM0yhR4lnPiERERUYlwSwGeBHfh4eHqdkpKCvbs2YNWrVpl7k9ISICrq2v+15KIiPJ0b+1g+Li74ELsDew+exVo8IBpx79/AAkX9a4eEREROVqA16NHD9XXbvPmzXjxxRfh5eVlNXLm/v37Ua1atYKoJxER5cHD1Rnd64eq28v/uQCUrgaUbw5oRuDQj3pXj4iIiBwtwHvjjTfg4uKCe+65R/W7k8XNzS1z/7x589TImkREpO+k578ciERKmhFo8KBpB5tpEhERlQi3NA9emTJl8OeffyIuLg4+Pj5wdna22r906VK1nYiI9NGmWhkE+brjUkIyNp+4hE717wfWTAYi/gEuHQeCaupdRSIiInKUDJ7lROdZgzsRGBholdEjIqLC5exkQO+GpizechlN07sMUD1jovMDHOWYiIiouLutAI+IiBy/mea6w1G4npwGNLRopqnJ8JpERERUXDHAIyIqZhqW90eVMt5ISjVi7eEooFYPwM0HiD0LnNuhd/WIiIioADHAIyIqZgwGA/o0Kntz0nM3L6BOH9NODrZCRERUrDHAIyIqxs00N5+4jMvXkm820zz0E5CWom/liIiIqMAUuQAvOTkZjRs3Vr9Q792712qfzMMn8/J5eHigQoUKmDlzZrbHy0iftWvXVmUaNGiA1atXW+3XNA2vvfYawsLC4Onpic6dO+PEiRNWZWJiYvDwww/Dz88PAQEBGDlyJK5du3bLdSEiKihVg3xUU810o4Zf9kcCVdoDPqHAjavAyd/1rh4REREVkCIX4E2aNAlly5p+mbYUHx+v5uCrVKkSdu/ejXfeeQdTp07F559/nllm69atGDx4sArI/vnnH/Tr108tBw8ezCwjgdiHH36IuXPnYseOHfD29ka3bt2QlJSUWUaCu0OHDmHdunVYtWqVmjpi9OjRt1QXIqKC1rdxObVesfcC4OQMNBho2sFmmkRERMVWkQrwfv31V6xduxbvvvtutn2LFi1CSkqKmmy9Xr16eOihh/Dss8/i/fffzywze/ZsdO/eHc8//zzq1KmjJm5v0qQJPv7448zs3axZs/DKK6+gb9++aNiwIRYuXIiIiAgsX75clTly5AjWrFmDL7/8Ei1btkTbtm3x0Ucf4fvvv1fl7K0LEVFB690wDE4GYM/ZWJy9knizmeaxX4GkOL2rR0RERHpPdK6nixcvYtSoUSrQ8vLyyrZ/27ZtaN++vdU8fJJ5mzFjBq5evYpSpUqpMhMmTLB6nJQxB2/h4eGIiopSzTIt5/yTQE4eK4GarKVZZrNmzTLLSHknJyeV8evfv79ddcmp+akslplAkZqaChcXl8zbRIXNfN3x+itaSnk6o1XVQGw9FYOf9pzDU/fUgUuZWjBcPoa0Az9Ba/wwigJef6QnXn+kJ15/ZMne66BIBHiSWRs+fDiefPJJFVidPn06WxkJzKpUqWK1LSQkJHOfBFWyNm+zLCPbzeUsH5dTmeDgYKv9EnzJJO+WZfKqiy3Tp0/HtGnTsm2XrKU5qJVmoUR64fVX9FSGAVvhjG+3nkCl60dR07Uh6uIYrm6ai60Rtv8WOSpef6QnXn+kJ15/JBITE+HwAd7kyZNVVis30iRSApyEhAS8+OKLKM7k9VlmGCWDJwO0SH8+GfBFPtxdunSBq6urrvWkkvmLEa+/oqldUiqWzdiEizeMqNKkLWp4NQA+Xooy146iR9tGgJ+pn54j4/VHeuL1R3ri9UeWzK37HDrAmzhxosrM5aZq1arYsGGDavbo7u5utU+yeTLgyYIFCxAaGqqacVoy35d95rWtMpb7zdtkFE3LMjJyp7lMdHS01XOkpaWpkTXzOo7lMWyR15f1NQr5QJs/1Ja3iQobr7+iJ9DVFZ3rBGP1gSj8cjAajXrUASrdDcOZLXA9shxoOx5FBa8/0hOvP9ITrz8S9l4Dug6yEhQUpKYsyG2RfmwyquW+ffvUtAiymKc2WLx4Md566y11u3Xr1mo0S8u2qfKLR61atTKbREqZ9evXW9VBysh2Ic0qJQCzLCORsvStM5eRdWxsrBod00wCUKPRqPrq2VsXIqLC0qeRKUu3cm+EmjYhc7CVA0v1rRgRERGVzFE0K1asiPr162cuNWvWVNurVauG8uXLq9tDhgxRwaBMgSBTGEjwJ6NmWjZ5HDdunBoB87333sPRo0fV1AW7du3CM888o/bL3Hrjx4/Hm2++iZUrV+LAgQMYOnSompZBplMQMvqmjMQpA77s3LkTW7ZsUY+XAVjM0zfYUxciosLSsXYQfD1cEBWfhJ3hMUDdvoCzG3DxIBB1c5oYIiIiKvqKRIBnDxntUvrqyUiYTZs2Vc0/ZcJyy/np2rRpg2+//VbNR9eoUSMsW7ZMjaApQaPlPHtjx45Vj2vevLmawFyCQpmw3EymQZDsYqdOndCjRw81VYLlHHf21IWIqLC4uzijR/2wm3PieZYCanQ17TywRN/KERERUb4qEqNoZlW5cmU1smZWMm/d5s2bc33sAw88oJacSBbv9ddfV0tOZMRMCRRzY09diIgKS9+7ymLxrnNYfSAS0/rWg3vDQcDRVcD+pUCnqYBTsfm9j4iIqETj/+hERCVAyyqlEerngfikNGw8dsmUwfPwBxIigDN/6V09IiIiyicM8IiISgBnJwN6NwrLHGwFrh5AXVPfYuxfrG/liIiIKN8wwCMiKiH6NjaNpvn7kYtISEoFpJmmOLwSSE3St3JERESULxjgERGVEPXK+qFakDeS04xYczAKqNga8K8AJMcDx9foXT0iIiLKBwzwiIhKCBlEql9GFm/lvgjTwCoNBpp27udomkRERMUBAzwiohKkT2PTfJ1bTl5GdELSzWaaJ9YCiTH6Vo6IiIjuGAM8IqISpFJpb9xVMQBGDVi1LxIIrgOENgCMqcChn/SuHhEREd0hBnhERCWMuZmmmvRcmLN4bKZJRERU5DHAIyIqYXo2DFPTJuw7H4fwy9eB+tIPzwCc2w7EhOtdPSIiIroDDPCIiEqYMj7uaFu9zM0snl8YUPUe084Dy/StHBEREd0RBnhERCVQ34zBVlbsjYCmaRbNNBcDcp+IiIiKJAZ4REQlUNd6ofBwdVJNNA9ciANq9wJcPIErJ4DIvXpXj4iIiG4TAzwiohLIx90FneuEqNvL/4kAPPyAWveZdnKwFSIioiKLAR4RUQkfTfPn/RFIN1o005R+eOlp+laOiIiIbgsDPCKiEqp9zSAEeLniUkIytp26AlTvBHgGAtejgfCNelePiIiIbgMDPCKiEsrNxQk9GoTdHE3T2RWoP8C0k800iYiIiiQGeEREJZi5meaag1FISk2/2UzzyM9A8jV9K0dERES3jAEeEVEJ1qxSKZT190BCcho2HI0GyjcDSlUBUhOBY6v1rh4RERHdIgZ4REQlmJOTAX0ysniqmabBYDEnHptpEhERFTUM8IiISjjzpOd/HL2EuMRUoOGDph2nNgDXovWtHBEREd0SBnhERCVcnTA/1ArxRUq6EWsORQKlqwHlmgJaOnDwR72rR0RERLeAAR4REaHvXWVvTnouMptpLtaxVgCM6TCc+QvlYraptdwnIiKinDHAIyIi9GlkCvC2h19BVFwSUO9+wOAMROwBLp/Qp1KHVwKz6sPlm35odmaOWst9tZ2IiIhsYoBHREQoX8oLzSuXgqYBP++LAHyCTBOfiz/fBQ4sA8I3F14GTYK4JUOB+IyMoll8pGk7gzwiIiKbGOAREZGSOZrmvgumDaWrm9b7vwd+GAks6FU4GTQJIte8AECzsTNj25rJbK5JRERkg4utjUREVPL0bBCGaSsP4eCFeERuW4Kw7XOyFzJn0B5cCNTtY98Tp6cCyQlAyjXT5Olqncv9mFPZM3dWNCD+AnBmK1Cl3W2/XiIiouKIAR4RESmB3m5oXzMIG49GweePl3PPoK14GojcZ5oQPVuwJusE01r2pScXTIWvXSyY5yUiIirCGOAREZHVnHiJxzfCNyWP+e+S44HN797akzu7AW4+gLsP4OabsZb75tsZ62uXgD1f5/18PiG3dnwiIqISgAEeERFl6lI3BJtd4u0rXLUjENbIRsBmI4CTtYubfc8rfetOrjU1B7WZRZQe5K6AVxn7XxgREVEJwQCPiIgyebm5oHKlKsA5Owq3m1gwfeCcnIHuM0x9/WCwHeQZU4Ev7wW6vw00GQoYpBwRERFxFE0iIrJSr819iNACYcyxhAHwKwdUalNwlZABXGQgF78w6+1y3N4fAlU7mPr//fwssHQYcONqwdWFiIioCGGAR0REVtrWDMH7zo+pxJmmMmiWMu5L5kwybQVJgrzxB5H2yHLsqjRGrTH+ANB0GPDIT0CX1wEnF+DwCmBOW9OomkRERCUcAzwiIrLi6uwEr0b9MSZ1POJcsvRz8yt7a1Mk3CknZ2iV2uJCYGu1zgwqnZyAu8cBI9cBgVWB+PPA1z2BDW8B6WmFUzciIiIHxD54RERkczTNAdtaYGtKS+x61BvuSZdMo1ZKs8yCztzdinJNgCf+BH59Adi7CPhzJvDvRmDAl0CpSnrXjoiIqNAxg0dERNk0qVgKFQI9kZCi4ZPwUKxIb41txrpIL+T/NtKNGnaEx2D3ZYNay/1sZJTOfp8CA74C3P2A8zuBuW2BA8sKta5ERESOgBk8IiLKxmAwoH5Zf5yLuYEPN5zM3B7m74Epveuie/0sg58UgDUHIzHt58OIjEuSSfSw8MSu3I/fYCBQvjnww+OmIO+HkcCpDcB9M0xBIBERUQnADB4REdkMrn49GJVte1RcEsZ8s0ftL+jjy3FMwd0tHF+aZY74FWg/CTA4mZptftYeuLCnQOtLRETkKIpMgFe5cmX1i7Ll8vbbb1uV2b9/P9q1awcPDw9UqFABM2fOzPY8S5cuRe3atVWZBg0aYPXq1Vb7NU3Da6+9hrCwMHh6eqJz5844ceKEVZmYmBg8/PDD8PPzQ0BAAEaOHIlr167dcl2IiByRNIOUzJkt5gaSst9mc8l8Ov7Unw/bnOLcruM7uwD3vgwMWwX4lQdi/gW+6gL8NQsw5jz5AxERUXFQpJpovv766xg1alTmfV/fm01u4uPj0bVrVxWQzZ07FwcOHMBjjz2mArDRo0erMlu3bsXgwYMxffp09OrVC99++y369euHPXv2oH79+qqMBGIffvghFixYgCpVquDVV19Ft27dcPjwYRWsCQnuIiMjsW7dOqSmpmLEiBHqGPJ89taFiMhR7QyPyZY5syRhlezv9eFm+Hi4qEArXZPYSVO3jZppMd3GzW2qnGyHdZmM7RJ7mfbnHjiajy/1bF2tdM4FK98NjPkLWPkscGQl8PsU4N8/gP6fAb6hd3KKiIiIHFaRCvAkoAsNtf2f8qJFi5CSkoJ58+bBzc0N9erVw969e/H+++9nBlWzZ89G9+7d8fzzz6v7b7zxhgrSPv74YxWISfZu1qxZeOWVV9C3b19VZuHChQgJCcHy5cvx0EMP4ciRI1izZg3+/vtvNGvWTJX56KOP0KNHD7z77rsoW7asXXUhInJU0Qk5B3eWjkQlwOHr6VnKNK3DnoXAmsmmETbntAH6fgLUuq8wqklERFSoilSAJ00yJSirWLEihgwZgueeew4uLqaXsG3bNrRv314FVGaSeZsxYwauXr2KUqVKqTITJkywek4pI8GbCA8PR1RUlMq8mfn7+6Nly5bqsRLgyVoycebgTkh5Jycn7NixA/3797erLrYkJyerxUwygUKyhObXKbeJCpv5uuP1VzKU9rLvv4ZnOlRFzRAfODsZ4GwwwEnWTgY4yW0DMm+b1rC4LWvT/cxtTsh8jr3n4jD2+3121dPua7LhEKBsc7gsHw3DxQPAdw8hvdnjMN47BXD1tO85qETi3z/SE68/smTvdVBkArxnn30WTZo0QWBgoGpq+eKLL6pmkpIVExKYSZNKS5J5M++ToErW5m2WZWS7uZzl43IqExwcbLVfgi+pl2WZvOpiizQdnTZtWrbta9euhZeXl7otGUcivfD6KxmkhWSAmzNiU+SewUYJDQFuQLWk49DOAjKteFqhHl86kGs4uHs7rhy5ted2Ch2POsYlqH7pNzjv+hLXD67BrspPIcGzfL7UnYov/v0jPfH6I5GYmAiHD/AmT56sslq5kSaRMiiKZeatYcOGKjv2xBNPqKDI3d0dxYEErZavUzJ4MkCL9OeTAV/kw92lSxe4urrqWk8qmb8Y8forWVwrX8zMoln2iDOFWwa8eX8jdKsXUujHNzPCgI+OuOPNvnXRq+GtTtnQF2mn1sP552fgd/08Op58HcbOr8PYZITMD5Ev9afig3//SE+8/siSuXWfQwd4EydOxPDhw3MtU7VqVZvbpdlkWloaTp8+jVq1aqm+eRcvXrQqY75v7reXUxnL/eZtMoqmZZnGjRtnlomOjrZ6DqmHjKyZ13Esj2GLBKq2glX5QJs/1Ja3iQobr7+So1fj8nBxcbaYh84ktJDmwcvp+DIP3vjONfDTPxew/d8YPLf0APaci8crverA3cXZ/gPU7g6U3wosHwPDyd/hvGYSnMM3AX0+ArxzGbilpDGmA2e2AtcuAj4hQKU2gNMtnOdihH//SE+8/kjYew3oGuAFBQWp5XbIoCXS783cXLJ169Z4+eWX1S8d5hcvv3hI8GduEill1q9fj/Hjx2c+j5SR7UKaVUoAJmXMAZ1EytK3bsyYMZnPERsbi927d6Np06Zq24YNG2A0GlXQaW9diIgcnQRxXeqGqtEqZUCTYF8PtKgSqPrMFebxt52MxtrNO9C1XUu0rh6sjj+gSXl88PtxfPLHKfxv+xnsOx+LT4Y0QYVAU3N2u/gEA0OWAjvmmkbYPPYLMHePaZTNqveYypTkAOfwSmDNC0B8xM1tfmWB7jOAun30rBkRERX1efBk0BIZ3XLfvn34999/1SiVMsDKI488khkwyaAr0mxT5qQ7dOgQFi9erEbNtGzyOG7cODUC5nvvvYejR49i6tSp2LVrF5555hm1X+bWk+DvzTffxMqVK9X0BkOHDlUjY8p0CqJOnTpqJE6ZrmHnzp3YsmWLerwMwCLl7K0LEVFRIMGUTEXQt3E5tS6s4M7y+C2rBKJpGU2tzcd3cXbC891qY/6I5gjwcsX+83Ho+eFm/H7YuvVEnmR0l9ZPAY+vB8rUBBIigYV9gd+nAgd/AmbVBxb0An4YaVrLfQl8CosEmOGbgQPLTGu5XxjkNS4Zah3cifhI0/bCPAdERFT8Ajxptvj999/jnnvuUVMOvPXWWyrA+/zzz61Gu5TBSGQkTMmsSfNPmbDcclqCNm3aqLnq5HGNGjXCsmXL1Aia5jnwxKRJkzB27Fj1uObNm6sJzCUoNM+BJyTAlH6BnTp1UtMjtG3b9pbrQkREd65jrWD88mw7NK4QgPikNDy+cBem/3oEqTLZ3q0IawiM3gg0lW4DGvDXB8Cy4foGOHIMPQJMCSIlc5fbVPMy5URhBZtERHRLDJpM/kYOSZqHSrAYFxenBllZvXq1CijZBpsKmzQ35vVHjnz9paQZVWA3f8tpdb955VL4aHAT1WfwlknmbtmIHAIcYTA1VRx/oOCaa5ozaNnqkJFBlbn9bDWTlP/S05KBlGumJVnW14GUBNPanvvXooCrpvOYq2GrgCrtUNzx7x/pidcf5RQb+Pn5ochPk0BERJQTNxcnTOldD80rB2LSsv34+/RV1WRz9kN3oW2NMrf2ZN5SPrffPjUg/gLwZRfAJwgwOGUsBsDgfPO+BH+Z+5zy3m7eJ3Z8nnsG7cdRwM7PM4Kz69YBnVZImTXpl0hERA6HAR4RERUbPRqEoW6YH8Ys2oMjkfF4dN4OjO9UE8/cW93+/oP2Bi4Ru6GbtCTg9Obcy7h6AW4+gJs34C5rn1zu+5rWcj8mHPj9tbzrIIPOEBGRw2GAR0RExUrlMt746ak2mLryEL7/+5wabXPXmRjMGtQYpX3c8y9wufs5oHQ1QDNmLOmmJpJyW/qnZW4375O1lmWfxW1jxvryceDU+ryP32I0UK2T7YBNltttPir12znX1N/QZhYxo4mqjChKREQOhwEeEREVOx6uznh7QEM0qxyIV5YfwOYTl9Hzw7/w8ZC71LZcSeAiAUxeAU6nVwumD56MlmlPgFenT8H0gZPXJFMhqD6ABtvnoPvbJWe6CCKiIqZIjKJJRER0OwY2LY8VT7dF1SBvRMUnYdDn2/HFn/8i1/HFzAGOkrVZp6HgAxxzgJnt2BZ18CtXsBk0GcBFBnLxszGhfbV7OQ8eEZEDY4BHRETFWq1QX6x8pi16NyqLdKOGt1YfwRP/2424G6m3HuBI4JXTCJb5Re8A00xe4/iDptEyB3wFdHvbtD18ExDzb8Eem4iIbhubaBIRUbHn4+6CDx9qjBZVAvHGz4ex9vBFHPloMz4d0hQNyvvnHODU7gmc2WoaeEX65knWrDCaJpoDTJmPznIuPgkwJbgrrAyavFbLZqCnfgdO/g5sfBu4/+b8r0RE5DgY4BERUYlgMBjwaKtKaFTeH08t2oNzMTcwYM5WvNa7Lh5uWVHtzzPAKUx6Bpg5ufdVU4C3fwlw9zggpJ5+dSEiIpvYRJOIiEqUhuUD8MvYduhcJwQp6Ua8svwgxi/ei+vJaXA45gCzwUDTWu+BTco2Bur2Mw28suEtfetCREQ2McAjIqISx9/LFV8MbYoX76ut5sdbsTcCfT/ZghMXE/SumuPr+LJpUvZjvwDn/ta7NkRElAUDPCIiKpGkSeYT91TDd6NaIcTPHSejr6HPx1vw0z/nM8vIoCzbTl3Bir0X1Frul3hBNYHGQ0y3N7yud22IiCgL9sEjIqISTQZe+eXZdhj3/T/YcvIKnlu8DzvDr6J11UBM//UoIuOSMsuG+XtgSu+66F7fxvQBJck9k0398ML/BE79AVTrqHeNiIgoAzN4RERU4pXxccfCx1piXKcakLFWvtt5Fs9+v9cquBNRcUkY880erDkok6AXPL0ziDkeP6AC0Gyk6fb614Hc5hUkIqJCxQweERERoPriPdelJu6qEIARC/62GbPIJhlrc9rPh9Glbqh6TEGRIFKOo1cGMc/jt5sI7FkIROwBjq4C6vQu8DoREVHemMEjIiKy4O7qnGtCSnZJ0DN99RGV2fr98EVsPXUZ+8/Hqn58kuVLSEq9o2ybBFeSKdQrg2jX8X2CgNZPmXZseBMwphdonYiIyD7M4BEREVmITrAOanLy5V/heZbxdHWGt7ssLvByc4FPxm1vNxe13bTNBV7uzmot2z1dnfDKikMqkMzKvO21FYdQPdhXNSfVNA0SS0pAadQ0FZwaLbaZ96ttqox5v6ms+XGyXcqmphvV8+d0fKsMZutngJ1fAJeOmvrkNR5s17kjIqKCwwCPiIjIQrCvh13lmlQsBQ9XJzV/3vWUdNM647Y5e3cjNV0tl6+l5GsdoxOS0fn9TdCDOYO5MzwGrauVBtqOB36fCmz8L1B/AODipku9iIjIhAEeERFRllE1pa+ZNEe0lcWSDFaovweWPtnaZh88yYIlpxkzAr50XE+5GfjJ+lpyGhJtBIXmfeev3kD45et51tPDxQluLk5wcjLA2WBQ0z5IdZwMBlUvQ8Zttc1J1jf3q8XJdFse52yxPSYxGSejr9uf6WzxBLB9DhB7FtizAGgxyr4TTUREBYIBHhERkQUJjmQgEelrJuGbZZBnDudkf04DrEjA5OHqrJbSPrd+fBmtcvAX2/MsN39EC1MGLZ/Ze/zMTKebF9D+eWD1f4BNM01z5Ll553u9iIjIPhxkhYiIKAsZJXLOI01Ups6S3JftBTmKpTmDmNP4nLJd9ks5hzl+k2FAQCXgejSw47MCqRcREdmHGTwiIiIbJIiTgUSkr5k0R5SMlQQ1BTk1Qn5kEAvy+Mi4n+340u+u40vAT08AW2YBzR4DPAMKpH5ERJQ7ZvCIiIhyIEGMNIPs27icWhd0cOcIGcTcji/qlfWzffwGDwBBdYCkOGDrhwVaPyIiyhkzeERERA5IrwxiTseXKRYmLt2HQxHx2H0mBk0rZWki6uQM3PsKsPhh06ArLZ8EfIILpa5ERHQTM3hEREQOSq8Moq3j929SHg80raC2v7f2uO0H1O4JlGsKpCYCf75bqHUlIiITBnhERERkl7GdqsPV2YCtp65g68nL2QvI3AydXjPd3jXPNHUCEREVKgZ4REREZJfypbwwuEVFdfu9dcfVnH/ZVO0AVLkHMKYCG98u/EoSEZVwDPCIiIjIbk93rA53FyfsPnMVm45fsl3InMXb9x1w6Vih1o+IqKRjgEdERER2C/HzwKOtKmX2xbOZxSvfDKjdC9CMwB9vFX4liYhKMAZ4REREdEue7FANXm7OOHAhDmsPX7RdqOPLppn7Dq8AIv4p7CoSEZVYDPCIiIjolpTxcceIuyur2x+sO66mUMgmpC7QcJDp9vo3CrmGREQlFwM8IiIiumWj2lWFr7sLjkYl4JcDkbYLdZgMOLkAp9YDp/8q7CoSEZVIDPCIiIjolgV4ueHxdlXV7Q9+P460dGP2QoFVgCbDTLfXvw7Y6q9HRET5igEeERER3ZbH2lZGgJcr/r10Hcv3RtgudM8kwMUTOLcDOP5bYVeRiKjEYYBHREREt8XXwxVP3lNN3Z69/jhSbWXxfEOBlqNNtze8ARhtlCEionzDAI+IiIhu29DWlVDGxw3nYm5g6a7ztgvdPR5w9wMuHgQO/VjYVSQiKlEY4BEREdFt83JzwVMdqqvbH204gaTUdBuFAoE2z5puy7x46amFXEsiopKDAR4RERHdkSEtKyLUzwORcUn4fudZ24VajQG8ygAx/wL/fFPYVSQiKjGKVID3yy+/oGXLlvD09ESpUqXQr18/q/1nz55Fz5494eXlheDgYDz//PNIS0uzKrNx40Y0adIE7u7uqF69Or7++utsx/nkk09QuXJleHh4qOPt3LnTan9SUhKefvpplC5dGj4+PhgwYAAuXrx4y3UhIiIqDjxcnfHMvaYs3sd/nMKNFBtZPHcfoP1/TLc3zQRSbxRyLYmISoYiE+D98MMPePTRRzFixAjs27cPW7ZswZAhQzL3p6enq4AqJSUFW7duxYIFC1Tw9tprr2WWCQ8PV2U6duyIvXv3Yvz48Xj88cfx2283R/VavHgxJkyYgClTpmDPnj1o1KgRunXrhujo6Mwyzz33HH7++WcsXboUmzZtQkREBO6///5bqgsREVFx8mCzCihfyhOXryVj4bbTtgs1ewzwKw8kRAB/f1nYVSQiKhm0IiA1NVUrV66c9uWXX+ZYZvXq1ZqTk5MWFRWVuW3OnDman5+flpycrO5PmjRJq1evntXjBg0apHXr1i3zfosWLbSnn3468356erpWtmxZbfr06ep+bGys5urqqi1dujSzzJEjR2RiH23btm1218UecXFx6nllnZKSoi1fvlytiQobrz/SE6+/omPJ32e1Si+s0hpP+01LSEq1XWj3Qk2b4qdpb1fWtBtxmqPj9Ud64vVHOcUGuXFBESCZtAsXLsDJyQl33XUXoqKi0LhxY7zzzjuoX7++KrNt2zY0aNAAISEhmY+TzNuYMWNw6NAh9Tgp07lzZ6vnljKSyROScdu9ezdefPHFzP1yTHmMPFbI/tTUVKvnqV27NipWrKjKtGrVyq662JKcnKwWs/j4eLWW47m4uGTeJips5uuO1x/pgddf0dGrfjA+/cML4VcS8eWfp/B0B9NE6FbqDYTLllkwXDmJ9C0fwtj+BTgyXn+kJ15/ZMne66BIBHj//vuvWk+dOhXvv/++6h/33nvvoUOHDjh+/DgCAwNV0GcZUAnzfdlnXtsqI4HUjRs3cPXqVdW80laZo0ePZj6Hm5sbAgICspXJ6ziWdbFl+vTpmDZtWrbta9euVX35xLp16/I4W0QFh9cf6YnXX9HQLtCA8CvO+GzjCYTEH4WXjW8aZX27o/mVj6Ft+Qi/x1ZGiosvHB2vP9ITrz8SiYmJcPgAb/LkyZgxY0auZY4cOQJjxqSoL7/8shrQRMyfPx/ly5dX/eCeeOIJFAeSOZT+f2YSeFaoUAFdu3ZVA8vIh7tLly5wdXXVtZ5UMn8x4vVHeuH1V7R0N2rY/sk2HI++hrNeNTChc43shbTu0Ob9CZeo/ejqdRDGzm/AUfH6Iz3x+iNL5tZ9Dh3gTZw4EcOHD8+1TNWqVREZGalu161bN3O7jIIp+2S0ShEaGppttEvzyJayz7zOOtql3Pfz81MBlLOzs1pslbF8DmnKGRsba5XFy1omr7rYIq9JlqzkA23+UFveJipsvP5IT7z+io4JXWvhyW92Y+G2s3i8XTWU9sn+fxs6TQEWDYDzrnlwbjMW8C8HR8brj/TE64+EvdeArqNoBgUFqf5ruS3SHLJp06Yq8Dl27JjVLxqnT59GpUqV1P3WrVvjwIEDVqNdyi8eEryZA0Mps379eqs6SBnZLszHsiwj2UO5by4j++XkWpaRekmgaS5jT12IiIiKq271QlC/nB+up6Tjsz9N3Syyqd4JqHQ3kJ4MbMq9NQ8RERWzaRIkMHryySfV1AXSH00CKhmwRDzwwANqLc0YJXiSqRRkGgWZ+uCVV15R89WZs2LyHNKfb9KkSapP3aeffoolS5aoaQ/MpInkF198oaY2kOahcpzr16+r6RmEv78/Ro4cqcr98ccfatAV2SdBnQywYm9diIiIiiuDwYCJXWqp2wu2nkZ0fJKtQkCnjOmDZOLzK6cKuZZERMVTkRhkRciImTKSpARNMiCKTEC+YcMGNeG5kKaVq1atUgGZBFve3t4YNmwYXn/99cznqFKliposXQK62bNnqz58X375pRrh0mzQoEG4dOmSmrPOPFrnmjVrrAZN+eCDD9TomtIfUEa9lMdLsGhmT12IiIiKsw61gtCkYgD2nI3FpxtPYWqfetkLVWwF1OgGnPgN+OMtYOA8PapKRFSsGGSuBL0rQTl3pJSMYVxcnOojuHr1avTo0YNtsKnQSZNoXn+kF15/RdfWk5cx5MsdcHN2wh/Pd0C5AM/shSL3A5+1M91+8i8gtAEcCa8/0hOvP8opNpAWjkW6iSYREREVPW2ql0GrqoFISTfi4w0nbBcKawjUu990e73jjqZJRFRUMMAjIiKiAjOxq6kv3pJd53HmynXbhTq+DBicTU01z24v3AoSERUzDPCIiIiowDSvHIh7agYh3ahh9vocsnhlqgN3PWy6vf51gL1HiIhuGwM8IiIiKlATu9ZU6+X/XMDJ6ATbhe55AXB2B85sAU5ZT2lERET2Y4BHREREBaph+QB0qRsCowZ88HsOWTz/8kDzx023mcUjIrptDPCIiIiowE3oYsri/bI/Ekci420XajcBcPMBIvcBh1cUbgWJyLEY04HwzcCBZaa13Ce7MMAjIiKiAlcnzA+9Goap2++vO267kHcZoPXTptsyL156WiHWkIgcJsA6vBKYVR9Y0Av4YaRpLfdlO+WJAR4REREVivGda8LJAKw7fBH7zsXaLtT6GcCzFHD5OLD/+8KuIhHpHWDJMZYMBeIjrLfHR5q2F1aQZyy6GUQGeERERFQoqgf7oN9d5dTt93LK4nn4AW0nmG7/MR04uaFIfsEiKrL0DLDSUoFfJwGw1Qc3Y9uayQX/t+Bw0c4guuhdASIiIio5xnWqgZV7I/Dn8Uv4+3SMmkYhmxajgM3vAfHngW/639zuVxboPgOo26dQ60ykC2M6DGf+QrmYbTCc8QOqtgecnAv8mFjzQi4BlsEUgIXUA9JTgNREIPWGaUm5nnHbYpu6nWhjm2V5i21pN/KooAbEXwBmVAa8AgE3X8BdFh/TWvrwupu32XHf2TXnADfrOTAHuA8udPi/QQzwiIiIqNBUKu2NB5pVwHc7z+Ld347h+9GtYDAYrAudWAck2WjCWYS+YBHdEQky1rwAl/gINJP7Z+bk/w8cRiNwIwa4dhFIiDKtz27PnrmzogEJkcBHTaCr5HjTcqdcPCyCPh9TwBixO/cAVzKItXsWfLB9BxjgERERUaEae291/LD7PHaEx2DrqSu4u3oZGxkEFOkvWPlCzsWZraYv3j4hQKU2xf81OxK9zv+dZpDSUkx1Ni/m4E3dlrXcjzbdN97mQEZOrqagyNULcPMCXD1Nt7Ots2xTZbOWk8XbtI7cDyx5JO/j9/kEKFMDSEkAkmW5ZlqnyDo+y/2ELLev3cwUpiWZlsTLdr7wjAyiXBdV2sFRMcAjIiKiQlU2wBNDWlbE11tP4721x9CmWumbWTz54pRXBkG+YO38AmjwAOBdGsU5g2N1LthEtfif/zybSAJY9ZwpKLl+yXbwduPqrR3Tq7QpgJVF/PtH3o959KeCCXBkPkw5zxLM2jwHBtP+xoPvLNhOT7UO+FQAmGBqPbBjbt6Pl/PtwBjgERERUaF7qkM1fP/3Wew5G4uNxy6hY+3gW/viJF+CZfEMBMrUNP2ar9YZtwMqAc4uRa8PVDHpA1Sk3en517Sb/cpUPzNZSx+zjD5nWbepdUbZq6fz+IEDpmzTj6PyzrBJwOabEbip26GATzDgE3pzu3cw4OJmHWDKYCJ5BViSzSwI8vmSIFqdf0OWOmT8CNT97Tv/HDq7mkbrlcVqu7t9AZ45GHZQDPCIiIio0AX7eWBY68r47M9/8d66Y+hQK8iUxbP3i5N8Mb0ebepDdG67abHk7AYEVsse+MkiTcscoQ/U7Q5ywSaqBSc1GVj9fO4ZtB9HA/98c3PwkKyBmiwFrUwtILS+KViToE0FbxaBnAQuWfu2OlKAlRv5fEkQbTOD+nbBfv4qtbEvg1hQAW4+YYBHREREunjinmr4ZvsZHLwQj98OXUT3+qH2f8EafwBISwaunDTNmXf5xM31lROmJmyXjpiWrHzL2gj8apqeV74UF1QGTZqFZfYFumbdX8i87eIB+5qonvoDqNEZxbYPYH43kTQPKCIDhEizRsu1vK/m+yqDbOu6syD9t078Zt9xXTL6mLl5W/RX87boi2beJmtvUzPL3fPyft6e7xVcHzA9AyzLOsiPGIV9/Tk5QICbDxjgERERkS4Cvd3wWNsq+GjDSby/7hi61A2B8618wZIvxmENTUvWL/Nx5yyCPosAULJ+CRGmJXyT9eNkND3J+l05nkcfqPGmAFKa1OUWrJn79Zi3yWPyy6IBgHeQqSlqqUrZ1/4VbA8BXxT6AN5KgC3NIZPisgdtah2Rsc5YjKn5V8cmw4Aq7TMCt4xBQiwDNXPw5uR060H1iTX6Z5D0CrAsybH0GMikrgMEuHeIAR4RERHp5vF2VbFg62kcv3gNq/ZHoG/jcnf+BUu+VEuQI0vWLJcMQHH5ZPbAL+ZfUxAWtS/vSideybsPVG6kn48akl2GZ/ezuO1jChpPrLXveWSQDVku7Mq+z+BkylTaCv5k7RuWc/ChZx9ACXB+fSHvJpLbPjUNKCKBW55zp1mQoFiaMMrrt1qXNa1jzwJLHs37eWSAn4IIPhwpg6RXgOUI6jpAgHsHGOARERGRbvw9XTGqXVW8t+44Zv1+Aj0bhMHF2angvmBJ36QKzU1L1qHlZYCL3V8D2z+xrw9U6Wo3AzM1ibJ5Lq2ctuUyufKtDnLxxJ9A3Hkg9gxw9YxpLcGJ+bZkC2WieFnObMn+NNJHUUYszBr8+VXIow+ajT6Acu7MIxJmZjTl9nWLjGbGvsxtFplNtZZsaAKQFA9o6bmfewnozm2z3uYRYCNoCwP8wm7ezzqgiC2hDfTvg1UMMkjFglPRDXAZ4BEREZGuRrStgnlbwhF++Tp++ueCmgi90L9gyRf/oJpArfvsC/AKqg+UvRkc7zKmpWzj7M8hzRZlnrPM4O+0dRAogWF6iilrKcstyegD+F5tU5NHCc7ys+mjvVqMBurdnxHIhZqaSRanDFrGDxxp//6JvZt/Q+N23eBSWKO4UpHHAI+IiIh05ePugjEdquG/q49i9voTqpmmm8st9l0qTqPo3WkGRwaKkWHwZanQIvv+9DRT/zRz0Ge5vnQUSIrNu47Sl9HWgCIqW+mdPZtpc5vl7Yx9Fw8By0bkffw6fYBKrVGsM2hOztAqtcWFQ/FoVKktgzuyGwM8IiIi0t2jrSrji83hOH/1BpbsOodHWlXSpyIOlsEpkD5AMj9gQEXTgixZyPDNwIJeeT9Hj/eBKm0zAreMQO1O5x0UpavrH2AXgz5YVLLp9PMYERER0U2ebs54ukM1dfvjDSeRlJpHP6yCZM7gSP8tSxJYFOYk4+Ymqg0GmtaFEVyYM5jmYNZmgFUOaDYcCKpl6sfnGZA/wZ1lgG0+VtZj6zHISGGef6J8wACPiIiIHMLglhVR1t8DUfFJ+HbHWX0rI0Hc+INIe2Q5dlUao9Zq7r3iPsCFIwRYjhJgExVRDPCIiIjIIbi7OGNspxrq9qcbTyIxJU3fCpn7QAW2VusSk8FxhAArI8DGsFXAgK9M65IQYBPlA/bBIyIiIocxsGl5zNl4CmdjErFg6xk1+ArpwBH6oBXhYeqJ9MQAj4iIiByGq7MTxnWqgYlL92HuppOoFeKDhOQ0BPt6oEWVQDg75dQ3jPIdAyyiIokBHhERETmUfneVw8zfjuJifDIeW7Arc3uYvwem9K6L7vWzNB0kIqJM7INHREREDmXd4SgV3GUVFZeEMd/swZqDMoQ+ERHZwgCPiIiIHEa6UcO0nw/b3GeeFU32SzkiIsqOAR4RERE5jJ3hMYiMS8pxv4R1sl+yfERElB374BEREZHDiE7IObiz9OQ3exDq54H65fxRv5wf6peVtT9C/NxhMHAgFiIquRjgERERkcOQ0TLtJROiy/L7kYuZ28r4uFsFfHK7XIDnbQV90gx0R3gMdl82oHR4DFpXDy7UUTzl+JLRlKCXo4gSkb0Y4BEREZHDkCBGRsuUAVVs9bKT8CbU3wNrxrfH8YsJOHA+Dgcj4nDoQjxORCfg8rVkbDx2SS1mAV6uVgGf3K4Y6AWnXIIlGchF+vqZmos6Y+GJXYU6iqf18U04iigVJr1/YND7+EUZAzwiIiJyGPIFToIYGS1TvspZBnnmr3ay39/TFc0rB6rF7EZKOo5ExePQhTgcvBCvAj8JAmMTU/HXyctqMfP1cEG9spaZPn9UKeOtji/BlRxfy2EUzzmPNCnQIEvv4xPp/QOD3scv6hjgERERkUORL3ASxGT9gheaxxc8TzdnNKlYSi1myWnpOB51TQV7B1XgF4cjUQlISErD9n9j1GLm5eaMOqG+ar+t7KGWEWRKvbrUDc01m6BpGmSgT8lCGDVNrdNlm9HyNrJtS00z4pXlB+/4+FT0M0h6NRHW+wcGvY9fHDDAIyIiIocjX+AkiLnTL9juLs5oUN5fLWap6UacjL6WGfAdjIjH4Yh4JKakY/fZ2FyfzzyK512vr4OLs8EUwGUEZ5bBXEHN4mA+/kcbTqBXwzBULu0NF2cOil7cMkh6NRE2T1OS1w8MneuE3NJn0d4+sPYevzB+4Egvwk1EDZr8xOTgNm7ciI4dO9rct3PnTjRv3lzd3r9/P55++mn8/fffCAoKwtixYzFp0iSr8kuXLsWrr76K06dPo0aNGpgxYwZ69OiRuV9Ox5QpU/DFF18gNjYWd999N+bMmaPKmsXExKjn/vnnn+Hk5IQBAwZg9uzZ8PHxySxjT13yEh8fD39/f8TFxcHT0xOrV69WdXV1db2l5yG6U6mpqbz+SDe8/qgwyJe58MvXsGDrafxv+9kCP55833U2GFQ/QFnLF0f57phm1FSgaS83ZydUDfJGjRBf1Az2Ma1DfFCptKm5aVH+gqvX8XPKIJmPrFcG61aPn5ZuxPXkdCQkp6qM9bXkNCQkWd5Ow7WkjG3Jptvnr97A4ch4OLp+jcuicYUABPl6IMjXHWV83NTax90lX0bR1TvAtyc28PPzK9oZvDZt2iAyMtJqmwRp69evR7NmzTJfcNeuXdG5c2fMnTsXBw4cwGOPPYaAgACMHj1aldm6dSsGDx6M6dOno1evXvj222/Rr18/7NmzB/Xr11dlZs6ciQ8//BALFixAlSpV1HG6deuGw4cPw8PDNLLXww8/rOqzbt069cVjxIgR6hjyfPbWhYiIiByHBA7Vg33Ro0FZuwK8GQMa4K6KpeCUEZyZgjXT81gGbmptuT+jfE5fQreduoLBX2zP8/jVyngjMj5JBYNHoxLUYsnNxQnVgnxQK8Qc9JkCvwqlch9cxlG+4Op1/LwySOK1FYfU+ZT3XrNIENy8fbO03Lbcbi5lTq9k3SbHz62Jrpi0bL/KOidK8JaUmhmsmYK0mwHcrfxQUNQs3xuhlqw8XJ1UoBfkI0Gfu+l2xpJ5P2Pt4epcbJuIFokMXlYSVJUrV05lxSQAE5Jle/nllxEVFQU3Nze1bfLkyVi+fDmOHj2q7g8aNAjXr1/HqlWrMp+rVatWaNy4sQrE5FSULVsWEydOxH/+8x+1XyLkkJAQfP3113jooYdw5MgR1K1bV2XmzMHlmjVr1C/L58+fV4+3py72YAaPHAUzKKQnXn9UmOQLdtsZG/IcxfOvF+4tkGzSrRxfbl+IvaEGkjl+8RpOyDo6QTU/TUo12nx++QJcPdgHNYN9M7N9EqzIVBLmwK+4ZLCk/2X8jTTEJ6Ui/kYq4pPSMtamIMh827KMTLsREWvfXIxFhbuLkxpUSLJbvh6uGWsX+Hi4wC/jvtyWbZGxN/DxH6fyfM7PH22KZhYDHIlbCSlyKrnrdIya4zIvXeuamojKqLmXEkzL9VsMaH09XEyBoDkI9HFHaR83fLk5HHE3Um0+pqA//yUqg5fVypUrceXKFZU5M9u2bRvat2+fGVAJybxJE8yrV6+iVKlSqsyECROsnkvKSOAlwsPDVVAmmTczOYktW7ZUj5UAT9aSiTMHd0LKS1PNHTt2oH///nbVxZbk5GS1WL6J5i83Li4umbeJCpv5uuP1R3rg9UeF7eX7amHs9/tyHMVT9hvT02BM1/f4ItTXFaG+gWhfPdAqSDwfewMnJeiLluU6jkdfw7+Xr6vAT40wesG6GZ4MMFM9yBvVgrzx+5FLefSBOoQONUrf8hdczaJ/ovRVNPVXzNieMSiNDDLzqh0ZrGORceoLvQRtCeYALaO5oQrkktKQkmY7yM0P7s4GuLg4wZDxrkhC1nw2zMlZ2WeZqLXcnv0xpq03Uk2vKS9tqgWiflk/+JqDM1ln3PbJsk2yufaS92fZ7vO4GJ+cyw8M7up6y/7+33nAI9dVqJ97nsf/cFDDbMdPTEnD5WspapGAT4I/dVttS8ala8m4knFfrg2V9UxKU5+LW+0Du+1kNFpWsQ5wC4O9/w8WyQDvq6++UgFT+fLlM7dJYCZNKi1J5s28T4IqWZu3WZaR7eZylo/LqUxwcLDVfgm+AgMDrcrkVRdbpOnotGnTsm1fu3YtvLy81G1pFkqkF15/pCdef1SYRtQ04MfTTohNufkl0t9Nw/2VjUg/sxurzxSN41eUxRvoVAVIrwxcSQIiEw2IugFEJRoQecOA6Bvy5Tgd+y/EqyXvL7jJaP7mWjgbTM0KJYyytbbeln/ZDgmAPlifd5ZJSCNKD2fA0wXwzFxr1vddNHVbysUkA8vP2G66Z2lUrTTU8M//RnAn4gz4+HDex2/ifgk10qIBiQUz4pPkjOXKHdahR6gB8+LNQaHl+2ZqTHpfSCJ+W/PrHR6l4I9fKmOp4WpxJ+N6vJEOJKQCCSlAfKoB8eq2AeEJwKmEvAPitZt34MqRwm8EmZiY6PgBnjRblKxWbqRJZO3atTPvSzPI3377DUuWLEFx8+KLL1plGCWDV6FCBdWfT5poypebLl26sIkS6fKLEa8/0guvP9KDDL82yahh+6lL2LBtN+5t3RStqgUVWrMs8/F3nbmK6IRkBPu6o1mlUgVyfBlV9MyVRJXt++VAFH47HJ3nYxJS9R1NsEXlANQr66+a2fllNDWUta+nZK5c4edp2u7t5mJXn0PLDNb29/7MM4P0zKD2BdZEd5mOxzdfe00OXcSbq48iKj7Zqg/ky/fVRrd61omQ4nT8HeExeGTerjzLdW3XUpcMnrl1n0MHeNLXbfjw4bmWqVq1qtX9+fPno3Tp0ujTp4/V9tDQUFy8eNFqm/m+7MutjOV+87awsJttu+W+9NMzl4mOtv7Dl5aWpkbWzOs4lsewxd3dXS1ZyRca85cay9tEhY3XH+mJ1x8VNrna7q4RjLgTmloX9vUnR2tbM6Tgj+MK1CnnjjrlSiHIz8uuAO+NfvXRqLx/5iAzprWpqaEaUCZjUBnL/RKPmAeYMY8aatp+877MS2jPIDPPdamN1tVKoyDO+dQ+9VQfwJyayE7pXQ8e7je74RSn45v1alwe9zUsp9soqnodv3X1YBVI5tUHtrDmJMzK3r9BugZ4Mn2ALPaSNtoS4A0dOjTbC2zdurUa2ER+6TXvk198a9WqldkkUsrIyJvjx4/PfJyUke1CmlVKACZlzAGdRMrSt27MmDGZzyHTJ+zevRtNmzZV2zZs2ACj0aj66tlbFyIiIiJHI1+i7fmCO6RFxQL5gmvv8aVcQZEBXGQgl6yjeIYW0iiieh/fTN7fggiiHfn4zk4GdY5zD7DrOvx8eEVqZkwJpGQglMcffzzbviFDhqhBTUaOHIlDhw5h8eLFam46yyaP48aNUyNevvfee2o0y6lTp2LXrl145pln1H75RUmCvzfffFMN5CLTG0gwKSNjynQKok6dOujevTtGjRql5uDbsmWLerwMwCLl7K0LERERkaMxf8EVOQ2hUZBfcPU+vpkEUTJS4nejWmH2Q43VWu4XVnBlPv43jzXD0Brpal2Yxy/JumcE2BJQW5L7RWGKhCI3yIoMriJz4ln2ybMc7VIGI5HJxSWzVqZMGbz22mtW887JY2WuuldeeQUvvfSSmrxcRtA0z4EnZDJymUpBHieZurZt26qg0DwHnli0aJEK6jp16pQ50bnMnXcrdSEiIiJyRHpnkPQ+viNlsKSflwzmIWtHzxoVJ93rh6FL3VDdmqiWyHnwSgrOg0eOgvOQkZ54/ZGeSvL1JwN+6PkFV+/jO4KSfP1RCZsHj4iIiIgKliNksPQ8PlFRVaT64BEREREREVHOGOAREREREREVEwzwiIiIiIiIigkGeERERERERMUEAzwiIiIiIqJiggEeERERERFRMcEAj4iIiIiIqJhggEdERERERFRMMMAjIiIiIiIqJhjgERERERERFRMueleAcqZpmlrHx8cjNTUViYmJ6rarq6veVaMShtcf6YnXH+mJ1x/pidcfWZLrwDJGyAkDPAeWkJCg1hUqVNC7KkRERERE5CAxgr+/f477DVpeISDpxmg0IiIiAr6+vuqNlEDv3Llz8PPz07tqVAJ/MeL1R3rh9Ud64vVHeuL1R5YkbJOYoGzZsnByyrmnHTN4DkzeuPLly6vbBoNBreXDzQ846YXXH+mJ1x/pidcf6YnXH5nllrkz4yArRERERERExQQDPCIiIiIiomKCAV4R4e7ujilTpqg1UWHj9Ud64vVHeuL1R3ri9Ue3g4OsEBERERERFRPM4BERERERERUTDPCIiIiIiIiKCQZ4RERERERExQQDPCIiIiIiomKCAV4R8Mknn6By5crw8PBAy5YtsXPnTr2rRCXE1KlTYTAYrJbatWvrXS0qpv7880/07t0bZcuWVdfa8uXLrfbLmGCvvfYawsLC4Onpic6dO+PEiRO61ZdK1vU3fPjwbH8Pu3fvrlt9qfiYPn06mjdvDl9fXwQHB6Nfv344duyYVZmkpCQ8/fTTKF26NHx8fDBgwABcvHhRtzqTY2OA5+AWL16MCRMmqCFy9+zZg0aNGqFbt26Ijo7Wu2pUQtSrVw+RkZGZy19//aV3laiYun79uvobJz9q2TJz5kx8+OGHmDt3Lnbs2AFvb2/191C++BAV9PUnJKCz/Hv43XffFWodqXjatGmTCt62b9+OdevWITU1FV27dlXXpNlzzz2Hn3/+GUuXLlXlIyIicP/99+tab3JcnCbBwUnGTn7V+fjjj9V9o9GIChUqYOzYsZg8ebLe1aMSkMGTX7H37t2rd1WohJHsyE8//aR+yRbyX5VkViZOnIj//Oc/altcXBxCQkLw9ddf46GHHtK5xlScrz9zBi82NjZbZo8ov126dEll8iSQa9++vfpbFxQUhG+//RYDBw5UZY4ePYo6depg27ZtaNWqld5VJgfDDJ4DS0lJwe7du1UzJDMnJyd1Xz7QRIVBmsDJF+uqVavi4YcfxtmzZ/WuEpVA4eHhiIqKsvp76O/vr34E499DKiwbN25UX7xr1aqFMWPG4MqVK3pXiYohCehEYGCgWst3QcnqWf79k+4SFStW5N8/sokBngO7fPky0tPT1S/UluS+fNEhKmjy5VmyI2vWrMGcOXPUl+x27dohISFB76pRCWP+m8e/h6QXaZ65cOFCrF+/HjNmzFDZlfvuu0/9P02UX6Sl1vjx43H33Xejfv36apv8jXNzc0NAQIBVWf79o5y45LiHiEo8+fJi1rBhQxXwVapUCUuWLMHIkSN1rRsRUWGybAbcoEED9TexWrVqKqvXqVMnXetGxYf0xTt48CD7u9MdYQbPgZUpUwbOzs7ZRkmS+6GhobrVi0ou+fWwZs2aOHnypN5VoRLG/DePfw/JUUizdfl/mn8PKb8888wzWLVqFf744w+UL18+c7v8jZNuO9IH1BL//lFOGOA5MEnHN23aVDUHsUzdy/3WrVvrWjcqma5du4ZTp06pYeqJClOVKlXUFxnLv4fx8fFqNE3+PSQ9nD9/XvXB499DulMyiJQEdzKwz4YNG9TfO0vyXdDV1dXq759MoyB94vn3j2xhE00HJ1MkDBs2DM2aNUOLFi0wa9YsNWzuiBEj9K4alQAyWqHMCyXNMmVIZpmuQ7LKgwcP1rtqVEx/QLDMhkifTxnBVQYakMEEpF/Km2++iRo1aqgvQK+++qoaAMhypEOigrj+ZJk2bZqae0x+aJAfuiZNmoTq1aurqTqI7rRZpoyQuWLFCjUXnrlfnQwkJXN+ylq6Rch3QrkW/fz81GjqEtxxBE2ySaZJIMf20UcfaRUrVtTc3Ny0Fi1aaNu3b9e7SlRCDBo0SAsLC1PXXrly5dT9kydP6l0tKqb++OMPmbYn2zJs2DC132g0aq+++qoWEhKiubu7a506ddKOHTumd7WpBFx/iYmJWteuXbWgoCDN1dVVq1SpkjZq1CgtKipK72pTMWDrupNl/vz5mWVu3LihPfXUU1qpUqU0Ly8vrX///lpkZKSu9SbHxXnwiIiIiIiIign2wSMiIiIiIiomGOAREREREREVEwzwiIiIiIiIigkGeERERERERMUEAzwiIiIiIqJiggEeERERERFRMcEAj4iIiIiIqJhggEdERERERFRMMMAjIiLKwenTp2EwGLB37144iqNHj6JVq1bw8PBA48aN7+i55LUtX7483+pGRET6Y4BHREQOa/jw4SoIefvtt622S1Ai20uiKVOmwNvbG8eOHcP69etzLBcVFYWxY8eiatWqcHd3R4UKFdC7d+9cH3MnNm7cqN6T2NjYAnl+IiKyDwM8IiJyaJKpmjFjBq5evYriIiUl5bYfe+rUKbRt2xaVKlVC6dKlc8w8Nm3aFBs2bMA777yDAwcOYM2aNejYsSOefvppODJN05CWlqZ3NYiIiiwGeERE5NA6d+6M0NBQTJ8+PccyU6dOzdZccdasWahcubJVNrBfv37473//i5CQEAQEBOD1119XwcTzzz+PwMBAlC9fHvPnz7fZLLJNmzYq2Kxfvz42bdpktf/gwYO477774OPjo5770UcfxeXLlzP3d+jQAc888wzGjx+PMmXKoFu3bjZfh9FoVHWSekjWTV6TBGZmkiHbvXu3KiO35XXb8tRTT6n9O3fuxIABA1CzZk3Uq1cPEyZMwPbt2+3OwEnTVNkmAaM4c+aMygKWKlVKZRHlOVevXq32S/AoZJ88Rs63+TXJe/f/9u4mpKo1CuP4e02DBjargY4iJRVKFAkiKAgUwRAKDKMIFMGaKFJYBg6kRmGCX5mEQjoIQQ0yEUUQIglREoMUVBIkiowaiCki0eVZsL37HI9fZfdeT/8fCB7POfvjbdLDWuvdhw4dcvv27XPJycmuvb19zXl7enoslOq+X7586cbGxuyY0dHRbv/+/fbeyMhIyGsHAPyDgAcA+F/bs2ePhbLa2lr3/v37XzqWKlofPnxwL168cFVVVdbuePbsWQslQ0ND7urVq66wsHDNeRQAr1+/7kZHR92JEycs5Hz58sXeUyA6c+aMS0lJsQCiQPbp0yd34cKFgGM8fvzY7d271w0ODrqHDx+GvL7q6mp3//59V1lZ6d68eWNBMDs7201NTdn7Hz9+tFCla9HvN27cWHOMr1+/2jWoUqcQFkzB9mfpmMvLy7Z+qgqqsqpQq/bPjo4O+4xaR3VtuhdRuGtpabF7fvv2rSspKXGXL19eE5Jv3bplrbgTExPu2LFj7tKlSxZ0h4eHLdTq/aioqJ++dgD4U0T+1xcAAMBmzp07Z9UsBbKmpqafPo6qdDU1NS4iIsIdOXLE3bt3zy0uLrrbt2/b+2VlZRYyVEHKzc1d/Z6qb6qESUNDgwUoXUdpaamrq6uzcKcQ6mlubrbQMzk5adUziY+Pt/NtRMHu5s2bq+dWgBoYGLBqZH19vVUyIyMjLVTp91Cmp6etzTEhIcHttNnZWVuHo0eP2mvN9/nXVg4ePLgaIhUGtS79/f0WjL3vaH0bGxvd6dOnV7+vqmR6enrAuRSsvfvQ+gEANkfAAwDsCgo7qpSFqlptlapfCncetVOq5dJfLdRc29zcXMD3vHAiClhpaWlWaRK1EiqEKXSFmpfzAp5aDDcyPz9v1cWTJ08G/F2vdY6tUrj7XYqKity1a9dcX1+ftc4q7Knath6FTQVof3DzZhAViv20pn5qJy0oKHCtra12rpycHHf48OEdviMACD+0aAIAdoVTp05Zy6KqbMEU2oKDzcrKyprPBbf4afYr1N80N7ZVCwsL1rKpeTX/j9oqdc2eUO2Sv4MqXboHzQ1uhxd8/esYvIYKXO/evbMZQ7VoKpSpdXajtZHu7u6AtRkfHw+Ywwu1PpovVEtnVlaWtdYmJSW5p0+fbuueAOBPRMADAOwaap/s6upyr169Cvj7gQMH7LEA/nCyk8+u829Mok1ZNBOWmJhor1NTUy2IaEOXuLi4gJ/thDptJBITE2Mzen56rXCzVWqVVBBWS+e3b9/WvL/eYwy0hqL5uY3WUK2nmlXs7Oy0WcBHjx7Z3zVfKN+/f1/9rK5bm6ao3TJ4bXSczaj6qZk9VQzPnz8fcgMcAEAgAh4AYNfQ7Jc239AcnZ92qfz8+bPNuKktUuFGuzLuFB1P1SNVxbTRiB7ZkJ+fb+/ptTY2uXjxom0IovP39va6vLy8gLCzFZo5UytqW1ubbVaijUUUsoqLi7d9vTr38ePHbfMTVRPVUqp187eb+nmhS5UzfV5VN2344qddQHVvMzMz7vXr19aa6gVdPbZBlcPnz5/bv4Wqd9oBUy21CmnaZEZro++p6qfX61laWrK5R+2wqZ07FXK1tt65AADrI+ABAHYVbcYR3EKp//g/ePDAgo224dfjAX5lVi9U5VA/OrY2CHn27Jk97kC8qpsCVUZGhoVQBSFtNOKf99vqjJtmz1QZ03G0mYvOtd0NRrSRiYKUHjOgY2nOUHNwesi5NokJRa2qT548sRCruToFzbt37wZ8RveoQKv1zszMtAqb1l1iY2NdRUWFhVLNNiqgyZ07d1x5ebntpul9T+FRj01Yj2YhtUvplStX7BzakVSPodDxAQAb++vH75zGBgAAAAD8a6jgAQAAAECYIOABAAAAQJgg4AEAAABAmCDgAQAAAECYIOABAAAAQJgg4AEAAABAmCDgAQAAAECYIOABAAAAQJgg4AEAAABAmCDgAQAAAECYIOABAAAAgAsPfwNPCHh0WD9FnQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1000x500 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Optimal number of clusters: 17\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 0: Best model is Ridge with CV MAE -0.24\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 1: Best model is LinearRegression with CV MAE -1.51\n",
-      "Cluster 2 has too few weighted samples after thresholding.\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 3: Best model is GradientBoostingRegressor with CV MAE -0.61\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 4: Best model is GradientBoostingRegressor with CV MAE -0.48\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 5: Best model is GradientBoostingRegressor with CV MAE -1.57\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 6: Best model is Ridge with CV MAE -0.27\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 7: Best model is GradientBoostingRegressor with CV MAE -0.95\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 8: Best model is GradientBoostingRegressor with CV MAE -0.70\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
-      "1 fits failed out of a total of 10.\n",
-      "The score on these train-test partitions for these parameters will be set to nan.\n",
-      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
-      "\n",
-      "Below are more details about the failures:\n",
-      "--------------------------------------------------------------------------------\n",
-      "1 fits failed with the following error:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
-      "    estimator.fit(X_train, y_train, **fit_params)\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\ensemble\\_gb.py\", line 734, in fit\n",
-      "    self.init_.fit(\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\dummy.py\", line 578, in fit\n",
-      "    self.constant_ = np.average(y, axis=0, weights=sample_weight)\n",
-      "                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
-      "    raise ZeroDivisionError(\n",
-      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
-      "\n",
-      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n",
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
-      "1 fits failed out of a total of 10.\n",
-      "The score on these train-test partitions for these parameters will be set to nan.\n",
-      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
-      "\n",
-      "Below are more details about the failures:\n",
-      "--------------------------------------------------------------------------------\n",
-      "1 fits failed with the following error:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
-      "    estimator.fit(X_train, y_train, **fit_params)\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 622, in fit\n",
-      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
-      "                                        ^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 184, in _preprocess_data\n",
-      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
-      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\utils\\_array_api.py\", line 716, in _average\n",
-      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
-      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
-      "    raise ZeroDivisionError(\n",
-      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
-      "\n",
-      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "No valid model found for cluster 9.\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
-      "5 fits failed out of a total of 50.\n",
-      "The score on these train-test partitions for these parameters will be set to nan.\n",
-      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
-      "\n",
-      "Below are more details about the failures:\n",
-      "--------------------------------------------------------------------------------\n",
-      "5 fits failed with the following error:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
-      "    estimator.fit(X_train, y_train, **fit_params)\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_ridge.py\", line 1249, in fit\n",
-      "    return super().fit(X, y, sample_weight=sample_weight)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_ridge.py\", line 956, in fit\n",
-      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
-      "                                        ^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 184, in _preprocess_data\n",
-      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
-      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\utils\\_array_api.py\", line 716, in _average\n",
-      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
-      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
-      "    raise ZeroDivisionError(\n",
-      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
-      "\n",
-      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan nan nan nan nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 10: Best model is RandomForestRegressor with CV MAE -0.61\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 11: Best model is RandomForestRegressor with CV MAE -0.45\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 12: Best model is GradientBoostingRegressor with CV MAE -1.95\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 13: Best model is RandomForestRegressor with CV MAE -0.42\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 14: Best model is Ridge with CV MAE -0.30\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 15: Best model is GradientBoostingRegressor with CV MAE -1.78\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 16: Best model is Ridge with CV MAE -0.25\n",
-      "FeatureStacker - Transformer 'gmm' output shape: (860, 18)\n",
-      "FeatureStacker - Combined features shape: (860, 28)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n",
-      "FeatureStacker - Transformer 'gmm' output shape: (3437, 18)\n",
-      "FeatureStacker - Combined features shape: (3437, 28)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3wAAAHWCAYAAAAsDIuDAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAn8xJREFUeJzs3Qd4U1UbB/B/0r1LoaVsyt6g7CnIXgqigqgMERUFRfhEcCE4EFRERUURFRQVEEVAZAjIkCUge8gG6WJ1UTqT73lPmpK0aZtCRpv+f89zucm9J8lJchry5j1Do9fr9SAiIiIiIiKXo3V2BYiIiIiIiMg+GPARERERERG5KAZ8RERERERELooBHxERERERkYtiwEdEREREROSiGPARERERERG5KAZ8RERERERELooBHxERERERkYtiwEdEREREROSiGPAREbmYqlWrYtiwYc6uBjnBN998A41Gg7Nnz6Kk6Nixo9pc5bFL4ntIRPbFgI+ISpRPP/1UfZlq2bJlnmXk/OjRo3MdT0hIwJQpU9C4cWP4+/vDx8cHDRo0wIsvvojIyEgUN/I8TTc/Pz/Uq1cPb775JpKTk83KSgApz9mSX375BT179kSZMmXg6emJ8uXL48EHH8SGDRvyfXx5jNdffx1//vmnTZ+XfFE2fV4eHh6qbm3atMFLL72E8+fP3/J926vOrkKv1+Pbb79Fhw4dEBwcDF9fXzRs2BBTp07F9evXb/l+jxw5ol734hwEZWZm4uuvv1YBYkhICLy8vNSPM8OHD8fu3bsdVo9Vq1ap15KISg53Z1eAiMiRFi5cqL5k7dq1CydPnkSNGjWsut3p06fRpUsXFSw88MADeOKJJ1Rwc+DAAcybN08FPf/++y+Km65du2LIkCHqclJSErZs2YJXX30V+/fvx5IlSwr8cv/YY4+pjMQdd9yBcePGITw8HFFRUer16Ny5M/766y8VaOUVPEkALeyRoXnooYfQq1cv6HQ6XLt2DX///TdmzZqFDz/8UL1ngwYNKvR92rvOt+vRRx9Vz0uCCWcENIMHD8bixYvRvn17FVRIwCdtSl4zaU9//PEHypYte0sBn9yHvOby92tq7dq1KOpu3LiB++67D6tXr1bBsPzwIEGfBLDyes2fP199tlSsWNEhAd8nn3zCoI+oBGHAR0QlxpkzZ7Bt2zb8/PPPePLJJ1XwN3ny5AJvl5GRob6sxcTEqMxOu3btzM6/9dZbmD59OoqjWrVq4ZFHHsm+/tRTTyEtLU29RikpKfD29s7ztu+//74K9saOHYuZM2eqbJrRyy+/rDI97u7O+2/mzjvvNHtu4ty5c+jWrRuGDh2KunXrqmxtUSDZL8mw3i43Nze1OcOMGTNU8PK///0P7777bvZx+XFEMr79+vVTmeLff//dpo8rP7wUdS+88IIK9j744AP192JKPoPkeHEmP/7I54X0eiCiIkhPRFRCvPHGG/pSpUrpU1NT9aNGjdLXrFnTYjn5aHzmmWeyr//444/q2FtvvXXLj3327Fn1mLVq1dJ7e3vrQ0JC9Pfff7/+zJkzZuW+/vpr9Vhbt27VP//88/oyZcrofX199f369dPHxsaaldXpdOo5VahQQe/j46Pv2LGj/tChQ/oqVarohw4dWmCdcj5Po9GjR+vd3Nz06enp2cfk/vz8/LKvJycnq+dQp04dfUZGRqFfD3ne8vg5t8mTJ2eXWb9+vb5du3bq+QcFBenvuece/ZEjR6y+73fffdfi+W3btqnzgwcPNjt+7do1/XPPPaevWLGi3tPTU1+9enX9O++8o8/MzLS6zkePHtUPGDBAtTMvLy9906ZN9b/++qvF9/jPP/9UbSI0NFQfHByszt111136+vXr6/fv36/v0KGDel+lHkuWLFHn5TYtWrRQbUja0rp16yzet2m7kvbQu3dv/ZYtW/TNmzdX9YqIiNDPnz8/12tT0GuQF2kP8pylTqbtxtTw4cNV3bZv356rbmvWrNE3btxY1a1u3br6pUuX5npOObeNGzdmv2ayGclxOb9o0SL966+/ri9fvrze399fvS9xcXH6lJQU9RzldZc2PWzYMHXM1FdffaXv1KmTKiOvg9Tp008/zfWccj62JRcuXNC7u7vru3btmm+5/N7DnO3M9PUz/VtPS0tTz7lGjRrqtZS/0bZt2+rXrl2rzktZS6+lkbzPH3zwgb5evXrq9mFhYfonnnhCf/Xq1VyPK+/b6tWrVRuXsnI7IY8ljyl/s/L6SpuYNGmSVc+diOyDGT4iKjEkoyeZOskISHe/zz77THXza968eb63W758eXZ3uVsljyPZReluJ922pCuXPL50UZPuatL1zdSYMWNQqlQp9eu/lJWuiDKucNGiRdllXnvtNTXeTrotyrZ3716VvZIMnbXkV/nLly9nZ5mkC6Z0L5Ouefll57Zu3YqrV6+qbMWtZJRCQ0PV8x81ahT69++v3hfRqFEjtZeufzIusFq1aqrrmXSJ+/jjj9G2bVv1PHN26yuM1q1bo3r16li3bp1ZV8277roLFy9eVNnfypUrq/dr0qRJqouqvP4F1fnw4cOqfhUqVMDEiRNVxk4yXpLZWrp0qbqNqaefflrdp7yPpuPbpPtpnz59VFuR7sPymHJZ2q+83pKFlfdHsmj3338/Lly4gICAgHyfs3RflrIjRoxQ2c2vvvpKZduaNm2K+vXrW/0a5NcepN7PPfdcnu1Gug7LGLaVK1eiVatW2cdPnDiBgQMHqucldZMy8rwlIyZdjqUL5LPPPouPPvpIdYWUzKww7vMybdo0lXGS90Kev7QfGc+p1WpVXaVd7dixQ2WpIyIi1PtgJK+5vC733HOPej4rVqxQ75d0D37mmWdQGJLRlF4Ct/P5YS15TvK8H3/8cbRo0UKNO5bxgfI3I6+lvK8y3ljavmTgc5Lz8nrIuEJ5zaVXxOzZs/HPP/+ozwZ5/YyOHz+uPkflNiNHjkTt2rXV34C0XfmbkHGb0rVYXnu5LRE5kZ0CSSKiImX37t3ql2xjRkSyY5LFkF/6C8p83XHHHerX6tshGZCcJNMhj7VgwYJcv+536dJF1dFIsn2SdZMMhZBsn2Qe5Fd203IvvfSSur21GT5Lm2QTc2Y8cmb4PvzwQ1X2l19+0d+qS5cu5Zm5aNKkicouXLlyJfuYZL20Wq1+yJAht5XhE/fee68qEx8fr65LplSe37///mtWbuLEiep1P3/+fIF17ty5s75hw4Zmr528N23atDHLJhvfY8le5syOSrZIzn3//ffZx44dO6aOyXPfsWNH9nHJislxub+CMnxybPPmzdnHpP1IVmb8+PHZx6x9DSyZNWtWge1BskRS5r777stVN9OMnrwn5cqVU393RpLhNM3q5XzNLGX4GjRooDJeRg899JBeo9Hoe/bsaXb71q1bq3oU9PfavXt3fbVq1fJ9bEvkb1fq888//+jtneGTLKl8JuRHPtssff2TDLAcX7hwodlxyeLlPG583+ScKcnyyXH5OyGiooOzdBJRiSDZEZksolOnTuq6jDeTrMKPP/6oJpvIj/xKXlAGpSCmY1vS09Nx5coVNWGMzGQov77nJOOeTMfEySQYUk8Zg2bMgEkmTzKBpuVyjg8qyL333qt+7Zft119/VdkcyaxIBsnwPTPv10Tc7utiiWST9u3bpzJQMrGFkWQNJEshk07cLuOMo4mJiWovE4rIayxZVcl4GjeZqEde982bN+d7f5LtlFlJZaya3Kfx9vI+d+/eXWWxJHNmSrIilrKjUjfTCWUkcyLtRDJaprPLGi/LhEIFkdlX5fkZSWZR7tf0trfzGhhfx/zag/Gcse0YyayuptnPwMBAlQ2UrFJ0dDRuldyHaUZKXi/jREOm5LhkSSULZ+nvNT4+Xr0Okv2U10uuF4Y9/1ZyknYiWTZpb4Ul739QUJD6GzN9/yULLG1y48aNZuUlKyptO+fjC/kskWwoERUN7NJJRC5PvqxKYCfBnnRRMv2iJxOPrF+/XnWFzIt8AbXmS3V+pEuidLWS7mryxd80mLL0BVK605mSL+FCuqIJY+BXs2ZNs3LyRd5Y1hrSvVS+0BtJF7bSpUuriTek613fvn3zfE1Mv+jbkvG5SUCSkwQ9a9asue1JTmRGUtMv4fIFWWZcldfPktjY2HzvT7qtyXsqM5zKltd9SHdP0y/Meb0npkG8kC/ilSpVynXMtE3kJ2d7EtJOTG97O6+B8XXMrz3kFRTKDx85n69MJiSkO7PM/Horcj5n4+tl6XWU4ET+DqXtC+mCKN2pt2/fnmuJEilnvC9r2PNvJSfpRik/4sjrJ0vG9OjRQ3UlNXY7zo+8//LcwsLCrHr/LbVf+RHtyy+/VF1KpSutzNQrXZ+lO7F0pSUi52DAR0QuTzIvkjWSoE82S9m//AK+OnXqqGyDZAFyflm0lmTiJNiTDJyMIZMvjPIlVzI5ln4Jz2tcXH5ZN1uRL2lCMjp5BXzymoiDBw+qMWrFzaFDh9QXW+OXcXkPJLMxYcIEi+WNAUhejO+hBMo5sx5GOZcAyWtGw7ze+9tpE9bc9nZeA+N4OgkY82oPcs6YbXSEW30dT506pf4GpI3L7LPyNy/jfiWzLLNpFjZzZfq30qRJE9hSzt4JMt5R6i8ZNlmuQoIvqfOcOXNUEJYfeV7yNyGfh5bk/CHAUvuVY/K5IdnA3377TfUWkHHHd999t6qPs2aQJSrpGPARkcuTLzDyRUbWnspJlh+QNePkC1FeX8Al6Pnhhx/w3XffqS6Pt+Knn35SE1JIRtF0wpS4uLhbur8qVapk/yovE5sYXbp0yaqMT36MXduMWTBLZGkKyRDJ6yITadzKF7mcWZ2cz00mhcjp2LFjahH128nuSdZGvhSbLtkgk7jI8zXNdhamzsb3QLoQFnQfRZW1r0Fe7UG6833//fdqSQ5L7WHBggVqL5N6WMqOmr62xjUtjZPz5PW624NM0JKamqomazLNEubs0mgtmXxIXg/5/LjViVvkby3nZ4V06ZYfsnKSbtAy6Yps8n5KECiTuRgDvrxeS3n/pau4TDx0O8srSCZPAmbZJGB+++23VZuQ16+4/m0QFXfMrxORS5OulBLUyZdM6VaUc5OZL6WrlXEmTkukXMOGDdV6exIs5CS3ly80+ZEvfDkzMTJrYEHjB/MiX5wkuJD7ML3f/GZSLMwXXpHfGnUyq+iLL76Io0ePqr2lLJN8wZUF7vO7D5Hzi2y5cuVUJkRmCzU9J1k5yRLIjKS3011UxgZKxkbWRjOSsXfy3kp30ZykDsYgOK86yw8KMuPq559/bvFLuATiRZ21r4El8rpIdlOCdEt/C5LtkdkfJftpOkOnkFkj5UcX0zFvEhxKGzB25zQG+Lf6A0lhGIPVnN2uJUN/KyRDKOM1pe3K36ulzJr8EPTff//leR8SjOUcQ/nFF1/k+vyQMaOmZOydZJYlgDXK67WU91/u74033sj1+PLeW/Pay1jWnIxZTdM6EJFjMcNHRC5NAjkJyGRsmiXy5VO6KkkWUMafWCKBlQSNEmTJr+XyxUh+BZfjMkGCZDXkF3gJCPMiAadMgy5dOaVLm3yxll/TjWOGCkvqLF+wZVyg3LcEQdLtVKaAlwyYtSSTIoGZkLFKMk29BFryJbGgbIQETPL85cuq/HovgbF8QZeJNpYtW6aCPZnWPy+SRZDXQrp8SXdByUzIuCPZZMkByYxI91dZSsC4LIO8fpKtsIZMhiPPTb5Qy5dVWRpDlkeQDIe8F6bjmuS5SFuR19K4XIGME5RueJKdlbFk8rrmV2fJIEumS34ckC/4kvWLiYlR77V8md+/fz+KMmtfg7zImC1pg9OnT1fPecCAAer1kiUb5H2Qbp/StnKS11HeY3l/ZGIlWTJCXjfTAEuCBgnE5L4l+JLp/qWbYF7jzW6HdO+WHwQksy9LDkiWbO7cueqxLAXz1pC/Eckqy1IHxh+g5DPj/PnzarIUyVybTtSTk2TnZNkKeU2l2620JQnMc74f0jblhwd576RtypIM8t7JD1tGck5IXSQAl9dVHlsmpZHnK58pMmmSvA7yGSe9CKSOH374ofobL2gMoQSmvXv3Vpl6Gff36aefqnGp8rdBRE7i7GlCiYjsqW/fvmqR6uvXr+dZRhZe9vDw0F++fDnfBcllUerXXntNTb0vi4HL/crU77KocFRUVL71kNvKwtOykLosAi1TvMt0+zmnVTdOyf7333+b3d441bzptPSySPKUKVPUFPa3uvC66SZT78tSFbLQckxMTL7LMpj66aef9N26dVOLPMsC01KfgQMHqkXCCyKLoMvCzbLERM6p5//44w+1gLM8t8DAQPVeFmbhdeMmdZK6tWzZUr1X586ds3i7xMREdV4WrZb6yHslSyq89957ZtP751fnU6dOqWUjwsPDVZuqUKGCvk+fPuo1Kug9Nl14PSfjQtc55Wyr+S28bumxci4pYO1rkBdpk1IHed/kPZO/EXk+0k6TkpLyfF6yxESjRo3UUhF16tTJXmje1Ny5c9WyCNJOrVl4Ped95PW6y/uXcymB5cuXq/pI/atWraqfPn26Wow952trzbIMRrIEx5dffqlv3769WuZF2oc8f/lcMF2ywdJ7KK/riy++qN4P+eyRz4+TJ0/m+lt/88039S1atNAHBwervxt5Ld966y2z907qMWbMGLWovCxTkfOr4BdffKHat9w+ICBAfd5NmDBBHxkZmet9y2n9+vVqyRNZ7F7aj+xlOYycS30QkWNp5B9nBZtERERUcskYPcmOyoywRERkHxzDR0RERERE5KIY8BEREREREbkoBnxEREREREQuimP4iIiIiIiIXBQzfERERERERC6KAR8REREREZGL4sLrRZgsFhwZGYmAgAC1UDAREREREZVMer0eiYmJKF++PLRa6/N2DPiKMAn2KlWq5OxqEBERERFREXHhwgVUrFjR6vIM+IowyewZ39TAwECkp6dj7dq16NatGzw8PJxdPXJBbGNkb2xj5AhsZ2RvbGPkjDaWkJCgkkHGGMFaDPiKMGM3Tgn2jAGfr6+vuswPF7IHtjGyN7YxcgS2M7I3tjFyZhsr7FAvTtpCRERERETkohjwERERERERuSgGfERERERERC6KY/iIiIiIiMhhSwtkZGQgMzPT2VUpctzc3ODu7m7z5dgY8BERERERkd2lpaUhKioKycnJzq5KkSUTtZQrV86mQR8DPiIiIiIisiudToczZ86oLJYsHO7p6WnzTFZxz3ympaXh0qVL6nWqWrWqze6bAR8REREREdmVBDMS9Mk6cpLFotx8fHzUEgznzp1TyzLYCidtISIiIiIih9BqGX5Y8/pIxs9W+IoTERERERG5KHbppILpMoFz24CkGMC/LFClDaB1c3atiIiIiIioAAz4KH9HlkO/+kVoEiKzD+kDy0PTYzpQ7x6nVo2IiIiISp5MnR67zlxFbGIKwgK80SIiBG5aTgCTF3bppPyDvcVDoDcJ9oRcl+NynoiIiIjIUVYfikK76Rvw0NwdeO7HfWov1+W4vW3fvl3NMtq7d2+z42fPnlUzju7bt8/s+NKlS9GxY0cEBQXB398fjRo1wtSpU3H16lU4EgM+skyXiRsrXlADRnM2Erkux+W86u5JRERERGRnEtSN+m4vouJTzI5Hx6eo4/YO+ubNm4cxY8Zg8+bNiIw0T4jk9PLLL2PgwIFo3rw5fv/9dxw6dAjvv/8+9u/fj2+//RaOxC6dZFHm2b/gcyMayCM7LllzOS/l3Kp1cHT1iIiIiKiYUwmE9Eyru3FOXn4YluaulGPylfX15UfQtkYZq7p3+ni4FWodwKSkJCxatAi7d+9GdHQ0vvnmG7z00ksWy+7atQtvv/02Zs2aheeeey77uKyt17VrV8TFxcGRGPCRRadOn0Ita8sx4CMiIiKiQpJgr95ra2xyXxL0RSekoOHra60qf2Rqd/h6Wh8KLV68GHXq1EHt2rXxyCOPYOzYsZg0aZLFoHHhwoWqC+fTTz9t8b6Cg4PhSOzSSRbF6oNtWo6IiIiIqLiaN2+eCvREjx49EB8fj02bNlkse+LECVSrVk0tol4UMMNHFrlVbYvIrSEIx1XVfTMnWQsyBsGqHBERERFRYUm3Ssm0WUNm5Rz29d8FlvtmeHM1a6c1j22t48ePq26av/zyi7ru7u6uxudJECiTsuRky0XTbYEBH1nUonooXvZ4HG+nz4BObxizZyRtWLLXPshAC79oAGHOrCoRERERFUPSHdLabpXta4aiXJC3mqDFUjglX1XDg7xVOVsv0TBv3jxkZGSgfPnyZkGdl5cXZs+enat8rVq1sHXrVqSnpxeJLB+7dJJF8ofSsd9jeDp9LKJh/itJLIIRqQtBEJKg/aYXcGqD0+pJRERERCXju+nkvvXU5ZzhnPG6nLd1sJeRkYEFCxaoGTZl2QXjJrNtSgD4ww8/5LrN4MGD1SQvn376qcX75KQtVGT0aFAOGPwUHljeFpWS9iMMcSrYO+bZALrURHzu8QFapx2BfuED0PT9ELjD0K+ZiIiIiMge300/e+ROTFlxxGxpBsnsSbCnvrva2MqVK3Ht2jWMGDFCradnasCAASr7J2P6TLVs2RITJkzA+PHjcfHiRfTv318FhydPnsScOXPQrl07s9k77Y0BH+VL/nC61gvHrjNNEZuYgrAAb9UveuWBSIxY7IW38Dn64y/g12eAuAtAx4mG/p5ERERERHb7bnrV7LuprTN7RhLQdenSJVewZwz4ZsyYgYSEhFznpk+fjqZNm+KTTz5RQZ5Op0P16tVx//33Y+jQoXAkBnxUIPkDal29tNmxe5tUQLCvJ5761hMXM8pgtPuvwKZ3gPgLgGT73JzfX5mIiIiISsZ3U3tZsWJFnudatGiRPUGLpYlaHnzwQbU5G8fw0S27q1YoFo5shS89H8Gk9BHIlOa0byGw8AEgJfcvHURERERE5FgM+OxM0rhVq1aFt7e36s8rU7q6kjsrl8KSJ1tjo19vjEgbj2R4A6c3Al/3BBIinV09IiIiIqISjQGfHS1atAjjxo3D5MmTsXfvXjRu3Bjdu3dHbGwsXEnNsgH4aVRrnA9phwdTX8FlBAMxh4AvuwAxh51dPSIiIiKiEosBnx3NnDkTI0eOxPDhw1GvXj01YNPX1xdfffUVXE3FUr5Y8lRraCvcgX6pU3BKXwFIuAh81QM4tdHZ1SMiIiIiKpE4aYudpKWlYc+ePZg0aVL2Ma1Wq2b52b59u8XbpKamqs3IOOOPLNpo3IzXi6JALy3mD2uKZ753Q//TkzHX8wO0TD0K/cL7kdl7FvSNBjm7ilSAot7GqPhjGyNHYDsje2MbKzx5rWRiE5mtUjayTF4beZ1k/b+cbexW25tGb2lKGbptkZGRqFChArZt24bWrVtnH5c1OTZt2oSdO3fmus3rr7+OKVOm5Dr+/fffq8xgcZGhA749ocWRq5l4z2MO7nEzBLhHy92Hf8vey2UbiIiIiEoYd3d3hIeHo1KlSvD09HR2dYp00ujChQuIjo7ODvqMkpOT1aLu8fHxCAwMtPo+meErQiQbKGP+TDN88kfRrVs39aZKVL9u3Tp07doVHh5Fe9mD3jo9Xl95FM/9/Qwu6stglPsK1I36GbXDfJDZ4z0u21BEFac2RsUT2xg5AtsZ2RvbWOGlpKSoQMbf319NZkh5v04+Pj5o06YNNm/ebNbGLK33Zw0GfHZSpkwZuLm5ISYmxuy4XJdfNyzx8vJSW07yJpt+mOS8XhRJ7abd1wihAd6YvuEhFfRN9ZgP7f6F0CZFAw98A3hb/8sEOVZxaGNUvLGNkSOwnZG9sY1ZLzMzExqNRg1xko0sk9dGXifJiOZsY7fa1vhq24mkqps2bYr169eb9cmV66ZdPF2ZNNbx3Wpjct96+C6zKx5PG4dUjTdwaj3wdS8gIcrZVSQiIiIicmkM+OxIumfOnTsX8+fPx9GjRzFq1Chcv35dzdpZkgxvG4FZA5tgM5rigZSXEa+VZRsOZi3bcMTZ1SMiIiKi4kSXCZzZAhz8ybCX65QnBnx2NHDgQLz33nt47bXX0KRJE+zbtw+rV69G2bJlUdL0u6MC5g5phn/da6L3jddx0a0ikPCfYdmG05ucXT0iIiIiKg6OLAdmNQDm9wGWjjDs5boct5Nhw4apnmvGrXTp0ujRowcOHDiQXUaOL1u2zOx2GzduRK9evVR5mYBRlmkbP348Ll68CEdiwGdno0ePxrlz59RyCzIzZ8uWLVFSdaoThu9GtESCV3n0uv4aDrnVA1Ljge8GAPsXObt6RERERFSUSVC3eAiQEGl+XIYJyXE7Bn09evRAVFSU2mSIloyx69OnT57lP//8c7Ucm8zdsXTpUhw5ckStyS0zbL7//vtwJE7aQg7VrGoIFj/VGkPm7cKAxAn41HcuOuv+An55Aog/D7T/H5dtICIiIioJZHW49GTrykq3zd8nyI0s3ZHk2IDVLwLVOgJat4Lvz8O3UN85ZWJF48SLsp84cSLat2+PS5cuITQ01Kzsf//9h2effVZtH3zwQfbxqlWrokOHDoiLi4MjMeAjh6sTHoilo9rg0Xk78fiVUXjdpwyG6n8FNrwJxF0Aes8E3Ng0iYiIiFyaBHtvl7fRnekNmb93KllX/KVIwNPvlh4pKSkJ3333HWrUqKG6a+a0ZMkStZ6erL9tSXBwMByJ36rJKSqF+OKnUW0w9KtdmBw5EBe8SuNl7TfQ7J0PJFw0LNsgv7yc2wYkxQD+ZYEqbaz7xYaIiIiIyIZWrlyp1hAUMgljuXLl1DFLS0ycOHFCraEtZYoCBnzkNGX8vfDjE60wcsFufHm6Cy66h2C212y4nfwD+KwtkJEKyJp9RoHlgR7TgXr3OLPaRERERGQL8uO+ZNqsIUmAhfcXXO7hnwxJAmseuxA6deqEzz77TF2+du0aPv30U/Ts2RO7du1ClSpVzMrq9Xo1iUtRwUlbyKkCvD3wzfAW6F6/LH7PuBP333gJae7+QNw582DPQQNyiYiIiMhBJCiSbpXWbNXvNvz4L2P1LN8ZEFjBUM6a+9MULiDz8/NTXThla968Ob788kuV6ZMl2HKqVauWmpxFJngpChjwkdN5e7jhk8F3YmCzStivq4a4dDeLw3GzB+munsj1VoiIiIhKEhnWIz29lJzBWtb1Hu84bPiPRqNR3Tlv3LiR69z9998PT09PzJgxw+JtOWkLlUjublq8M6AhGmceRNjR+AIG5F40pPUj2juwhkRERETkVDKs58EFhtk4TZdmUMN+3rHrsJ/U1FRER0dnd+mcPXu2mrylb9++ucpWqlRJzc4py7MlJCRgyJAhaoZOmb1zwYIFaiygI5dmYMBHRYb8UjK4nhdw1IrCMpELEREREZUsEtTV6e3wif1Wr16dPQlLQEAA6tSpo2bj7Nixo8XyTz/9tOra+d5776F///4qEyhBn6zdN27cODgSAz4qUjL9wuBmw3JERERE5GIkuHNgT69vvvlGbfmRiVpykoXXZXM2juGjImVXZh1E6kOg0+e9PmeUPkSVIyIiIiKi/DHgoyIl9no6pqQPUZdzBn0S7MmESpd1gbiUmHuALBERERERmWPAR0VKWIA31uhaYFT6WEQjxOzcZQQiTe+Ghm5n0eL4u4YIkIiIiIiI8sQxfFSktIgIQbkgb6yNb4F1qc3QQnsMYYhDLIKxS1cH3bS78annhwg//i2wox7Q+mlnV5mIiIiIqMhiho+KFDetBpP71lOX9dBih64eluvaqL0OWqzWtcAsPGIovOYl4OhK51aYiIiIiKxmaXITyv36yOz1tsKAj4qcHg3K4bNH7kR4kLfZ8fBAL4QHeuOjlB743buXYU2+pY8DF/c6ra5EREREVDAPDw+1T05OdnZVijTj6+PubruOmOzSSUU26OtaLxy7zlxFbGKKGtsn3T3/u5aMez/5C6PjHsKK0pdR7/ou4PuBwMj1QHBlZ1ebiIiIiCxwc3NDcHAwYmNj1XVfX1+bZrFcIbOXnJysXh95neT1shUGfFSku3e2rl7a7FiV0n747OGmeHTeTjx45Qn8Wfoaylw/ASx8EBixBvAOclp9iYiIiChv4eHham8M+ig3CfbkdcrIyICtMOCjYkeCwKn3NsBLvxxE3yvPYmPwG/C+dBRYPBR4eAngZugyQERERERFh2T0ypUrh7CwMKSnpzu7OkWy26stM3tGDPioWBrcsjL+jUnEN9uAh68/j8Veb8Dt9Ebgt3FA348MC/YRERERUZEjQY09AhuyjJO2ULH1Su+6aF+zDPakV8GLGAu9RgvsXQD8NcvZVSMiIiIiKhIY8FGx5e6mxezBd6JaqB9+SmqAL/2eMJz443Xg0M/Orh4RERERkdMx4KNiLcjHA/OGNlf7ty53wKZS9xtO/PIUcGGXs6tHRERERORUDPio2Iso44dPH75Tzeo5PKofzpS+C8hMBX4YBFw97ezqERERERE5DQM+cglta5TB633rQQctekcORUJwfSD5imG5huSrzq4eEREREZFTMOAjl/Fo66p4tFUVJOu90ffqaKT7lweunAAWPQpkpDm7ekREREREDseAj1zKa33roW2N0jiXFoTH0iZA5+kPnNsKLB8D6PXOrh4RERERkUMx4COX4uGmxaeDm6pxfVsSwvCW70ToNW7AgR+BTTOcXT0iIiIiIodiwEcuJ8jXA3OHNEOAtzvmRVfDT+HPG078+Tawf5Gzq0dERERE5DAM+Mgl1QjzxyeDDTN3vnDmTuyrPNRw4tdngLN/Obt6REREREQOwYCPXFaHWqF4tXdddfm+E10RW7E7oEsHfhwMXD7h7OoREREREdkdAz5yaUPbVMXglpWh02vR4/wjuBF2B5ASByy8H7h+2dnVIyIiIiKyKwZ85NI0Gg2m3FMfraqF4GqaGx5IeBaZgZWBa2cNmb70FGdXkYiIiIjIbhjwUYmYufOzh5uiSmlfHIrzwv88X4HeOwi4sBNYNgrQ6ZxdRSIiIiIiu2DARyVCKT9PzBvaDAFe7vjlP398ET4Feq07cPhnYOObzq4eEREREZFdMOCjEqNGWAA+HnwHtBpg2rEwbK79quHElveBvd86u3pERERERDbHgI9KlI61w/By73rq8vB9NXG2/tOGEyvHAqc2OrdyREREREQlNeB766230KZNG/j6+iI4ONhimfPnz6N3796qTFhYGF544QVkZGSYlfnzzz9x5513wsvLCzVq1MA333yT634++eQTVK1aFd7e3mjZsiV27dpldj4lJQXPPPMMSpcuDX9/fwwYMAAxMTGFrgs5x2Ntq2Jgs0rQ6YG+h+5CQs1+gC4DWDwEiD3q7OoREREREZW8gC8tLQ0PPPAARo0aZfF8ZmamCrCk3LZt2zB//nwVzL322mvZZc6cOaPKdOrUCfv27cPYsWPx+OOPY82aNdllFi1ahHHjxmHy5MnYu3cvGjdujO7duyM2Nja7zPPPP48VK1ZgyZIl2LRpEyIjI3HfffcVqi7k3Jk73+jXAC0iQpCYmon+/z2M9AotgdQEYOGDQKJ58E5EREREVFwVm4BvypQpKtBq2LChxfNr167FkSNH8N1336FJkybo2bMn3njjDZWtk8BLzJkzBxEREXj//fdRt25djB49Gvfffz8++OCD7PuZOXMmRo4cieHDh6NevXrqNpKl++qrr9T5+Ph4zJs3T5W7++670bRpU3z99dcqsNuxY4fVdSHn8nTXYs4jTVEpxAenrqXjqYzx0IdUB+LPAz8MAlISgTNbgIM/Gfa6TGdXmYiIiIio0NzhIrZv366CwbJly2Yfk8ycZAQPHz6MO+64Q5Xp0qWL2e2kjGT6hARje/bswaRJk7LPa7VadRu5rZDz6enpZvdTp04dVK5cWZVp1aqVVXWxJDU1VW1GCQkJai+PZ9yM1+n2BXhq8PngO/DA3J1Yfy4D7zacihdujIEmci/079WAJuPmGn36gPLI7PY29HX6wJWxjZG9sY2RI7Cdkb2xjZEz2tittjeXCfiio6PNAixhvC7n8isjgdWNGzdw7do11R3TUpljx45l34enp2eucYRSpqDHMa2LJdOmTVOZzJwkYyhZRqN169bl+1pQ4TwcocHcY1p8elCDBmXuRk/8ZBbsKYmRcFs6DH9HjEFUcHO4OrYxsje2MXIEtjOyN7YxcmQbS05OLn4B38SJEzF9+vR8yxw9elRl0EoCySzK+EEjCUQrVaqEbt26ITAwUEX18qZ37doVHh4eTq2rK+kl6/RtPYt31xzDHYkbAE3uMnJIDw2aX/kZGYNeAbRucEVsY2RvbGPkCGxnZG9sY+SMNmbs/VesAr7x48dj2LBh+ZapVq2aVfcVHh6eazZN48yZcs64zzmbplyXYMrHxwdubm5qs1TG9D6k62dcXJxZli9nmYLqYonMHCpbTvImm36Y5LxOt++pjjWAc3+h3NmreZbRQA8kXIRH5N9ARHu4MrYxsje2MXIEtjOyN7YxcmQbu9W25tRJW0JDQ1X2Lr9Nuk9ao3Xr1jh48KDZbJoSFUswJ5OvGMusX7/e7HZSRo4LeSyZhMW0jE6nU9eNZeS8vNimZY4fP66WYTCWsaYuVPRm7ny8yc1us/lK4iyeRERERFQ8FJsxfBJQXb16Ve1lnJ0sqyBkLT1ZC0+6PUow9eijj2LGjBlqrNwrr7yi1sszZs2eeuopzJ49GxMmTMBjjz2GDRs2YPHixfjtt9+yH0e6VA4dOhTNmjVDixYtMGvWLFy/fl3N2imCgoIwYsQIVS4kJEQFcWPGjFFBnkzYIqypCxU92sC8s6+mMv3C4JodOomIiIjI1RSbgE/WsJP17IyMM11u3LgRHTt2VF0xV65cqWbClODLz89PBW5Tp07Nvo0sySDBnSzv8OGHH6JixYr48ssv1QyaRgMHDsSlS5fU40mgJssqrF692mwSFlnGQWbvlAXXZVZNuf2nn36afd6aulDRsyuzDqroQxCOq9BaGMen1wOXEIRTmXVgyOUSERERERVtxSbgk4XLZctPlSpVsGrVqnzLSHD4zz//5FtG1ueTLS/e3t5qTT3ZbqcuVLTEXk/HN+lD8JnHLOj0MAv6JNjTaAAvfRqux5wAaoY5s6pERERERK618DqRvYUFeGONrgVGpY9FNELMzkWjFM7rQhGkuYH220YA8f85rZ5ERERERC6X4SOytxYRISgX5I218S2wLrUZWmiPIQxxiEUwdunqoBQS8bPPG6iSHAks6AcM/x3wD3V2tYmIiIiI8sQMH1EWN60Gk/saZlHVQ4sdunpYrmuj9jpocQVB2NRiLhBUCbhyAviuP3AjztnVJiIiIiLKEwM+IhM9GpTDZ4/cifAgb7PjXu6GP5WZfyfjXO+FgF8oEH0Q+GEQkJbspNoSEREREeWPXTqJLAR9XeuFY9eZq4hNTFFj++qXD8Sj83Zi/3/xGPzzFSy//0eUXnIfcH47sPhRYNAPgLt1a0YSERERETkKM3xEeXTvbF29NO5tUkHtA3088NWw5ogo44eLcTfw8MpkJN3/PeDhC5z8A/h5JKDLdHa1iYiIiIjMMOAjslJpfy8seKwFQgO8cCw6EY9tcEPagPmA1gM4sgxY8Zxh/QYiIiIioiKCAR9RIVQK8cU3w5vD38tddfl8bndpZN73JaDRAv98C6x9hUEfERERERUZDPiICql++SB8MaQpPN20+P1QNF4/WQP6vh8aTm6fDWx5z9lVJCIiIiJSGPAR3YI21ctg5sDG0GiAb3ecw+xrrYHubxtObngT2PmFs6tIRERERMSAj+hW9WlUHpP7GNbte3/dv/jRrS9w14uGk7+/AOxf5NwKEhEREVGJx4CP6DYMaxuBpztWV5df+uUg1oU9BrR8ynBy2Sjg2G/OrSARERERlWgM+Ihu0wvda+OBphWh0wOjf/gHe+q+ADQeDOgzgSXDgNObnF1FIiIiIiqhGPAR3SaNRoNp9zXE3XXCkJqhw2Pz9+JEq7eBOn2AzDTgh4eA/3Y7u5pEREREVAIx4COyAXc3LWYPvgNNKgUj/kY6hnyzF1FdPwGqdQTSrwPfDQBijji7mkRERERUwjDgI7IRX093fDWsOaqF+iEqPgVDF+xH/D3fABWbAylxwLf9gaunnV1NIiIiIipBGPAR2VCInycWPNYCZQO98G9MEh7/8ShSHvwRCKsPJEUDC/oBCZHOriYRERERlRAM+IhsrGIpX8x/rAUCvN3x99lreHbZWWQ8vBQoFQHEnTNk+pKvOruaRERERFQCMOAjsoM64YGYO6QZPN21WHskBq+uvwz9kGVAQHng0jHgu/uAlARnV5OIiIiIXBwDPiI7aVWtND4c2AQaDfDDrvP4cE8aIEGfTwgQ+Y9h9s70G86uJhERERG5MAZ8RHbUs2E5TL23gbo8648TWHjaG3j0Z8AzADi31bBOX2a6s6tJRERERC6KAR+RnT3aqgqevbuGuvzqskNYc60cMHgR4O4N/LsaWDYK0OmcXU0iIiIickEM+Igc4PmutTCoeSXo9MCYH/7BLn1d4MEFgNYdOLgEWPU/QK93djWJiIiIyMUw4CNyAI1Ggzf7NUCXumWRlqHD4/P/xvHANkD/z+UssHsesH6qobAuEzizBTj4k2Ev14mIiIiIboH7rdyIiArP3U2Ljx+6A4/M24k9565h6Fe7sPTp3qjQZyaw8nlg60wg4SJwdov5Wn2B5YEe04F69ziz+kRERERUDDHDR+RAPp5umDe0GWqG+SM6IUUFfXH1HgG6TDEUOLAo98LsCVHA4iHAkeVOqTMRERERFV8M+IgcLNjXUy3MHh7ojZOxSXjsm79xo9nTgKd/HrfIGtu3eiK7dxIRERFRoTDgI3KC8sE+WDCiBQK93bH3fBxmfzMfSEvK5xZ6Q3fPc9scWEsiIiIiKu4Y8BE5Sa2yAZg3rDm83LW4cP6sdTdKirF3tYiIiIjIhTDgI3Ki5lVD1EQulxBs3Q38y9q7SkRERETkQhjwETlZt/rhuOee+xGpD1Hr9FkiS/SleQYDVdo4unpEREREVIwx4CMqAh5sURUzMFxdzhn0SbCn0QCeaXHQrRwHpN9wTiWJiIiIqNhhwEdUBOw6cxXLUptiVPpYRCPE7FwUQrAqswV0eg20e78B5nYGLh13Wl2JiIiIqPjgwutERUBsYorar9G1wLrUZmihPYYwxCEWwdilqwMdtGinPYgvA76Ad+xh4IuOQO/3gSaDnV11IiIiIirCmOEjKgLCAryzL0twt0NXD8t1bdReroutuoY41HcVEHEXkJ4MLBsF/PwkkJrfcg5EREREVJIx4CMqAlpEhKBckDc0+ZQJDfDCHfVqA4/+Atz9CqDRAgd+NGT7og86sLZEREREVFww4CMqAty0GkzuW09dzivoS7yRjnVHogGtG9DhBWDYb0BAeeDKCcO4vr/nGWZ4ISIiIiIqTgHf2bNnMWLECERERMDHxwfVq1fH5MmTkZaWZlbuwIEDaN++Pby9vVGpUiXMmDEj130tWbIEderUUWUaNmyIVatWmZ3X6/V47bXXUK5cOfVYXbp0wYkTJ8zKXL16FQ8//DACAwMRHBys6paUlFTouhCZ6tGgHD575E6EB93s3inKBnqhRpg/UjJ0eOq7vXjn92PIyNQZlmh4aitQszuQmQr8Ng5YMhS4Eee050BERERERUuxCPiOHTsGnU6Hzz//HIcPH8YHH3yAOXPm4KWXXsouk5CQgG7duqFKlSrYs2cP3n33Xbz++uv44osvssts27YNDz30kArQ/vnnH/Tr109thw4dyi4jgdlHH32k7n/nzp3w8/ND9+7dkZJimFRDSLAn9Vi3bh1WrlyJzZs344knnihUXYjyCvq2vng3fhjZCh8OaqL22yZ2xu/Ptcfj7SJUmTmbTmHIV7twOSkV8CsNDF4EdHsL0LoDR34FPu8AXNzj7KdCREREREWBvpiaMWOGPiIiIvv6p59+qi9VqpQ+NTU1+9iLL76or127dvb1Bx98UN+7d2+z+2nZsqX+ySefVJd1Op0+PDxc/+6772afj4uL03t5eel/+OEHdf3IkSPSZ07/999/Z5f5/fff9RqNRn/x4kWr62KN+Ph49ViyF2lpafply5apPZVMK/Zf1Nd99Xd9lRdX6lu9/Yd+77mrN09e2K3Xf9BQr58cqNdPKa3Xb5stjbpQ9882RvbGNkaOwHZG9sY2Rs5oYzljA2sV22UZ4uPjERJyc72y7du3o0OHDvD09Mw+Jpm56dOn49q1ayhVqpQqM27cOLP7kTLLli1Tl8+cOYPo6GjVjdMoKCgILVu2VLcdNGiQ2ks3zmbNmmWXkfJarVZlBPv3729VXSxJTU1Vm2mmUKSnp2dvxutUMnWvG4pqT7bEM9/vw5kryXjw8+14tXcdDGpWEZqyjYARG+D22/PQHlsOrHkJulN/IrPvbMDXfG2/vLCNkb2xjZEjsJ2RvbGNkTPa2K22t2IZ8J08eRIff/wx3nvvvexjEqjJGD9TZcuWzT4nQZbsjcdMy8hxYznT2+VVJiwszOy8u7u7Cj5NyxRUF0umTZuGKVOm5Dq+du1a+Pr6Zl+XrqRUsj1VDVio1+LAVS1eW34UK7cfxgMROni6AfAegKoVS6HBxe/hdnItUme3wu6qo3DVv7bV9882RvbGNkaOwHZG9sY2Ro5sY8nJycUv4Js4caLKeuXn6NGjapIVo4sXL6JHjx544IEHMHLkSLiSSZMmmWUgJcMnE77IeECZIEaiennTu3btCg8PD6fWlZyvv16PL7acxcw/TmDXJS2S3IMw+6HGqFRKfhzoDV3McGh/HgGfq6fQ7uQ70HV4Ebo2zxlm+cwD2xjZG9sYOQLbGdkb2xg5o40Ze/8Vq4Bv/PjxGDZsWL5lqlWrln05MjISnTp1Qps2bXJNgBIeHo6YmBizY8brci6/Mqbnjcdklk7TMk2aNMkuExsba3YfGRkZaubOgh7H9DEs8fLyUltO8iabfpjkvE4l1+jOtXBHlRCM+eEfHIlKRP/PdqrJXjrWDgMq3gE8uVnN3qk5sAhum96G24VtQP8vgADzLHZObGNkb2xj5AhsZ2RvbGPkyDZ2q23NqbN0hoaGquxdfptxHJxk9jp27IimTZvi66+/VmPmTLVu3VrNlmnat1Wi4tq1a2d3oZQy69evN7udlJHjQrphSkBmWkYiaRmbZywj+7i4ODX7ptGGDRvULKIy1s/auhDZStsaZbBiTDs0rhiE+BvpGP7N3/ho/QnodHrAyx/o/zlw76eAhy9w+k9gTjvg1EZnV5uIiIiIHKBYLMtgDPYqV66sxu1dunRJjYUzjpkTgwcPVsGhLLkgSyYsWrQIH374oVkXyeeeew6rV6/G+++/r5Z6kKUSdu/ejdGjR6vzGo0GY8eOxZtvvonly5fj4MGDGDJkCMqXL6+WbxB169ZVXUqlO+muXbvw119/qdvLhC5Sztq6ENlShWAfLH6qNQa3rKzWXp+57l+MXLBbBYDQaIA7Hgae+BMIqwdcjwW+7Q+sfwPIzHB21YmIiIiopAd8kh2TiVok81axYkXV3dK4mc6mKZObyEybkgWU7qKygLrp+njSFfT7779X3UEbN26Mn376Sc3Q2aBBg+wyEyZMwJgxY9TtmjdvrhZUlyBRFlA3Wrhwoco+du7cGb169UK7du3MuphaUxciW/Nyd8Pb/Rtixv2N4Omuxfpjsbhn9lYcjcrq7x1aGxi5AWgq3aj1wJb3gPl9gPiLhvO6TGjObUWFq9vVXq4TERERUfGmkbUZnF0Jsky6k0rwKEtQGCdtWbVqlQoy2V+c8nPoYjye+m4P/rt2A94eWky7ryH631HRpMBSYPlzQFoi4BNiCAIP/AgkRN4sE1ge6DEdqHePU54DuSZ+jpEjsJ2RvbGNkTPaWM7YwKUyfERUOA0qBGHF6HboUCsUKek6PL9oPyb/eghpGbqsAgOAJzcB5ZoAN64CW2eaB3siIQpYPAQ4stwpz4GIiIiIbh8DPiIXVcrPE18Pa45n766hrs/ffg4Pzd2BmIQUQ4HS1YHhvwOefnncQ1byf/VEdu8kIiIiKqYY8BG5MDetBuO61ca8oc0Q4O2OPeeuofdHW7Hj9BVDgYt7gLTr+dyDHki4CJzb5qgqExEREZENMeAjKgE61y2runjWCQ/A5aRUPPzlTny55TT0iTdnus1Xkvm6kkRERERUPDDgIyohqpbxwy9Pt0W/JuWRqdPjzd+O4sNdidbd2D//hdqJiIiIqGhiwEdUgvh4uuGDgU0w5Z76cNdq8NHJUMRqSkMPTd438goAKrd2ZDWJiIiIyEYY8BGVMBqNBkPbVMWiJ1uhTIAPXk19FLI6iy7HAi3ZC7akJgK/T+DELURERETFEAM+ohKqaZUQ/Dq6LTZqWmJU+lhEI8TsfBRK4/uMTtBJ9m/3POCn4UBGqtPqS0RERESF534LtyEiF3H2cjLSMvVYgxZYl9oMLbTHEIY4xCIYu3R1oIMWW3UNMdt7DrRHfgWSrwKDvge8rV/sk4iIiIichxk+ohIsNjFrTT5ABXc7dPWwXNdG7eW6WKVrhe2t5wCe/sDZLcA3vYGkWCfWmoiIiIisxYCPqAQLC/C2qpy2Wkdg2ErAtwwQfQCY1w24esbu9SMiIiKi28OAj6gEaxERgnJB3vnN0YmwAC9VDuXvAEasBYIrA9fOAF91B6IPOrC2RERERFRYDPiISjA3rQaT+9ZTl/MK+tIydDhz+brhSunqwIh1QNkGhsXYv+4FnN3quAoTERERUaEw4CMq4Xo0KIfPHrkT4UHm3TvLBnqhXKA34m6kY+Dn23EkMsFwIiAcGPYbUKUtkJoAfHsfcHSFcypPRERERPliwEdEKujb+uLd+O6xZhhSM1Ptt03sjN+ea48GFQJx5XoaBn2xHf+cv2a4gU8w8MjPQJ0+QGYqsHgIsGe+s58GEREREeXAgI+Isrt3towIQdMyerWX6yF+nvh+ZCs0rVIKCSkZeOTLndh+6orhBh7ewAPzgTuHAHodsOJZYPO7Jiu2ExEREZGzMeAjonwFentgwWMt0KZ6aVxPy8Swr3dh4/GsZRnc3IG+HwHt/2e4vuFN4PcXAZ3OqXUmIiIiIgMGfERUID8vd3w1rDk61wlDaoYOTyzYjd8PRhlOajRA51eBnjMM13d9Dvz8OJCR5tQ6ExEREREDPiKykreHG+Y82hS9G5VDeqYez3y/Fz/v/e9mgZZPAgPmAVoP4NBS4PsHgdREZ1aZiIiIqMRjwEdEVvNw0+KjQXfggaYVodMD45fsx8Kd524WaHg/MHgR4OEHnN4IzO8LXL/szCoTERERlWgM+IioUGQyl+kDGmFYm6pqfpaXfzmEuZtP3yxQozMwdAXgEwJE/mNYoP2aSVBIRERERA7DgI+ICk2btWD70x2rq+tvrTqKWX/8C71xhs6KTYERa4GgSsCVk4agL+awcytNREREVAIx4COiW6LRaDChRx280L22uj7rjxN4e9XRm0FfmZqGoC+0LpAYBXzdEzi33bmVJiIiIiphGPAR0W15plMNle0Tc7ecwSvLDkEnA/xEYHlg+CqgUksgJR74th9w/HfnVpiIiIioBGHAR0S3bXjbCMwY0Eit0LBw53n8b8l+ZGRmrcXnGwI8ugyo1QPISAF+fBj45zsUGbpM4MwW4OBPhr1cJyIiInIR7s6uABG5hgebV4K3pxvGLdqHn/+5iOS0THz00B3wdNcCnr7AwO+AFc8B+xYCvz5jmL2z7XOGdfyc5chyYPWLQELkzWOSlewxHah3j/PqRURERGQjzPARkc3c07g8PnukKTzdtFh9OBpPfLsbKelZGTM3D+DeTwxBnvhjMrD2FUCnc06WTYK9xUPMgz2REGU4LueJiIiIijkGfERkU13rlcW8Yc3g4+GGP49fwtCvdiEpNcNwUrJ5XacC3d4yXN8+G5jfB/iggWG/dIRhP6uBfQMuCSgls4essYZmso6tnsjunURERFTsMeAjIptrXzMUC0a0QICXO3aeuYpHvtyJ+OT0mwXajAb6fw5otMC5v4BEG2fZMjOAG3FA/H9A7DHgv93AqY3A0RXAvh+ANS/lzuyZ0QMJF4Fz227t8YmIiIiKCI7hIyK7aF41BN+PbIVHv9qJfRfiMGjuDnw7ogXK+HsZCjR8wBB4JV/JO8u2ciyQdh1Ivw6kJgFpSTf3ppfVPvHmdZkcxhZWPg9UbgmUrgGEVM/aRwAePrd/35I9lIAyKQbwLwtUaQNo3WxRayIiIqJsDPiIyG4aVgzCoida45F5O3E0KgEPfr4dCx9viXJBPoZgx2KwZ0LOL3vq1iug9QC8/AHPgKy9v2GffgM4b8WagFdOGDYzGiCoIhBSDShtDAKz9qWqGMYqFoSTxRAREZGDMOAjIruqHR6AxU+2xsNzd+D0pet4YM52fP94K1SWzJY1ZOF2CayMwVr2PiD3dU8/83PuWdlES9k1GScoXUctjuPTAH5lDGMNr50BrpwErpwybKnxQPwFw3ZmU46buRmCPmMAqALC6obrEiRKBs84WUzOxzV2Y31wAYM+IiIishkGfERkdxFl/LBkVBsV9J29kqwyfUt7BqKCNTfu9S4Q0d62FZLAS7JpKvDS5Ai+spaJ6D0zd+Cl1xuyjtkB4EngalYgKFvGDeDqacN2cp35bd28gFJVgbhz+UwWozFMFlOnN7t3EhERkU0w4CMih6gQ7KMyfdK989+YJPRb4YZtfuXgcT067yybdHOUsW32IMHcgwugX/0iNCZdK/WB5aHp8Y7lLJsmK/MnW+VW5udkeYnEqKwAMCsglMBPBYVngMxU4PLxAiplMlmMrYNcIiIiKpEY8BGRw4QFeqsxfUO+2oWDF+MxQTcYMzFTBXcak6BPr64DkMDLjpmu1brmeCPlQ1RK248wxCEWwbiQ0hiv6hqiR2HvTKsFgioYtogOuWcNlS6ge74B/ppV8H1Z292ViIiIqABcloGIHKqUnycWjmyJ5lVL4ZeUphiT+TxiEGJWRq7/0/pDu45lW30oCqO+24uLCenYoauH5bo2ah+ZkK6Oy3mbcXM3zO5Zo4t15WXWTiIiIqKSFPDdc889qFy5Mry9vVGuXDk8+uijiIw0X0frwIEDaN++vSpTqVIlzJgxI9f9LFmyBHXq1FFlGjZsiFWrVpmd1+v1eO2119Rj+Pj4oEuXLjhxwnyWvqtXr+Lhhx9GYGAggoODMWLECCQlJRW6LkQlVaC3B+Y/1gJ1wgOwMr0Z2qR8iEFpr+DZtNFq3zblQ9y3sYxtgy4TmTo9pqw4kt+y6+q8lLMp6Z4q3VSN4wQtdmOtYL9urERERFTiFJsunZ06dcJLL72kArGLFy/if//7H+6//35s22ZYGDkhIQHdunVTAdqcOXNw8OBBPPbYYyoge+KJJ1QZKfvQQw9h2rRp6NOnD77//nv069cPe/fuRYMGDVQZCcw++ugjzJ8/HxEREXj11VfRvXt3HDlyRAVvQoK9qKgorFu3Dunp6Rg+fLh6DLk/a+tCVNJ5ubshLjlNXdZBq7JrOf1vyQG1hp8EQvJjjARgEoPp9HqTDbnP5SynM70NcOV6KqLi816rT8I8Ob/rzFW0rl7aQZPFZLFzN1YiIiIqWYpNwPf8889nX65SpQomTpyogjUJuDw8PLBw4UKkpaXhq6++gqenJ+rXr499+/Zh5syZ2UHWhx9+iB49euCFF15Q19944w0VtM2ePVsFZvKlcdasWXjllVdw7733qjILFixA2bJlsWzZMgwaNAhHjx7F6tWr8ffff6NZs2aqzMcff4xevXrhvffeQ/ny5a2qC1FJJ8FUdEJqvmWSUjMwZ9NpOMu7a46hW/1w1CsXiHrlA28uGm+DyWJyrcMnSzo88DWXZCAiIqKSGfDl7FIpQVWbNm1UsCe2b9+ODh06qADLSDJz06dPx7Vr11CqVClVZty4cWb3JWUkmBNnzpxBdHS0yswZBQUFoWXLluq2EvDJXjJ1xmBPSHmtVoudO3eif//+VtXFktTUVLUZSaZQSFBr3IzXiezBkW0sKu66VeXa1yyNmqH+aoJMrUYDN63m5mWNxvJxszIyuaZGXdbKMa0GZy5fxxdbzhb42HvPx6nNKCzAC3XDA1C3XED2vkqIr7rPQqnZE5kRXXFi9zqkXDmHOw+8CTddCjJ8QqF38b9vfo6RI7Cdkb2xjZEz2tittrdiFfC9+OKLKhuXnJyMVq1aYeXKldnnJFCTLpimJDNnPCdBluyNx0zLyHFjOdPb5VUmLCzM7Ly7uztCQkLMyhRUF0ukq+mUKVNyHV+7di18fX2zr0tWksieHNHGTsdLkFRw18XGHrGoqY+52fsx8/Yfu64eCPZ0Q5zqUWopWNPDzx3oWE6HyGQNLl7X4FIKEJuYqrZNJy5nl/TU6lHeF6jgp0dFPz0q+OpRzhfwzOep7b+iwc9ntYhLk0LVMNOjGe5z24o9S2ciuuajKAn4OUaOwHZG9sY2Ro5sYxIDFbuAT7plStYrP9KFUiZZEdIVUyZIOXfunAqMhgwZooI++fXeFUyaNMksAykZPpnwRcYDygQxEtXLm961a9fszCaRLTmyjcmYu5/e34yYhNS8VuFDeJAXRg/soDJ2tuZRNQZjftyvLudedl2D6fc3Rvf6N3/8SU7LwPGYJByNSsTR6EQciUrA8egkpGbocDYJOJt0s45S3Wpl/AyZQJUNDFT70n6eWHM4Bl9v32/2mMszW6uAr1riLlyu9B66NbRqSfpiiZ9j5AhsZ2RvbGPkjDZm7P1XrAK+8ePHY9iwYfmWqVatWvblMmXKqK1WrVqoW7euCoZ27NiB1q1bIzw8HDEx5mtXGa/LOePeUhnT88ZjMjmMaZkmTZpkl4mNjTW7j4yMDNXNtKDHMX0MS7y8vNSWk7zJph8mOa8T2Zoj2pjc++v31FdLIOScvsQYOk3uWx/eXje7RttSnyYV4e7upmbjNJ3AJTzIG5P71kOPBjc/A0SQhwdaVPNBi2qh2ccyMnU4e+U6DkcmqADwiOwjE3DlehpOXrquthUHDJl/ERbgifgbGbkC3K26hriq90eoJh5rfv8ZPZo8b5cgtyjh5xg5AtsZ2RvbGDmyjd1qW7utgE8mJpFxb9WrV1fdGgsrNDRUbbdCJ9PuZY17ExL0vfzyy9mTuAiJimvXrp3dhVLKrF+/HmPHjs2+Hykjx4V0w5SATMoYAzyJpGVs3qhRo7LvIy4uDnv27EHTpk3VsQ0bNqj6yFg/a+tCRFBB1WeP3Gl10GWPx+9aL1xNIBObmIKwAG+0iAixOthyd9OiRliA2u5tYsjKyeRPlxJTcdgYAEYl4GhkAs5cuY7YRMOspDllwB2/Z7bEw+7r0ebGJuw6M9S2s4MSERFRiXVLAZ/0Hx0zZoxaukD8+++/KhMnxypUqKC6atqSBFwyK2a7du1UwHTq1Cm1XIIEmsZgbfDgwaqbp3T5lLF+hw4dUrNyfvDBB9n389xzz+Guu+7C+++/j969e+PHH3/E7t278cUXX6jz0jVUgsE333wTNWvWzF6WQWbelBlBhWQWZabPkSNHqpk9JagbPXq0mtBFyllbFyKyTdB1u+RxbBlcyedIWKC32jrVvjne93pqBuZuOY1Zf5iv62m0QtcaD2M9errtwuY46bLBgI+IiIictPC6jDXbv38//vzzz+y16YyzVS5atAi2JhOW/Pzzz+jcubPKkkkg1ahRI2zatCm7C6TMpimTm0jGUTJv0l1UFlA3XQZBZvWUtfIkwGvcuDF++uknNUOncQ0+MWHCBBW4yu2aN2+uFlSXZRhMn6fMECrjCqU+shyDBKLGoNHauhBR7qBLsmSyd8XujH5e7mgZkXcQt0tXB9H6UgjSJKNm4i6H1o2IiIhc1y1l+CRIksBOZso0nTBF1puT7JutNWzYUHWbLIgEgVu2bMm3zAMPPKC2vMjzmTp1qtryIjNyGhdZv526EFHJIpnLckHeiI5PyTWOTxafX5nZCo+7/45al9YAGOikWhIRERFKeobv0qVLuZYmENevX3eZGTOJiGxNMpcyNlFY+qRckdlG7bX//g6kWbdOIREREZHNAz5ZdPy3337Lvm4M8r788svsMXVERJT3RDUyMY0pd60GowbfD5SKANKTgeO/O62OREREVMK7dL799tvo2bMnjhw5opYkkAlJ5PK2bdvUuDoiIrJuopozl5PwyrJDyNDpUSs8EGh4P7D5XeDgT4bLRERERI7O8MkkJTJpiwR7Mr5OJiiRLp7bt2/PXqqAiIgKnqhmcMsq6FDLsDzNygNRQIOsIO/kH0DyVedWkoiIiEpewCfLEDz22GOqG+fcuXOxa9culd377rvvVPBHRESF06eRYUmX5fsjoQ+tDYTVB3TpwLGVzq4aERERlbSATxYSX7p0qX1qQ0RUAnWrXxaeblqcjE3C8ZhEoOEAwwnp1klERETk6C6dsgi5LM1ARES3L9DbAx1rZ3Xr3C/dOrMCvrNbgMQY51aOiIiISt6kLTVr1lTr1P31119qzJ6fn5/Z+WeffdZW9SMiKhH6NC6PtUdisOJAJMZ36whNxebAf38Dh38BWj3l7OoRERFRSQr45s2bh+DgYOzZs0dtpmRsHwM+IqLC6VI3DD4ebjh3JRmHLiagoUzeIgHfoZ8Y8BEREZFjA74zZ87c+iMSEVEuvp7uuLtuGH47EKWyfA3b9wfWTDIEfdfOAqWqOruKREREVFLG8JnS6/VqIyKi29M3a7bOlfsjofMLA6q2N5w4xImyiIiIyMEB34IFC9QyDD4+Pmpr1KgRvv3221u9OyKiEk8mbvH3ckdkfAr+uXDt5sLrh352dtWIiIioJAV8M2fOxKhRo9CrVy8sXrxYbT169MBTTz2FDz74wPa1JCIqAbw93NCtXll1eYXM1lm3L6D1AGIOAbHHnF09IiIiKikB38cff4zPPvsM06dPxz333KO2GTNm4NNPP8VHH31k+1oSEZUQfRsbunX+djAKmV7BQI0uhhMyeQsRERGRIwK+qKgotGnTJtdxOSbniIjo1rStUQZBPh64lJiKnWeu3OzWKYuwc7w0EREROSLgq1GjhurGmdOiRYvUGn1ERHRrPN216Nkg/Ga3zto9AQ9f4NoZIHKvs6tHREREJWFZhilTpmDgwIHYvHkz2rZtq47JIuzr16+3GAgSEVHhunX++PcFrD4Uhan31oeHBH0yU+fBpUCFps6uHhEREbl6hm/AgAHYuXMnypQpg2XLlqlNLu/atQv9+/e3fS2JiEqQlhEhKOPviWvJ6fjr5GVAFmEXh38GdJnOrh4RERG5eoZPNG3aFN99951ta0NERHB306JXw3JYsP0cVh6IQsf+nQHvICAxCji3DYjIWp+PiIiIyB4ZvlWrVmHNmjW5jsux33///VbukoiITPTJWoR9zaFopMpvc7JEg+Ai7ERERGTvgG/ixInIzMzdrUiv16tzRER0e5pVKYXwQG8kpmZg0/FLN7t1HvkVyEx3dvWIiIjIlQO+EydOoF69ermO16lTBydPnrRFvYiISjStVoPejcqpy9KtExEdAL8w4MZV4NRGZ1ePiIiIXDngCwoKwunTp3Mdl2DPz8/PFvUiIirxjIuw/3E0BjcyANTPmhSLi7ATERGRPQO+e++9F2PHjsWpU6fMgr3x48fjnnvuuZW7JCKiHBpXDEKlEB8kp2Viw7HYm4uwH/sNSEt2dvWIiIjIVQO+GTNmqEyedOGMiIhQm1wuXbo03nvvPdvXkoioBNJoNNmTt6zYHwlUbA4EVwbSkoATuSfOIiIiIrLJsgzSpXPbtm1Yt24d9u/fDx8fHzRu3Bjt23OqcCIiW+rbqDw++/MUNhyPVRO4BDQYAGz9ADj4080unkRERES2yPBt374dK1euzP7luVu3bggLC1NZPVmM/YknnkBqamph7pKIiPJRt1wAqoX6IS1Dp8byQQI+cWIdkBLv7OoRERGRKwV8U6dOxeHDh7OvHzx4ECNHjkTXrl3VcgwrVqzAtGnT7FFPIqISSX5ckyyfWLE/CijbAChTG8hMNYzlIyIiIrJVwLdv3z507tw5+/qPP/6IFi1aYO7cuRg3bhw++ugjLF68uDB3SUREBejb2LA8w5YTlxB3I/3m5C3SrZOIiIjIVgHftWvXULZs2ezrmzZtQs+ePbOvN2/eHBcuXCjMXRIRUQFqhAWgTngA0jP1WHM4+ma3ztN/AtcvO7t6RERE5CoBnwR7Z86cUZfT0tKwd+9etGrVKvt8YmIiPDw8bF9LIqISzrgmn+rWWbo6UP4OQJ8JHP7F2VUjIiIiVwn4evXqpcbqbdmyBZMmTYKvr6/ZzJwHDhxA9erV7VFPIqISzTiOb9upy7iclAo0yOrWeWipcytGRERErhPwvfHGG3B3d8ddd92lxu3J5unpmX3+q6++UjN3EhGRbVUu7asWYtfpgd8PRgEN7pMpXYDz24E4dqUnIiIiG6zDV6ZMGWzevBnx8fHw9/eHm5ub2fklS5ao40REZJ9unfv/i8eKA1F4tHVroEob4NxfwOGfgbbPObt6REREVNwzfKYLr+cM9kRISIhZxo+IiGynV0PDbJ1/n72K6PiUm5O3cLZOIiIismXAR0REjlc+2AfNq5aCXg/8Jt066/UDtO5A9AHg8glnV4+IiIiKIAZ8RETFSJ/sRdgjAb/SQLVOhhOcvIWIiIhcIeBLTU1FkyZNoNFo1ELwpmSWUJk11NvbG5UqVcKMGTNy3V7GGdapU0eVadiwIVatWmV2Xq/X47XXXkO5cuXg4+ODLl264MQJ81/Or169iocffhiBgYEIDg7GiBEjkJSUVOi6EBEVVs+G4dBqgH0X4nDharL5IuyS+iMiIiIqzgHfhAkTUL684RduUwkJCWqG0CpVqmDPnj1499138frrr+OLL77ILrNt2zY89NBDKkD7559/0K9fP7UdOnQou4wEZh999BHmzJmDnTt3ws/PD927d0dKSkp2GQn2Dh8+jHXr1mHlypVqIpsnnniiUHUhIroVYQHeaF29tLq88kAUUKc34O4NXDlh6NpJREREdKuzdDrb77//jrVr12Lp0qXqsqmFCxeqxeBlaQiZOKZ+/foqAzhz5szsYOzDDz9Ejx498MILL2QvMyFB2+zZs1WAJ9m9WbNm4ZVXXsG9996ryixYsEAtOL9s2TIMGjQIR48exerVq/H333+jWbNmqszHH3+s1ih87733VDBqTV3yyl7KZho4ivT09OzNeJ3IHtjGioee9cvir5NXsHzfRTzetjLcanSD9thyZO5fDF2ZeijK2MbIEdjOyN7YxsgZbexW21uxCfhiYmIwcuRIFXjJgu85bd++HR06dDCbJVQyc9OnT8e1a9dQqlQpVWbcuHFmt5Mycp/izJkziI6OVt04TWckbdmypbqtBHyyl26cxmBPSHmtVqsygv3797eqLpZMmzYNU6ZMyXVcglzT5yxBKpE9sY0Vbdp0QKtxw9HoRHy9dBWapFZBC/nRaM/3WJfSDNAU/c4bbGPkCGxnZG9sY+TINpacnOy6AZ9k3oYNG4annnpKBVpnz57NVUYCtYiICLNjkpkznpMgS/bGY6Zl5LixnOnt8ioTFhZmdl4Wo5clKUzLFFQXSyZNmmQWkEqGT8b/SfdQGS8oUb286V27doWHh0cBrxpR4bGNFR9r4vdi04nLSAqpjTvadYJ+1tfwTbuK3o3KQF+pFYoqtjFyBLYzsje2MXJGGzP2/itWAd/EiRNV1is/0oVSMlyJiYkqIHJlXl5eastJ3mTTD5Oc14lsjW2s6LunSQUV8K06FIPnu9aGpm5fYP8PcD+6DKjWHkUd2xg5AtsZ2RvbGDmyjd1qW3Nqv5/x48ergC6/rVq1atiwYYPqJinBkGTTatSooW4v2b6hQ4eqy+Hh4arbpynjdTmXXxnT86a3y6tMbGys2fmMjAw1c2dBj2P6GEREt6Nr/bLwdNfiZGwSjsckAg2yZus8vAzIzHB29YiIiKiIcGrAFxoaqpZIyG+TcXAya+b+/fvVxCeyGZdSWLRoEd566y11uXXr1mq2TNPBjJIGrV27dnYXSimzfv16szpIGTkupBumBGSmZSR1KmPzjGVkHxcXp2bfNJKAVKfTqbF+1taFiOh2BHp7oGOt0Jtr8lW7C/AtDSRfBs5scnb1iIiIqIgo+iP7AVSuXBkNGjTI3mrVqqWOV69eHRUrVlSXBw8erIJDWXJBlkyQYFBm5TQdE/fcc8+pGTbff/99HDt2TC2VsHv3bowePVqdl7X9xo4dizfffBPLly/HwYMHMWTIEDXzpizfIOrWratm+pQJZHbt2oW//vpL3V4mdDEuF2FNXYiIblffxuWzl2fQa92BeobPKS7CTkRERMUq4LOGzKYpY/1kps2mTZuq7qKygLrpMght2rTB999/r9bDa9y4MX766Sc1Q6cEkabr/I0ZM0bdrnnz5mpBdQkSZQF1I1l2QbKPnTt3VssxtGvXzmyNPWvqQkR0uzrXDYOPhxvOXUnGwYvxNxdhP7oCSL+5digRERGVXMVils6cqlatqmbuzKlRo0bYsmVLvrd94IEH1JYXyfJNnTpVbXmRGTklcMyPNXUhIrodvp7uKuiTDJ9062zUsxUQWAFIuAicXAfIRC5ERERUorlMho+IqCR36/ztQBR00AD1+xtOHPzJuRUjIiKiIoEBHxFRMXZXrVAEeLkjMj4Fe89fu9mt89/VQGqis6tHRERETsaAj4ioGPP2cFNLNAjp2olyTYCQ6kBGCnD8d2dXj4iIiJyMAR8RUTHXt9HN2TozZXizMcvHbp1EREQlHgM+IqJirm2NMgj29cDlpFTsPH3l5iLsp9YDyVedXT0iIiJyIgZ8RETFnKe7Fj3qh6vLK6RbZ2gtILwhoMsAjvzq7OoRERGREzHgIyJyodk6fz8UhfRM3c0sHxdhJyIiKtEY8BERuYBW1UqjjL8X4pLT8dfJy0CD+wwnzm4FEiKdXT0iIiJyEgZ8REQuwE2rQa+GWd0690cBwZWBSi0B6IHDvzi7ekREROQkDPiIiFysW+faw9FISc+82a2Ts3USERGVWAz4iIhcRNPKpRAe6I3E1Axs/vcSUL8foNECkXuBq6edXT0iIiJyAgZ8REQuQqvVoE+jcjdn6/QPAyLuMpzk5C1EREQlEgM+IiIX7Nb5x5EYJKdlmCzCzoCPiIioJGLAR0TkQhpVDELlEF/cSM/EhmOxQJ0+gJsncOkoEHPY2dUjIiIiB2PAR0TkQjQak26d+yMBn2CgZjfDSU7eQkREVOIw4CMicjF9Ghm6dW48fgmJKek31+STcXx6vXMrR0RERA7FgI+IyMXULReA6qF+SMvQYd2RGKBWT8DDD4g7B/y329nVIyIiIgdiwEdE5ILdOo2Tt6yU2To9fYE6vQwnD7FbJxERUUnCgI+IyIW7dcp6fHHJaTcXYT/8C6DLdG7liIiIyGEY8BERuaAaYf6oWy4QGTo9Vh+KBqrfDXgHA0kxwNmtzq4eEREROQgDPiIiF2WcrVN163T3BOrdazjBbp1EREQlBgM+IiIX1TerW+e2U5dxKTH15iLsR5YDGWmOr5AuE5pzW1Hh6na1Z9dSIiIi+3N3wGMQEZETVC7ti8aVgrH/QhxWH4rCoy3bAv7hQFI0sO0joFRVwL8sUKUNoHWzb2UkyFz9ItwTItFMrp/7DAgsD/SYDtS7x76PTUREVIIxw0dE5ML6Zi/CHmUI6so1NpzY8AawdAQwvw8wq4EhILMXue/FQ4CESPPjCVGG4/Z8bCIiohKOAR8RkQvrnRXw7Tp7Fdd2/wScWJO7kK0CL1nUPT0FuH4ZuHoaiDoAnN4MrBwrJy3dwLBbPZHdO4mIiOyEXTqJiFxYuSAfNK9aCnvOXoHHupfyKCWBlwZY9T8gqBKQcQNITby5pSVlXZZ9Qo7rct5YNgnQpReyhnog4SJwbhsQ0d4Gz5iIiIhMMeAjInJxsgi72/m/4J8ak08pvWHJhrkdbfOgHn6Al7/hstxvQawpQ0RERIXGgI+IyMX1bFAOe1bGWVfYKxDwCzUEa3LZU/YBWddlHwB4Bpgfy3Xd/+YkMGe2GMYJFsTN6/aeJBEREVnEgI+IyMWFBnghtFxl4LIVhQd9b9uulTIDqMzGKeMELY7jy/LbOMAnCIjoYLvHJiIiIk7aQkRUEtRs3g2R+hDo8iyhAQIrGAI0W5JMnyy9YHyMnI8p5HGvxwIL7gX+fIcTuBAREdkQAz4iohKge8MKeDNjqEqy6fMKvHq8Y5/1+GSdvQcXAIGGGUOzSebvwW+B0buBOx4B9Drgz2mGwC8x2vb1ICIiKoEY8BERlQDBvp64UaMXRqWPRZJnqIXAa4F9F0CX+x57CBmPLMPuKqPUHmMPGo57+gL3fgL0/8Iw2cvZLcCcdsCpDfarDxERUQnBMXxERCVEn0blMf54C5z27IC1D3lAkxQL+Jc1dOO0R2YvJ60b9FXa4eLhBDSu0i73YzYeCJS/A1gyDIg9DHx7H9B+PNBxEuDG/66IiIhuBTN8REQlRNf6ZeHprsWJyyk45t0EaHi/YYIWRwR7ADJ1euw8cxV7LmvUXq7nEloLGLkeaDrcMMnLlveA+X2BhEiH1JGIiMjVMOAjIiohAr090Km2oTvnnD9P4dd9F7H91BXLgZeNrT4UhXbTN+CRr3ZjwQk3tZfrcjwXDx+g7yxgwDzDkg/ntxm6eJ5YZ/d6EhERuRoGfEREJUjFUr5q/+v+SDz34z48NHdH3oGXjch9j/puL6LiU8yOR8enqON5PrZkIJ/cBIQ3ApKvAAvvB9a9BmSm262uRERErqbYBHxVq1aFRqMx29555x2zMgcOHED79u3h7e2NSpUqYcaMGbnuZ8mSJahTp44q07BhQ6xatcrsvF6vx2uvvYZy5crBx8cHXbp0wYkTJ8zKXL16FQ8//DACAwMRHByMESNGICkpqdB1ISJyJAmsvtp6JtfxAgOv2yDZwykrjlhcgc94TM7nmWUsXR0YsQ5oPtJw/a8PgW96A3EXbF5XIiIiV1SsRsFPnToVI0dm/acPICAgIPtyQkICunXrpgK0OXPm4ODBg3jsscdUQPbEE0+oMtu2bcNDDz2EadOmoU+fPvj+++/Rr18/7N27Fw0aNFBlJDD76KOPMH/+fERERODVV19F9+7dceTIERW8CQn2oqKisG7dOqSnp2P48OHqMeT+rK0LEZEjWRN4jV+yH7vPXYNebyiv0+vN9pk6mB3L67jhmOFyXHJarsxezseW87vOXEXr6qUtF/LwBnq/B1RtBywfA1zYaeji2X8OULunbV4gIiIiF1WsAj4J8MLDwy2eW7hwIdLS0vDVV1/B09MT9evXx759+zBz5szsIOvDDz9Ejx498MILL6jrb7zxhgraZs+erQIzye7NmjULr7zyCu69915VZsGCBShbtiyWLVuGQYMG4ejRo1i9ejX+/vtvNGvWTJX5+OOP0atXL7z33nsoX768VXUhInIkCajyC7zE9dRMfLkldwbQEWIT86+bUr8fUK4x8NNwIPIf4IdBQOvRQOfJgLunI6pJRERU7BSrgE+6cEqQVrlyZQwePBjPP/883N0NT2H79u3o0KGDCrCMJDM3ffp0XLt2DaVKlVJlxo0bZ3afUkaCOXHmzBlER0erzJxRUFAQWrZsqW4rAZ/sJVNnDPaElNdqtdi5cyf69+9vVV0sSU1NVZuRZAqFZBGNm/E6kT2wjbmuqLjrVpXrVLsMaob5w02jgVarMdnDsNdqoNUY9nJMutffPIZctzsVm4RZG04V+Lilfd2ta3cBFYEhv0G7YQrcdn0ObJ8N3bltyOw/FwiuYtVzJNfHzzKyN7YxckYbu9X2VmwCvmeffRZ33nknQkJCVNfMSZMmqW6VkjUTEqhJF0xTkpkznpMgS/bGY6Zl5LixnOnt8ioTFhZmdl6CTqmXaZmC6mKJdDWdMmVKruNr166Fr69hogUhWUkie2Ibcz2n4zUACl5+ob5bDGpmGD7LbpcOQBU9EOzphrg0OSJ1yE0LPfb/vQNXjhbm3tsiPMIbd5yfC8/Ivcic0x7/VH4cUcE3f4wj4mcZ2RvbGDmyjSUnJxe/gG/ixIkq65Uf6UIpk6yYZuYaNWqksmdPPvmkCpK8vLzgCiSINX2ekuGTCV9kPKBMECNRvbzpXbt2hYeHh1PrSq6Jbcx1yZi6n97fjJiEVIvj+CQUCw/ywuiBHVTGzpY8qsZgzI/71WVLj62DBrOPeeKtfvXRt1G5QtxzLyB+GHS/jITHxd1oceYjZDYbCV3n1wF31/h/gW4NP8vI3tjGyBltzNj7r1gFfOPHj8ewYcPyLVOtWjWLx6WbZUZGBs6ePYvatWursX0xMTFmZYzXjeP+8ipjet54TGbpNC3TpEmT7DKxsbFm9yH1kJk7C3oc08ewRAJXS8GrvMmmHyY5rxPZGtuY65F38/V76qvZODU5Ai9jeDe5b314e9l+LFyfJhXh7u6mJo0xHUdYLsgb47vWUktEbDlxGeOWHMShyCRM6lUHHtI/1BplqgGPrQbWTwG2fQy33XPhdvFv4IGvgRDL/3+UGLpM4Nw2ICkG8C8LVGkDaAvO8roSfpaRvbGNkSPb2K22NacuyxAaGqqyd/ltpuPgTMkkKDJuzti9snXr1ti8ebNZ31aJiiUYNHahlDLr1683ux8pI8eFdMOUgMy0jETSMjbPWEb2cXFx2LNnT3aZDRs2QKfTqSDU2roQETlajwbl8NkjdyI8yDDjsJFcl+Ny3p6PvfXFu/HdY80wpGam2sv1+5tVwjfDW+CZTtVVua/+OoOHv9xp3SQuRm4eQLc3gcGLAZ9SQNQ+4PO7gMO/mAc/Z7YAB38y7OW6KzuyHJjVAJjfB1g6wrCX63KciIhKlGIxhk8mQZGgq1OnTmqmTrkuE7Y88sgj2QGUTOIi499kTbwXX3wRhw4dUrNyfvDBB9n389xzz+Guu+7C+++/j969e+PHH3/E7t278cUXX6jzMvnA2LFj8eabb6JmzZrZyzLIzJuyfIOoW7eumulTloeQmT0lqBs9erSa0EXKWVsXIiJnkMCra71wNWunBFVhAd5oERFi826clshjtIwIwZWjerU3PqbsX+heB40qBmP84v2qbn0/3opPH26KplUK8SNZre7AU1uBn0YAF3YAS4YZgrsqbYF1rwAJkTfLBpYHekwH6t0Dl8u0SVC3eEjuDrQJUYbjDy5wzPMmIqIioVgEfNLNUYKz119/Xc1iKYGYBHym491kNk2Z3OSZZ55B06ZNUaZMGbWAuukyCG3atFFr5cmyCy+99JIK6mSGTuMafGLChAm4fv26up1k8tq1a6eWYTCuwSdk2QUJ8jp37qyyjAMGDFBr9xWmLkREziIBVp5r3jlR9/rhqDHaH099uwcnYpMw6IvteK1vfTzSsrL6Qc4qQRWBYb8BG98Cts4Eds8zbDk5KviR4Gv1i44LNiW4lMfLc8VFDbB6IlCnd4nr3klEVFJp9LL4HBVJ0p1Ugsf4+PjsSVtWrVql1vxjf3GyB7YxKgptLCk1AxN+2o9VBw2zhQ64syLe6t8A3h6FDFD+XWNYq08v84VaojEEX2MP2if4ySvTZhw1WVCwmZEGpCUBqYlZ+yQgLTFrb7ye4/LVM4bsZkGGrgQi2sNV8bOM7I1tjJzRxnLGBi6V4SMiopLD38sdnwy+E3O3nMY7vx/D0r3/4Vh0AuY80hSVQm4uUVMgD998gj2hBxIuAt8/CARWADRaQ+Ane7XJZU2O4ybntcZyJseN5YRkGfPMtAH45UngwGIg/brlIC5TrWVhH9K9lIiISgQGfEREVORIF84nOlRHg/JBGP3DPzgcmYC+s7fio0F3oEOtUNsGNSf/gFOkJwPHVhRczt0b8PQHPP0ArwDDZS9/k33AzetJ0cCOzwq+TxlLSEREJQIDPiIiKrLa1CiDlWPaYdR3e7D/v3gM/XoX/tetNkbdVR3agiaasTaouXMIEFwZ0OkMGUG1ZRr2MiYu+5guxzHjXp/7WNx54OLN2Zzz1HiwoWulpeDNuJdZSK0l9Tjyq2GMYl4rLko3Vpk4hoiISgQGfEREVKSVD/bBoidbY8qKw/hh1wW8u+Y49l2Iw/sPNkagdz7BkAQ1EtwUFPz0mWX7MXwyO6gshVCQJlkBn63I85AJYdTYwZwrLgo90OMdTthCRFSCOHUdPiIiImvIhC3T7muEd+5rCE83LdYdiUG/2X/hRExiwcGPkjMbmHXdXsGPMdjM9bgmjy/jBu2RaZOJYGRCmEAL6yqG1eOSDEREJQwDPiIiKjYGtaiMJU+1Rvkgb5y+fB33fvIXfjsgGbxCBj8SjNlzSQZnBptCntfYQ4bZOAfMAwZ8BWjcgdgjwNmt9nlMIiIqktilk4iIipXGlYKxYkw7jPnhH2w7dQXPfL8X+/+rhgnda8PdTWs5+JF15xy5+LnxcSWotLgO3zv2z7TJ8zPtLnruL8OahBvfNqxVaO3ahkREVKwx4CMiomKntL8XFjzWAu+uPY7PN53GF5tP4+B/8fh48B0o4+9VcPDjKM4KNi1pPx7451tD4HdmM1DtLsfXgYiIHI5dOomIqFiSbN6knnXx6cN3ws/TDdtPX0Hfj7eqCV2KFGOw2fB+w95ZE6YEVQCaDjdcliyfzC5KREQujwEfEREVa70alsOvo9uiWqgfouJT8OCc7fhh13lnV6toave8YV2/CzuAUxucXRsiInIABnxERFTs1QgLwK/PtEX3+mWRlqnDpJ8P4sWfDiAlPVOdz9Tpsf3UFfy676Lay/USSSavaTbCcJlZPiKiEoFj+IiIyCUEeHtgziNN8dmmU3hvzXEs2n0BR6MTMLB5JczecFJl/4zKBXljct966NHAwtIFrq7dWGD3V8DF3cCJdUCtbs6uERER2REzfERE5DI0Gg2e7lgD8x9rgVK+HjjwXzxe/uWQWbAnouNTMOq7vVh9KJ8lHWzEWdnFPB/XPwxoMdJweeNbzPIREbk4ZviIiMjltK8ZimXPtEXn9zchw0KAJUdkUYIpK46ga71wuGnts0SBBJTyGI7OLhb4uG2fA/6eB0TtA46vMswkSkRELokZPiIickmRcSkWgz0jOSMB0Wu/HsTCnedUJuyPIzEqGyZLPJy+lITYhBRcT82A/hayYBJ0SRbR0dlFqx7XrwzQ8knDiY3TAJ3OLnUhIiLnY4aPiIhcUmyiecCTl4U7LwCQLW+yRrmfpzv8vNzg5+UOfy/3rOty2eRY1ubrqcX01cdVUJmT8dgryw4hxM8LklyU7pYSm0pgmak3XNbJXpfHZeOmM70OZOh0eDefxzXLarYZA+yaC8QcBI6tAOrda9XrRURExQsDPiIicklhAd5WlWtXowx8PN1UJk+2JLXPNFxOk+yeYZibHJcNSLVJ/S4npeHBz7fDkYxZzV1nrqJ19dJA66eBTdMNWb46fQEtO/4QEbkaBnxEROSSWkSEqHFr0pXRUsZLsl3hQd5qgpe8xvBJxu1GeqZ5EGgpMMw6dj1NLmfi1KUkHIlMKLCOZfw91eyikkF002ig1WjUZdlLnaRampyXpZzWUMZw/ebl2MQbOPBfgvXZz1ZPAzvmAJeOAkd+ARoMKPiFJSKiYoUBHxERuSQJkmSSEhm3JuGcadBnDO/kfH4TtkgQ5espXTTdgQDrH1vGAT40d0eB5T5+6E5Dps1GrH3c7OynTzDQZrRhts4/3wHq9QO0bjarDxEROR/7bhARkcuSGSk/e+ROlckzJdfluL1myjRmF/MKJeW4nJdyTn/clk8B3sHA5X+BQ0ttWh8iInI+ZviIiMilSVAnk5TIuDXpyijZLQl47LUUg62yi7Z+XGRdz/W43oFA22eB9VMNWb769wFu/HpAROQqmOEjIiKXJwGOdJ28t0kFtbdnsOfs7GJejysCvN1xV62w3Ddq8QTgWxq4ego4uNgu9SIiIufgT3hEREQulF209Lil/Twx8ecD+O9ailpz8PH21cxv4BVgWIx93WuGWTsbPgC4edi1jkRE5BjM8BEREblYdjHn47arGYoxd9dUx+dsOo0baZm5b9D8ccAvFLh2Ftj/g0PqSERE9seAj4iIqAS4786KqFjKB5eTUlWWLxdPP6Dd84bLm94FMtIcXkciIrI9BnxEREQlgIebFqM71VCXP998GinpFrJ8zR4D/MsC8eeBfd85vpJERGRzDPiIiIhKUJavQrAPLiVKlu987gIePkD78YbLm98DMlIdXkciIrItBnxEREQlhKe7FqPvNmT55mw6ZTnLd+dQIKA8kHAR2DPf8ZUkIiKbYsBHRERUggwwyfL9sMtSls8b6JCV5dvyPpB+w+F1JCIi22HAR0REVMKyfE93qq4uf/ZnHlm+O4YAQZWApGhg99eOryQREdkMAz4iIqIS5oGmlVA+yBuxian40VKWz90T6PCC4fLWmUDadYfXkYiIbIMBHxERUYnM8hnG8n2W11i+JoOB4CrA9UvA3/McX0kiIrIJBnxEREQl0APNKqosX0xCKhb9fSF3ATcP4K4XDZf/mgWkJjm8jkREdPsY8BEREZVAXu5uGGXM8uU1lq/RQCCkGpB8Bdj1heMrSUREt40BHxERUQn1YLOKKBfkjeiEFCzebSnL5w7cNdFwedtHQEqCw+tIRES3hwEfERFRCc7yPd3RMGPnpxtPITXDQpav4f1A6ZrAjWvAzs8dX0kiIio5Ad9vv/2Gli1bwsfHB6VKlUK/fv3Mzp8/fx69e/eGr68vwsLC8MILLyAjI8OszJ9//ok777wTXl5eqFGjBr755ptcj/PJJ5+gatWq8Pb2Vo+3a9cus/MpKSl45plnULp0afj7+2PAgAGIiYkpdF2IiIic7cHmlRAemJXlszSWT+sGdMzK8m3/GLgR5/A6EhFRCQj4li5dikcffRTDhw/H/v378ddff2Hw4MHZ5zMzM1WAlZaWhm3btmH+/PkqmHvttdeyy5w5c0aV6dSpE/bt24exY8fi8ccfx5o1a7LLLFq0COPGjcPkyZOxd+9eNG7cGN27d0dsbGx2meeffx4rVqzAkiVLsGnTJkRGRuK+++4rVF2IiIiKzFg+Y5bvzzyyfPX7A6F1gZR4YMdnjq8kERHdOn0xkJ6erq9QoYL+yy+/zLPMqlWr9FqtVh8dHZ197LPPPtMHBgbqU1NT1fUJEybo69evb3a7gQMH6rt37559vUWLFvpnnnkm+3pmZqa+fPny+mnTpqnrcXFxeg8PD/2SJUuyyxw9elQvL+X27dutros14uPj1f3KXqSlpemXLVum9kT2wDZG9sY2VjTdSMvQt3hrnb7Kiyv1324/a7nQoV/0+smBev3bFfX661f0RRnbGdkb2xg5o43ljA2s5Y5iQDJtFy9ehFarxR133IHo6Gg0adIE7777Lho0aKDKbN++HQ0bNkTZsmWzbyeZuVGjRuHw4cPqdlKmS5cuZvctZSTTJyQjt2fPHkyaNCn7vDym3EZuK+R8enq62f3UqVMHlStXVmVatWplVV0sSU1NVZtRQoJhcLw8nnEzXieyB7Yxsje2saLJDcAT7SPwxm/H8MnGk+jXOBxe7jk6AdXsCfew+tDEHkbmXx9D1/ElFFVsZ2RvbGPkjDZ2q+2tWAR8p0+fVvvXX38dM2fOVOPr3n//fXTs2BH//vsvQkJCVBBoGmAJ43U5Z9xbKiOB1Y0bN3Dt2jXVHdNSmWPHjmXfh6enJ4KDg3OVKehxTOtiybRp0zBlypRcx9euXavGAhqtW7cun1eL6PaxjZG9sY0VPUE6INDDDVHxKZj67Rq0LSs/JJsL9+uCljgM/fZP8UdCdaS5B6AoYzsje2MbI0e2seTk5OIX8E2cOBHTp0/Pt8zRo0eh0+nU5ZdffllNkCK+/vprVKxYUY2je/LJJ+EKJLMo4weNJBCtVKkSunXrhsDAQBXVy5vetWtXeHh4OLWu5JrYxsje2MaKtrjS5/DmquPYesUPkx9tB8+cWT59T+jnbYB7zEF08z8O3d1Fc2w62xnZG9sYOaONGXv/FauAb/z48Rg2bFi+ZapVq4aoqCh1uV69etnHZZZNOSezYYrw8PBcs2kaZ86Uc8Z9ztk05boEUzLzp5ubm9oslTG9D+n6GRcXZ5bly1mmoLpYIs9JtpzkTTb9MMl5ncjW2MbI3tjGiqZHWkfg8y1nERmfgl8PxGBwy8q5C939CvDDQLjt/hJubZ8F/ENRVLGdkb2xjZEj29ittjWnztIZGhqqxr/lt0n3yaZNm6pA6Pjx42ZR79mzZ1GlShV1vXXr1jh48KDZbJoSFUswZwwUpcz69evN6iBl5LgwPpZpGckuynVjGTkvL7ZpGamXBJ7GMtbUhYiIqKjx9nDDqLsMM3bKWL60DEMPGzO1ugMVmgLpycBfsxxfSSIicr1lGSRQeuqpp9RSCTKeTQIsmQBFPPDAA2ov3R4lmJKlG2TZBllq4ZVXXlHr5RmzZnIfMh5wwoQJakzep59+isWLF6tlFoykS+XcuXPVUgrSnVQe5/r162o5CBEUFIQRI0aochs3blSTuMg5CfJkwhZr60JERFQUSVYvNMALF+NuYOne/3IX0GiATlkTtvz9JZCY99h0IiJyvmIR8AmZkXPQoEEqiGrevDnOnTuHDRs2qAXYhXTFXLlypdpL8PXII49gyJAhmDp1avZ9REREqMXbJdsm6+vJxC9ffvmlmkHTaODAgXjvvffUmnkyE6is17d69WqzSVg++OAD9OnTR40n7NChg+qm+fPPP2eft6YuRERERTXL91RBWb7qnYFKLYGMFGDrB46vJBERWU0jazNYX5wcSQZmSkYxPj4+e9KWVatWoVevXuwvTnbBNkb2xjZWPKSkZ6Ld9I24nJSKd+5riEEtLIzlO/0nsOBewM0LePYfIKgCigq2M7I3tjFyRhvLGRu4XIaPiIiIHJnlq6Yuz954EumZFrJ8EXcBVdoCmanA1pmOryQREVmFAR8RERHl8nDLKijj74n/rt3AL3sv5j+Wb898IO6Cw+tIREQFY8BHREREufh4uuHJDoaxfB9vPGE5y1e1HRDRAdClA1vec3wliYioQAz4iIiIyKKHW1VGaT9PXLh6A7/8YyHLJzpmZfn++Q64dtah9SMiooIx4CMiIiKLfD3d8aRxLN+GPMbyVWkNVL8b0GUAm991fCWJiChfDPiIiIgoT4+0qqKyfOevJmNZQVm+fT8AV045tH5E5AC6TODMFuDgT4a9XKdigwEfERER5Zvle6LDzRk7Myxl+So1B2p2A/SZzPIRuZojy4FZDYD5fYClIwx7uS7HqVhgwEdERET5erR1FYT4eeLclWQs2xdpuVDHSYb9gUXA5RMOrR9RieCMLJsEdYuHAAk5/u4TogzHHRH0Mbt429xv/y6IiIjI1bN8I9tXw/TVxzB7wwn0a1Ie7m45fjOucCdQuxdwfBXw5ztA02FAUgzgXxao0gbQujmr+kTFnwRWq180D7wCywM9pgP17rHPY0pgJY8JvYWTckwDrJ4I1Oltv79vZzxvF8SAj4iIiAo0pHUVfLH5FM5eScav+yIxoGnF3IU6TjQEfId+MmxG/IJGdPtZtpyBlzHL9uCCgv+2dDog4waQfgNIu27Yp2ft05KBdJNNXb8BXD6eO7NnRg8kXARWvwSUbwJ4BZhsgTcve/gY1u10xvMmhQEfERERFcjPyx0jO1TDjNXH1Vi+ey1l+a6ds3xjfkEjV6LLhObcVlS4uh2ac4FAtQ72y3BlZgCrXsgnywbglyeBA4stBHQmAZycs5ddc/I/r3EzCQL9cwSGOYLD7CDRF/jteedmF10IAz4iIiKyypDWVTF382mcuXwdKw5Eov8dFS10/7KEX9DIxqS9ndvm+G7DWV0M3RMi0Uyun/vs1jLYknG7cRVIjAISYwz7pGgg0WST5yYZNpkMKT8S1B1bYf1ju/sYsm6efoa9BFeyefpmXc86fuMacGRZwfdXpS3g7g2kJubYEgx/+1L/lDjDZjNZ2cVN04Fa3YHgKoBv6VvLJBa1NmYHDPiIiIjIKv5e7ni8fTW8u+Y4Pl5/Evc0rgA3bdYXLPliZE33LykX0R4ux4W+HBZ5zhrXZU0Xwzp9gOQrWQFcTI6AzuS6BHeydqWtNHkYqNrOPGBTAZzJJtcl2NNqrW/Ts3YZnp/FTJvG8LoPXWG5rev1hmxjWtLNANBSUJjrWCIQdx6Iv1BwHSXgk03IcwyubNiCKt28HFzFsPcrY31A6GJjBxnwERERkdWGtqmKuVtO47Rk+fZHot8dFQwn5MusNX4bZ8gIhNYBQmsZ9gHlbPfLvCO727nol8MizRHjuiT7JuPb1Fg22V8HUhKBlWPz71q5ZFjW1ULMIulbxtD+A8oCAeGAf7hhr7Zyhm7SSx8r+H4aP2T7H1Lk70basHq9NTmee9bfa4938v77kr9p1YXT3/B8CkNm45TlHwoSWhdIiTcE0pLpvHTMsFni7mMSBFoKCEMNdXbBsYMM+IiIiKhQWb6RWVm+jzacQN/G5Q1ZPslqWePyv4bNlGeAIfgrUxsIzdrK1AJKVS1csGar7naF4YJfDotsZrPAWSMBrJRxX1ogMyUru3TdJHiT8WxJJpev39xnB3e3Md4tO9DTGLJJuQI44/WsAM8vDHD3zP8+y98BrHul4CybvO72IG1X2rDFHzTesV/blucjj1HQ8x71l6G9ZaQC8f8ZMoPGTTKExssJkYb3VSaikc0S6ZYqmUEp72JjBxnwERER0S3M2Hkapy9dx8oDkbi3SQXrvqDJL+jd3jAEfJfki9e/wJVTQFoicHGPYTPl5gWUqWkI/kwzgiHVc39RdnTglZkO3IgDVv3P5b4cOj2zKV0BpaufvHeJkTf3/+0toNswgOTLwOKHYRuarHFuvhJtAtcvF3yTnu8CzYYDbh5FI8tmC/JeSht2ZJflwj5vdy+gdHXDZklGGpCQIyCMMw0ILwIZKcCVgtYQLZ5d0xnwERERUaEEeHvg8XYReH/dv/hw/Qn0aSRZPiu+oPV+P3cgIF/Erp42/Op+yWSTL17yBSzmkGHLOetfSIQh+JNgUILCda8VHHjV6mn4lV/GCJmNKzJeluOmY4nyOW5VFijry+HC+4FKLQ0ZS+MmX5pt2I3V4eMHbzXAllknjWPZJHizuJfueddvvW6lIoCgijeDNdlbcznnMdPlBKztYhhW13bBnrOzbKakPTk6wLHl83b3BEKqGbY8A8KLwD/fAlveL/j+rO3CXkQw4CMiIqJCG9q2Kr7cesY8y3crX9Dki1hYHcOWM4iRX95VJlCCQMkKHjNkBSVIu3LSsFklK/B6swyc4tQGw5ZzPFGpKuZBoHGTMUUywUaxXZAbwIpnDe+XmmnSJFN3PRbQ66x7HK8gIFC6P5YzPCfJqh5cXPDt7vnY9sGJtV0M7dm10tFZtqLAUc/bXQLCCKBaJ+sCPmu7sBcRDPiIiIio0AK9PTCiXQRmrvsXH284mZXl09juC5qUly9gstXuYd7dT6asNwZ/sj/7V97jcizet/vN9b48Tdf/Mq4RFgh4mq4X5n9zrTDT41H7gW/7Ffx4dw7JWqfwrGGTsUaSIcxvggl53SwFgyo7GG6YadFW3VglgMvOZEpWU8a5mWQ403LspRtuQV0rZUr/jW9ZPicZWuOkJCqgK295L5m2nPU8t9U5QVdR6FrpjCxbUeDI513FyYG9nTDgIyIiolsyTLJ8W07jZGwSfjsYhXsal7f/FzTpYifBgGzVOxWuu92D3wE1uxrG+9iiO2VEB+u+HPaZZR4ISKZKJpQwBoCm29WzQGq8IViW7cLO3HcrYxtlVsF8J5cA8OvTwPntholJ8grerO6eegtkNtbKrW5m6Ix7Gct5K4GRs4OuotC1kuxLWwQCeztgwEdERES3keWrhg/++Bcfrz+B3g3L3VyXz5Gs/VW+Ti/bflG71S+HMsYrv/FEkh2zFAzKJhNNZKZaMbkEDAHdjk8L8Xw8bmY0szOfcjlran1j5vP6JWDP1wXfX8dJtg/8nR10ZWWwM05vxr4ta9CkfXe4O2LpD3Kceq4X2DPgIyIiotvL8m09jROxSVh1MEot01CifpW3x5dDn1KGTabktzTpicw2uHeBdWONanYHKjS92V3V2CU1u2uqMbjzN2Q+rSFdK0+sKbnj2bRu0Fdph4uHE9C4SjsGe66onmuNmWTAR0RERLcsyMcwlm/WHyfw8QZDlk/rjCyfM3+Vd+SXQzd3wzg+ayeXaDOm6C3Ibas6lMTxbOQ4WtdpY1pnV4CIiIiKt+FtIxDg7Y5/Y5Lw+6Fo51VEAq+xh5DxyDLsrjJK7TH2oGOnrW94v2Fv70yAsRurMcCymGXLWh/RngG2jKU0JXVy9cXmiYoZZviIiIjotrN8j7WNUGvyfbj+X/RsEO6cLF9J6m5XFLJsLtbtjchVMcNHREREt00CvgAvQ5Zv9WEnZvlKkqKQZXN0ZpOICo0ZPiIiIrptQb4eGN62Kj7acBKz1v2LYB8PXEpKRViAN1pEhDhn9s6SgFk2IioAAz4iIiKyicfaReCLzafxb2wSBn95c/24ckHemNy3Hno0yJGJIttwockliMj22KWTiIiIbGLH6StIydDlOh4dn4JR3+3F6kMyjT8RETkSAz4iIiK6bZk6PaasOGLxnHE6ETkv5YiIyHEY8BEREdFt23XmKqLiU/I8L2GenJdyRETkOBzDR0RERLctNjHvYM/UhKX70aFmKBpVDELDCsGoWdYfHm78/ZmIyF4Y8BEREdFtk9k4rXHh6g0s3HkeC7PmdPFy16Je+UA0qhCEhhWD0bBCEGqE+d/yrJ7SZXTnmavYc1mD0meuonWNMIfMECqPK9lLCXw5MykRFSUM+IiIiOi2SYAjs3HKBC2WRulJ6BMa4IVXe9fDoah4HPzPsCWmZuCf83FqA86psj4ebqhfPhANKwZlZwKrlfErcDF3mRRGxgkaupa6YcGJ3Q6ZIdT8cQ04Mym50o8K/EGjeGPAR0RERLdNvvxJgCOzccrXQNOgz/i1cOq99VUA1LdJeXVdp9Pj3NVkHPgvTgV/By7G4/DFeFxPy8Tuc9fUZuTv5a6CQBUAVgxWGcEqpX2h0Wiygy55bH0eM4R+9siddgm+nPW4VLI480cF/qBR/DHgIyIiIpuQL38S4OT8chiex5dDydhFlPFT271NKmRnEs5cTsIBCQAlCyhBYGQ8klIzVFdN2YwCvd1VFrB++SAs3n3BYmZRjklIKHXqWi/cplkJqevrK444/HHJ+dkuR3YbduaPCvxBwzUw4CMiIiKbkS9/EuDc6pdxKVcjLEBt991ZUR3LyNTh1KXrhkzgRUMgeCQqAQkpGfjr5BW15cc4Q2ifj7bA39tdfWHP1BsyjHJZpzfsM417OZZ9Hdnnbx4z3CYjU28x2Mv5uMv3XcQ9TSow6HO5bJf9uw0blztxxo8KznzsnPVgd9ISEPD9+eef6NSpk8Vzu3btQvPmzdXlAwcO4JlnnsHff/+N0NBQjBkzBhMmTDArv2TJErz66qs4e/YsatasienTp6NXr17Z5/V6PSZPnoy5c+ciLi4Obdu2xWeffabKGl29elXd94oVK6DVajFgwAB8+OGH8Pf3zy5jTV2IiIhckXwZa129tM3uz91Ni9rhAWp7oFkldSw9U4d/YxJVV9Dl+yOx7VT+QZ84Gp0IZ3h+8X5M+uUgaoYFoFbZANTJei6yhQV4ZXdLLa7ZLkc+tqtku+T75o30TCSmZCAxJV39eGG8bLqXNm7Ncift3tkAH0+33AWsfCssFbuRlmnVY8/ecALtaoaqtizjdL09LNTjFrE7aQkK+Nq0aYOoqCizYxK0rV+/Hs2aNVPXExIS0K1bN3Tp0gVz5szBwYMH8dhjjyE4OBhPPPGEKrNt2zY89NBDmDZtGvr06YPvv/8e/fr1w969e9GgQQNVZsaMGfjoo48wf/58REREqMfp3r07jhw5Am9vwwxkDz/8sKrPunXrkJ6ejuHDh6vHkPuzti5ERER062QpB+nKKVuV0n5WBXzP3l0DdcoFqoDETaNRe23WZa0WZsfcZZ913c30srGsVoN9F+LUF/2C66pBSrpOZSdlMxXs65EdBGbvwwMQ6O1RzLJd9n9sazNOXeqWVe+PXn9zLKkEWDcvy3F99mXkOG48ps+6ncjQ6TF5+eE8H1tM/PkgYhNTcT01E0mpxsDNckAnXZTl+dhKVIJ1y6LYwwd/nFCbUYC3e3bwJz8CGPZeCAv0Qqi/d9beS7X9/H7sYHdS29HojS25GJEgq0KFCiprJgGZkCzcyy+/jOjoaHh6eqpjEydOxLJly3Ds2DF1feDAgbh+/TpWrlyZfV+tWrVCkyZNVGAmL0X58uUxfvx4/O9//1Pn4+PjUbZsWXzzzTcYNGgQjh49inr16qnMnTHYXL16tcoS/vfff+r21tTFGhI4BgUFqToEBgaq571q1Sr1WB4e1v1HQFQYbGNkb2xjZA/yxbnd9A35zhAq4wi3vni3zcfwWfO4m17ohItxN3A8OtGwxSSo/ZnL15HXd/7yQd4qAyjBnzEYlOUqvNzdCvxCbHyGzsh2Ffax5buXTNITfyMdCTfSs/cSIN28bDh+9nIy9p6/OZGPK5DmKBMSBXh7qEApMGtv2DzU8/91f2SB9yNBtvz4UZDCfO2XsbNTVx4tsFzNMD/cSNepYDctQ2f1/csPIRL4hQZ6q70xEJR9GT8vvPTLQVy5nmbxtvb6my7q/1/mjA1cKsOX0/Lly3HlyhWVWTPavn07OnTokB1gCcnMSZfNa9euoVSpUqrMuHHjzO5LykggJs6cOaOCNMnMGcmL2rJlS3VbCfhkL5k6Y7AnpLx07dy5cyf69+9vVV0sSU1NVZuRvKnGN9y4Ga8T2QPbGNkb2xjZy8s9a2PMj/vznCFUzusyM6DLdPzjavSZqBjkiYpBpdG59s2urqnpmTh1+Tr+jUnC8ZgknFD7REQnpCIyPkVtG49fyi4vX2yrlvZFrTB/1Ajzw7c7Cpqo5jA61ixtl7FdrxeU7Vp6EJHXriMpNVMFb8YgToK3hBvmexsmupyuQfkA1Azzh78Ebl7u8Pd2Q4CXSRCnjt287Ovplm+WyzBBzBXEJKTm86OCFx5qZvsxoo0rBOCLzacLfOwVz7TJyqjqVfbyUlIaLiWmqgDwcpJxbzh2KSkVlxLTEHcjHemZ+ux2XljG7qTbTsSgVTXbdR8v6v9f3ur/ncUy4Js3b54KoCpWNAzmFhKoSRdMU5KZM56TIEv2xmOmZeS4sZzp7fIqExYWZnbe3d0dISEhZmUKqosl0tV0ypQpuY6vXbsWvr6+2delKymRPbGNkb2xjZE9DK+lwc9ntYhLu/nFN8hTj/uq6pB5bg9WnSuajys/DzeUrQyAMkByBhCVLJsme4tMBm5kQk1eIxsOW/OFOBUd31kLLzeZeMbYRRHQGfdZx8z2Jpezyxm7O2ZdNpTPP7iQL/RTfztu9WvoptHD1x3wcQN83AFfd332ZXXdTY/EdGBjVMHjw0bUykS1QEOIYlpL07jKeDH7kCZH2Ry3O5mgwZyjBT92x+A41PTJykJKcsokQZWUtRVWr3ANvkrQWqiZoWNqz7LJWLP691u4Z/s+tgQZ4VkbfLO2rK/YkghMSAcS0oDEdA3is/ZyXY5Lm7+SWnAAO/yb3ajgB4T76BHuq0e4D9S+lKf5+30rpJ2fStCo+gR6ANUD9Soj68z/L5OTk4tfwCfdHCXrlR/pQlmnTp3s69Jtcs2aNVi8eDFczaRJk8wykJLhq1SpkhoPaOzSKW96165d2RWK7IJtjOyNbYzsSaZgm6DTY8epS9iwfQ/ubt0UraqH2r3Ll/FxZd1AyWbIeKVmVUrZ9HElexKTmKqygbKtPxaL3edksfr8Rd9wXne3hhUCUbtsAIJ8DN0TjXtZTiPIx9iF0XDZy11b4OQ1ku3q+P7mAjNOLzzcwS5ZzWVWPPbogbZ/bGlfdx6OwZurjqnsr+l4yZd71kH3+uaJCld4bFn24pGvdhdYLkOvwbkk4FyS+Wvu5+mG6qF+qht0jTA/1Aj1V5lX6SotY3QLsuZwDKbleM7hgV54pZd9X++C/r809v4rVgGfjJUbNmxYvmWqVatmdv3rr79G6dKlcc8995gdDw8PR0xMjNkx43U5l18Z0/PGY+XK3ex3LtdlnJ+xTGxsrNl9ZGRkqJk7C3oc08ewxMvLS205yZts+sUo53UiW2MbI3tjGyN7kVbVtmYY4k/o1d5R7UwepV0t+34RrFTaE5VKB6BzPaBJ5RA8NHdHgbd5vkst1CsfqDIT2RPUmExSI8fUdY2hy6jhsnGyGsmS3JzgRuIx2f9zPg5PLyx4spqXetWz6Wyt8hq/fk99NXYwry60k/vWh7fXzSE1rvDYok+TiujZqIJTZmN1xmPL2oYSVBY0PvbrYc1VxvtEbKLqEi17GRsr40IPXExQmynpQmsIAv3VuFgJAmX23IqlfLIDQRmfKt20cz6uBPty3NGTxZj+f3mrn2dODfhkuQLZCvPrlgR8Q4YMyfWEW7durSZKkWjYeE6i4tq1a2d3oZQyMrPn2LFjs28nZeS4kG6YEpBJGWOAJ5G0jM0bNWpU9n3Icg179uxB06ZN1bENGzZAp9OpsX7W1oWIiIjoVskXbmu+EI++u4bNv5iH1fe26rGljrYmX7TlC3fO2UHDHTAzqTMf2x7LnRTlx5bHk9c0/wC7npp1Vzbg5msvS7acu2IYG2sMAk/EJOH05SQkSyD4n2EtT1PeHloVBNYM9ccfR2OdvvagrRWrMXwSWMnEKo8//niuc4MHD1bj30aMGIEXX3wRhw4dUmvjffDBB9llnnvuOdx11114//330bt3b/z444/YvXs3vvjiC3VefsWSYPDNN99U6+4Zl2WQmTdl+QZRt25d9OjRAyNHjlQze0pQN3r0aDWhi5Szti5ERERE9v5CbI8vpc58bCGBlXzhdka2y/jY20/GYu2WnejWvqXKRhWnL//Fxa0G2LJkS40wmdU2wDA41iwQTMbJ2ERDMBgrAWEiTl+6rpZNOXQxQW3WTBYjbc9ZwbfLB3wyWYusyWc6ps90Nk2Z3EQWO5fMW5kyZfDaa6+ZrXsnt5W18l555RW89NJLKqiTGTqNa/AJWRxdlm6Q20kmr127dmrZBeMafGLhwoUqyOvcuXP2wuuydl9h6kJERER0O5jtcl62q2VECK4c1as9gz37sWVw76ECQUN3zh43v/ojQwLBq8kqC7h830WsOmSYhDE/UpfipFgFfMaFzfPSqFEjbNmyJd8yDzzwgNryIlm+qVOnqi0vMiOnLepCREREVNyzXc54bCo57B3cu7tpUT3UX20ygZA1AZ+09eKkWAV8RERERFS0sl3FqWsbkS3GxtpjfKo9GRfWICIiIiIiKrHcssanipx5akeMT7UXBnxEREREREQm41Mlk2dKrjt6SQZbYZdOIiIiIiIiFx2fyoCPiIiIiIjIRcensksnERERERGRi2LAR0RERERE5KIY8BEREREREbkoBnxEREREREQuigEfERERERGRi2LAR0RERERE5KIY8BEREREREbkoBnxEREREREQuigEfERERERGRi2LAR0RERERE5KLcnV0Bypter1f7hIQEtU9PT0dycrK67uHh4eTakStiGyN7YxsjR2A7I3tjGyNntDFjTGCMEazFgK8IS0xMVPtKlSo5uypERERERFREYoSgoCCry2v0hQ0RyWF0Oh0iIyMREBAAjUajonoJ/i5cuIDAwEBnV49cENsY2RvbGDkC2xnZG9sYOaONSdgmwV758uWh1Vo/Mo8ZviJM3siKFSvmOi5vOj9cyJ7Yxsje2MbIEdjOyN7YxsjRbawwmT0jTtpCRERERETkohjwERERERERuSgGfMWIl5cXJk+erPZE9sA2RvbGNkaOwHZG9sY2RsWpjXHSFiIiIiIiIhfFDB8REREREZGLYsBHRERERETkohjwERERERERuSgGfERERERERC6KAV8x8sknn6Bq1arw9vZGy5YtsWvXLmdXiVzE66+/Do1GY7bVqVPH2dWiYmzz5s3o27cvypcvr9rTsmXLzM7LfGGvvfYaypUrBx8fH3Tp0gUnTpxwWn3J9drYsGHDcn2u9ejRw2n1peJn2rRpaN68OQICAhAWFoZ+/frh+PHjZmVSUlLwzDPPoHTp0vD398eAAQMQExPjtDqT67Wxjh075vose+qppwr1OAz4iolFixZh3LhxanrWvXv3onHjxujevTtiY2OdXTVyEfXr10dUVFT2tnXrVmdXiYqx69evq88p+aHKkhkzZuCjjz7CnDlzsHPnTvj5+anPNPnyRGSLNiYkwDP9XPvhhx8cWkcq3jZt2qSCuR07dmDdunVIT09Ht27dVNszev7557FixQosWbJElY+MjMR9993n1HqTa7UxMXLkSLPPMvk/tDC4LEMxIRk9+QVg9uzZ6rpOp0OlSpUwZswYTJw40dnVIxfI8Mmv4/v27XN2VcgFya+Rv/zyi/rlUsh/O5KVGT9+PP73v/+pY/Hx8Shbtiy++eYbDBo0yMk1puLexowZvri4uFyZP6JbdenSJZWFkS/pHTp0UJ9boaGh+P7773H//ferMseOHUPdunWxfft2tGrVytlVpmLexowZviZNmmDWrFm4VczwFQNpaWnYs2eP6vJkpNVq1XX5QCGyBelOJ1/Cq1Wrhocffhjnz593dpXIRZ05cwbR0dFmn2lBQUHqhy1+ppEt/fnnn+rLU+3atTFq1ChcuXLF2VWiYkwCPBESEqL28t1MMjKmn2UyHKJy5cr8LCObtDGjhQsXokyZMmjQoAEmTZqE5OTkQt2v+61Vhxzp8uXLyMzMVL9+m5Lr8ksS0e2SL9qSWZEvRdJVYMqUKWjfvj0OHTqk+pUT2ZIEe8LSZ5rxHNHtku6c0rUuIiICp06dwksvvYSePXuqL+Jubm7Orh4VM9KzauzYsWjbtq360i3k88rT0xPBwcFmZflZRrZqY2Lw4MGoUqWK+lH+wIEDePHFF9U4v59//tnq+2bAR0TqS5BRo0aNVAAoHy6LFy/GiBEjnFo3IqJbYdo1uGHDhuqzrXr16irr17lzZ6fWjYofGWclP4JyfDs5uo098cQTZp9lMtmZfIbJD1nymWYNduksBiSFK79G5pz1Sa6Hh4c7rV7kuuTXylq1auHkyZPOrgq5IOPnFj/TyJGku7r8f8rPNSqs0aNHY+XKldi4cSMqVqyYfVw+r2TYjYwVNcXPMrJVG7NEfpQXhfksY8BXDEh3gaZNm2L9+vVmaV+53rp1a6fWjVxTUlKS+uVIfkUisjXpYidfhkw/0xISEtRsnfxMI3v577//1Bg+fq6RtWSCKfkiLhMCbdiwQX12mZLvZh4eHmafZdLVTsbA87OMbNHGLDFOsFeYzzJ26SwmZEmGoUOHolmzZmjRooWaqUembB0+fLizq0YuQGZKlPWspBunTCkty39IVvmhhx5ydtWoGP9oYPrro0zUIv9JyUB0mdBAxim8+eabqFmzpvoP7tVXX1XjE0xnWSS61TYmm4xFljXR5McF+QFrwoQJqFGjhlr+g8jaLnYyA+evv/6qxrMbx+XJJFOyfqjsZdiDfEeTNhcYGKhmT5dgjzN0ki3amHx2yflevXqptR5lDJ8sBSIzeEo3davJsgxUPHz88cf6ypUr6z09PfUtWrTQ79ixw9lVIhcxcOBAfbly5VTbqlChgrp+8uRJZ1eLirGNGzfKkj+5tqFDh6rzOp1O/+qrr+rLli2r9/Ly0nfu3Fl//PhxZ1ebXKSNJScn67t166YPDQ3Ve3h46KtUqaIfOXKkPjo62tnVpmLEUvuS7euvv84uc+PGDf3TTz+tL1WqlN7X11ffv39/fVRUlFPrTa7Txs6fP6/v0KGDPiQkRP1fWaNGDf0LL7ygj4+PL9TjcB0+IiIiIiIiF8UxfERERERERC6KAR8REREREZGLYsBHRERERETkohjwERERERERuSgGfERERERERC6KAR8REREREZGLYsBHRERERETkohjwERERERERuSgGfERERHk4e/YsNBoN9u3bh6Li2LFjaNWqFby9vdGkSZPbui95bsuWLbNZ3YiIqOhhwEdEREXWsGHDVFDyzjvvmB2XIEWOl0STJ0+Gn58fjh8/jvXr1+dZLjo6GmPGjEG1atXg5eWFSpUqoW/fvvne5nb8+eef6j2Ji4uzy/0TEdGtYcBHRERFmmSypk+fjmvXrsFVpKWl3fJtT506hXbt2qFKlSooXbp0npnJpk2bYsOGDXj33Xdx8OBBrF69Gp06dcIzzzyDokyv1yMjI8PZ1SAichkM+IiIqEjr0qULwsPDMW3atDzLvP7667m6N86aNQtVq1Y1yxb269cPb7/9NsqWLYvg4GBMnTpVBRcvvPACQkJCULFiRXz99dcWu1G2adNGBZ8NGjTApk2bzM4fOnQIPXv2hL+/v7rvRx99FJcvX84+37FjR4wePRpjx45FmTJl0L17d4vPQ6fTqTpJPSQrJ89JAjUjyaDt2bNHlZHL8rwtefrpp9X5Xbt2YcCAAahVqxbq16+PcePGYceOHVZn6KQrqxyTAFKcO3dOZQlLlSqlsoxyn6tWrVLnJZgUck5uI6+38TnJexcREQEfHx80btwYP/30U67H/f3331WQKs9769at2L9/v7rPgIAABAYGqnO7d++2WHciIsobAz4iIirS3NzcVJD28ccf47///rut+5KMV2RkJDZv3oyZM2eq7pF9+vRRQcrOnTvx1FNP4ckn/9/e/b3i3cdxHP/cwn9gB3No8qOsaCmtKEVKKWprixSt7pyQtjDlQByJA8K2RG07WA5QfhyQciQHymqFQls5EeJg+ZGk++71rq++1+Vi1+W2lu/9fJTa9ev747OjV+/3+/P9+8p5FAhfv37tvn796vLy8iz0HBwc2GcKSIWFhS47O9sCiQLa7u6ue/78ecgxPn786BITE93i4qJ7//59xOvr7e11PT09rru723379s2CYVlZmdvc3LTPd3Z2LGTpWvTvN2/eXDnG4eGhXYMqeQpl4RR0b0vHPDs7s/VT1VCVV4VctYuOjY3Zd9RqqmvTvYjC3qdPn+yeV1dXXWNjo6uqqroSmltaWqx1d3193T1+/NhVVlZa8F1eXraQq88TEhJufe0A8H8V/6cvAACAXykvL7dqlwLa8PDwrY+jKl5fX5+Li4tzaWlprqury52cnLjW1lb7/O3btxY6VGF68eLF5e9UnVOlTN69e2eBStfR1NTk+vv7LewplHpGRkYsBG1sbFh1TVJTU+18N1HQa25uvjy3AtXCwoJVKwcGBqzSGR8fbyFL/45ka2vL2iLT09PdXdve3rZ1yMrKsteaD/SvrTx48OAyVCocal3m5+ctKHu/0fp++PDBFRQUXP5eVcuioqKQcyloe/eh9QMAxI7ABwC4FxR+VEmLVNWKlqpjCnsetV+qRdNfTdRc3N7eXsjvvLAiClxPnjyxSpSo9VChTCEs0rydF/jUkniTnz9/WvXx6dOnIe/rtc4RLYW936W+vt7V1dW5ubk5a7VV+FM17joKnwrU/iDnzTAqJPtpTf3Ufvrq1Sv3+fNnO9ezZ89cSkrKHd8RAAQfLZ0AgHshPz/fWhxVhQunEBcedM7Pz698L7wlULNjkd7T3Fm0jo6OrMVT827+P7Vh6po9kdorfwdVwnQPmjuMhReE/esYvoYKYN+/f7cZRbV0KqSp1famtZGZmZmQtVlbWwuZ44u0PppPVAtoaWmpteJmZma6iYmJmO4JAEDgAwDcI2q3nJqacktLSyHvJyUl2WMI/GHlLp+d59/oRJu8aKYsIyPDXufk5Fgw0QYxjx49CvmLJeRpY5KHDx/ajJ+fXivsREutlQrGagE9Pj6+8vl1j03QGorm725aQ7WqatZxfHzcZgmHhobsfc0nysXFxeV3dd3ahEXtmeFro+P8iqqjmvlTRbGioiLihjoAgJsR+AAA94Zmx7SZh+bw/LQL5v7+vs3IqY1SYUe7Pt4VHU/VJVXNtHGJHhFRW1trn+m1Nkp5+fKlbTCi88/OzrqampqQ8BMNzaypdXV0dNQ2P9FGJQpdDQ0NMV+vzp2bm2ubqajaqBZUrZu/PdXPC2GqrOn7qsppAxk/7TKqe/vx44dbWVmxVlYv+OoxEaosTk9P2/+FqnvaYVMtuApt2rRGa6PfqSqo19c5PT21uUnt4KmdQRV6tbbeuQAA0SPwAQDuFW3uEd5yqSAwODhoQUfb/utxBP9l1i9SZVF/OrY2HJmcnLTHK4hXlVPAKi4utlCqYKSNS/zzgtHOyGl2TZUzHUebw+hcsW5Yoo1RFKz0WAMdS3OKmqPTQ9e16Uwkam398uWLhVrN5Sl4dnZ2hnxH96iAq/UuKSmxCpzWXZKTk117e7uFVM1GKrBJR0eHa2trs906vd8pTOoxDdfRLKV2Qa2urrZzaMdTPfZCxwcAxOavf37ndDcAAAAA4I+hwgcAAAAAAUXgAwAAAICAIvABAAAAQEAR+AAAAAAgoAh8AAAAABBQBD4AAAAACCgCHwAAAAAEFIEPAAAAAAKKwAcAAAAAAUXgAwAAAICAIvABAAAAgAumfwHVUEu/QdCSKgAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1000x500 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Optimal number of clusters: 17\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 0: Best model is Ridge with CV MAE -0.24\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 1: Best model is LinearRegression with CV MAE -1.51\n",
-      "Cluster 2 has too few weighted samples after thresholding.\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 3: Best model is GradientBoostingRegressor with CV MAE -0.61\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 4: Best model is GradientBoostingRegressor with CV MAE -0.48\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 5: Best model is GradientBoostingRegressor with CV MAE -1.57\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 6: Best model is Ridge with CV MAE -0.27\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 7: Best model is GradientBoostingRegressor with CV MAE -0.95\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 8: Best model is GradientBoostingRegressor with CV MAE -0.70\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
-      "1 fits failed out of a total of 10.\n",
-      "The score on these train-test partitions for these parameters will be set to nan.\n",
-      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
-      "\n",
-      "Below are more details about the failures:\n",
-      "--------------------------------------------------------------------------------\n",
-      "1 fits failed with the following error:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
-      "    estimator.fit(X_train, y_train, **fit_params)\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\ensemble\\_gb.py\", line 734, in fit\n",
-      "    self.init_.fit(\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\dummy.py\", line 578, in fit\n",
-      "    self.constant_ = np.average(y, axis=0, weights=sample_weight)\n",
-      "                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
-      "    raise ZeroDivisionError(\n",
-      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
-      "\n",
-      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n",
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
-      "1 fits failed out of a total of 10.\n",
-      "The score on these train-test partitions for these parameters will be set to nan.\n",
-      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
-      "\n",
-      "Below are more details about the failures:\n",
-      "--------------------------------------------------------------------------------\n",
-      "1 fits failed with the following error:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
-      "    estimator.fit(X_train, y_train, **fit_params)\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 622, in fit\n",
-      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
-      "                                        ^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 184, in _preprocess_data\n",
-      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
-      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\utils\\_array_api.py\", line 716, in _average\n",
-      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
-      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
-      "    raise ZeroDivisionError(\n",
-      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
-      "\n",
-      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "No valid model found for cluster 9.\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
-      "5 fits failed out of a total of 50.\n",
-      "The score on these train-test partitions for these parameters will be set to nan.\n",
-      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
-      "\n",
-      "Below are more details about the failures:\n",
-      "--------------------------------------------------------------------------------\n",
-      "5 fits failed with the following error:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
-      "    estimator.fit(X_train, y_train, **fit_params)\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_ridge.py\", line 1249, in fit\n",
-      "    return super().fit(X, y, sample_weight=sample_weight)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_ridge.py\", line 956, in fit\n",
-      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
-      "                                        ^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 184, in _preprocess_data\n",
-      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
-      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\utils\\_array_api.py\", line 716, in _average\n",
-      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
-      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
-      "    raise ZeroDivisionError(\n",
-      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
-      "\n",
-      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan nan nan nan nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 10: Best model is RandomForestRegressor with CV MAE -0.61\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 11: Best model is RandomForestRegressor with CV MAE -0.45\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 12: Best model is GradientBoostingRegressor with CV MAE -1.95\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 13: Best model is RandomForestRegressor with CV MAE -0.42\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 14: Best model is Ridge with CV MAE -0.30\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 15: Best model is GradientBoostingRegressor with CV MAE -1.78\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "Cluster 16: Best model is Ridge with CV MAE -0.25\n",
-      "FeatureStacker - Transformer 'gmm' output shape: (860, 18)\n",
-      "FeatureStacker - Combined features shape: (860, 28)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n",
-      "FeatureStacker - Transformer 'gmm' output shape: (3437, 18)\n",
-      "FeatureStacker - Combined features shape: (3437, 28)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3gAAAHWCAYAAAAl5yv5AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAnxhJREFUeJzs3Qd4U9X7B/Bv0r1LgdKy9957C7KHCqIyBEQRFMWfCIrgAFH/IrjAiaIgKCqCiopMQURlg+yNbDpYbWlLZ+7/eU+akrRpGyBtRr+f57ne5N6T3JP0EPPmPUOnaZoGIiIiIiIicnl6R1eAiIiIiIiI7IMBHhERERERkZtggEdEREREROQmGOARERERERG5CQZ4REREREREboIBHhERERERkZtggEdEREREROQmGOARERERERG5CQZ4REREREREboIBHhGRm6lcuTJGjBjh6GqQA3z55ZfQ6XQ4deoUiotOnTqpzV2uXRz/hkRkXwzwiKhY+fjjj9WXp1atWuVZRs6PHTs21/GEhARMmzYNjRo1QmBgIPz8/FC/fn08//zzuHDhAlyNvE7zLSAgAHXr1sXrr7+O5ORki7ISMMprtuann35Cr169UKpUKXh7e6Ns2bJ44IEHsH79+nyvL9d45ZVXsGHDBru+LvlibP66vLy8VN3atm2LF154AWfOnLnl5y6sOrsLTdPw1VdfoWPHjggNDYW/vz8aNGiAV199FUlJSbf8vAcPHlTvuysHPZmZmZg/f74KCMPCwuDj46N+jHn44YexY8eOIqvHihUr1HtJRO7L09EVICIqSosWLVJfqrZt24bjx4+jevXqNj3uv//+Q9euXVVwcP/992P06NEqmNm7dy+++OILFeQcPXoUrqZbt24YPny4up2YmIi//voLL7/8Mvbs2YMlS5YU+GX+kUceURmHJk2aYPz48YiIiEBUVJR6P7p06YJ//vlHBVZ5BUsSMIvCyMAMHjwYvXv3hsFgwNWrV7F9+3bMmjULs2fPVn+zQYMG3fRzFnadb9ewYcPU65LgwREBzJAhQ/D999+jQ4cOKoiQAE/alLxn0p5+//13lClT5pYCPHkOec/l36+5NWvWwNldv34d9957L1atWqWCX/mhQYI8CVjl/VqwYIH6bClfvnyRBHgfffQRgzwiN8YAj4iKjZMnT2LTpk348ccf8dhjj6lgb+rUqQU+LiMjQ305i4mJUZmb9u3bW5z/v//7P8yYMQOuqGbNmhg6dGj2/ccffxxpaWnqPUpJSYGvr2+ej33nnXdUcDdu3Di8++67Kltm8uKLL6pMjqen4/4307RpU4vXJk6fPo3u3bvjoYceQp06dVQ21hlIdksyqLfLw8NDbY4wc+ZMFaw8++yzeOutt7KPy48hktHt16+fygSvXLnSrteVH1qc3XPPPaeCu/fee0/9ezEnn0Fy3JXJjz3yeSG9GojICWhERMXEa6+9ppUoUUJLTU3VxowZo9WoUcNqOflofPLJJ7Pvf/fdd+rY//3f/93ytU+dOqWuWbNmTc3X11cLCwvT7rvvPu3kyZMW5ebPn6+u9ffff2vPPPOMVqpUKc3f31/r16+fFhsba1HWYDCo11SuXDnNz89P69Spk7Z//36tUqVK2kMPPVRgnXK+TpOxY8dqHh4eWnp6evYxeb6AgIDs+8nJyeo11K5dW8vIyLjp90Net1w/5zZ16tTsMuvWrdPat2+vXn9ISIh29913awcPHrT5ud966y2r5zdt2qTODxkyxOL41atXtaefflorX7685u3trVWrVk178803tczMTJvrfOjQIW3AgAGqnfn4+GjNmjXTfv75Z6t/4w0bNqg2Ubp0aS00NFSdu+OOO7R69eppe/bs0Tp27Kj+rlKPJUuWqPPymJYtW6o2JG1p7dq1Vp/bvF1Je+jTp4/2119/aS1atFD1qlKlirZgwYJc701B70FepD3Ia5Y6mbcbcw8//LCq2+bNm3PVbfXq1VqjRo1U3erUqaP98MMPuV5Tzu2PP/7Ifs9kM5Hjcn7x4sXaK6+8opUtW1YLDAxUf5e4uDgtJSVFvUZ536VNjxgxQh0zN2/ePK1z586qjLwPUqePP/4412vKeW1rzp49q3l6emrdunXLt1x+f8Oc7cz8/TP/t56WlqZec/Xq1dV7Kf9G27Vrp61Zs0adl7LW3ksT+Tu/9957Wt26ddXjw8PDtdGjR2tXrlzJdV35u61atUq1cSkrjxNyLbmm/JuV91faxOTJk2167URkH8zgEVGxIRk7ycTJL/7Sfe+TTz5R3fZatGiR7+N++eWX7O5vt0quI9lD6T4n3bCka5ZcX7qcSfcz6cpm7qmnnkKJEiXUr/tSVroWyrjAxYsXZ5eZMmWKGi8n3RBl27Vrl8pOSQbOVvKr+6VLl7KzSNKlUrqLSVe7/LJvf//9N65cuaKyEbeSMSpdurR6/WPGjEH//v3V30U0bNhQ7aUrn4zrq1q1qupKJl3cPvjgA7Rr1069zpzd9G5GmzZtUK1aNaxdu9ai6+Udd9yB8+fPq+xuxYoV1d9r8uTJqsupvP8F1fnAgQOqfuXKlcOkSZNURk4yWpK5+uGHH9RjzD3xxBPqOeXvaD4+TbqT9u3bV7UV6Q4s15Tb0n7l/ZYsq/x9JEt233334ezZswgKCsr3NUt3ZCk7cuRIlb2cN2+eyqY1a9YM9erVs/k9yK89SL2ffvrpPNuNdAWWMWjLly9H69ats48fO3YMAwcOVK9L6iZl5HVLxku6EEuXxv/97394//33VddGybwK0z4v06dPVxkl+VvI65f2I+Mx9Xq9qqu0qy1btqgsdJUqVdTfwUTec3lf7r77bvV6fv31V/X3ku6+Tz75JG6GZCylF8DtfH7YSl6TvO5HH30ULVu2VOOGZXyf/JuR91L+rjJeWNq+ZNhzkvPyfsi4QHnPpdfDhx9+iH///Vd9Nsj7Z3LkyBH1OSqPGTVqFGrVqqX+DUjblX8TMu5SugrLey+PJaIiZKdAkYjIqe3YsUP9Um3KeEj2S7IU8kt+QZmtJk2aqF+jb4dkOHKSTIZca+HChbl+ve/atauqo4lk8ySrJhkIIdk8ySzIr+jm5V544QX1eFszeNY2yRbmzGjkzODNnj1blf3pp5+0W3Xx4sU8MxONGzdW2YPLly9nH5Osll6v14YPH35bGTxxzz33qDLx8fHqvmRC5fUdPXrUotykSZPU+37mzJkC69ylSxetQYMGFu+d/G3atm1rkS02/Y0lO5kz+ynZIDn3zTffZB87fPiwOiavfcuWLdnHJeslx+X5CsrgybGNGzdmH5P2I1mXCRMmZB+z9T2wZtasWQW2B8kCSZl77703V93MM3byN4mMjFT/7kwkg2metcv5nlnL4NWvX19ltEwGDx6s6XQ6rVevXhaPb9OmjapHQf9ee/TooVWtWjXfa1sj/3alPv/++69W2Bk8yYLKZ0J+5LPN2tc/yfDK8UWLFlkclyxdzuOmv5ucMydZPDku/06IyHE4iyYRFQuS/ZDJHTp37qzuy3gxyRp89913anKI/Miv4AVlSApiPjYlPT0dly9fVhO8yEyD8ut6TjJuyXxMm0xaIfWUMWSmDJdk6iTTZ14u5/iegtxzzz3q13zZfv75Z5WtkcyJZIiM3yvzfk/E7b4v1ki2aPfu3SrDJBNRmEhWQLIQMknE7TLNCHrt2jW1lwlA5D2WrKlkNE2bTKwj7/vGjRvzfT7JZsqsoTLWTJ7T9Hj5O/fo0UNlqSQzZk6yHtayn1I38wlgJDMi7UQyVuazv5puywRABZHZUeX1mUjmUJ7X/LG38x6Y3sf82oPpnKntmMisq+bZzeDgYJXtk6xRdHQ0bpU8h3nGSd4v08RA5uS4ZEEly2bt32t8fLx6HyS7Ke+X3L8ZhflvJSdpJ5JFk/Z2s+TvHxISov6Nmf/9JcsrbfKPP/6wKC9ZT2nbOa8v5LNEsp1E5BjsoklEbk++nEogJ8GddDky/2InE4WsW7dOdW3Mi3zhtOVLdH6ki6F0nZLuZ/JF3zx4svaFUbrHmZMv3UK6lglToFejRg2LcvLF3VTWFtJdVL7Am0iXtJIlS6qJMqQr3V133ZXne2L+xd6eTK9NApCcJMhZvXr1bU9KIjOGmn/pli/EMiOqvH/WxMbG5vt80g1N/qYyA6lseT2HdN80/4Kc19/EPGgX8sW7QoUKuY6Zt4n85GxPQtqJ+WNv5z0wvY/5tYe8gkD5oSPn65XJf4R0T5aZWW9Fztdser+svY8SjMi/Q2n7QroUSvfozZs351oyRMqZnssWhflvJSfpFik/2sj7J0u49OzZU3UNNXUjzo/8/eW1hYeH2/T3t9Z+5Uezzz//XHURla6xMpOudGWW7sHSNZaIigYDPCJye5JZkayQBHmyWcvu5Rfg1a5dW2UT5Ff+nF8ObSWZNgnuJMMmY8DkC6J8qZVMjbVfuvMa15ZfVs1e5EuZkIxNXgGevCdi3759aoyZq9m/f7/6Imv68i1/A8lcTJw40Wp5U8CRF9PfUALjnFkNk5xLcuQ142Bef/vbaRO2PPZ23gPTeDgJEPNqD3LOlE0sCrf6Pp44cUL9G5A2LrPDyr95GbcrmWOZ7fJmM1Pm/1YaN24Me8rZ+0DGK0r9JYMmy0dIsCV1njNnjgq68iOvS/5NyOehNTkDf2vtV47J54Zk+3777TfVG0DGDd95552qPo6a4ZWouGGAR0RuT76wyBcXWfspJ1kOQNZsky9AeX3hliDn22+/xddff626MN6KpUuXqgkkJGNoPsFJXFzcLT1fpUqVsn91l4lITC5evGhTRic/pq5qpiyXNbJUhGSA5H2RiS9u5YtbzqxNztcmkzjkdPjwYbVo+e1k7yQrI1+CzZdQkElX5PWaZzNvps6mv4F0CSzoOZyVre9BXu1Buud98803aokMa+1h4cKFai+TcFjLfpq/t6Y1JU2T6eT1vhcGmVAlNTVVTa5kngXM2UXRVjJZkLwf8vlxqxOtyL+1nJ8V0kVbfrjKSbo1yyQpssnfU4I+mXzFFODl9V7K31+6fstEQbez3IFk6iRAlk0C5DfeeEO1CXn/XPXfBpGrYb6ciNyadI2UIE6+VEo3oZybzEwpXadMM2VaI+UaNGig1ruT4CAnebx8gcmPfMHLmWmRWf0KGv+XF/miJMGEPIf58+Y30+HNfMEV+a0RJ7N+Pv/88zh06JDaW8siyRdaWVA+v+cQOb+4RkZGqkyHzOZpfk6ybpIFkBlDb6f7p4ztk4yMrE1mImPn5G8r3T9zkjqYgt686iw/IMiMqJ9++qnVL90SeDs7W98Da+R9keylBOXW/i1INkdmZ5TspvkMmkJmdZQfWczHrEkwKG3A1D3TFNDf6g8iN8MUnObsRi0Z+FshGUAZbyltV/69WsucyQ8/586dy/M5JPjKOQbys88+y/X5IWM+zcnYOckcS8Bqktd7KX9/eb7XXnst1/Xlb2/Ley9jUXMyZS3N60BEhYsZPCJyaxK4SQAmY8uskS+b0vVIsnwyfsQaCaQkSJSgSn4Nly9C8iu3HJcJDSRrIb+wSwCYFwkwZVpy6ZopXdTki7T8Wm4a83OzpM7yhVrG9clzS9Aj3UhlSnbJcNlKMiUSiAkZayTTxktgJV8KC8o2SIAkr1++nMqv8xIIyxdymRhj2bJlKriTafbzIlkCeS+kC5d0/5PMg4wbkk2WAJDMh3Rnlan9TcskyPsn2QhbyOQ18trkC7R8OZWlKmS5AslgyN/CfFySvBZpK/JempYPkHF+0q1Osq8yFkze1/zqLBliyWTJjwHyhV6yejExMepvLV/e9+zZA2dm63uQFxlzJW1wxowZ6jUPGDBAvV+yhIL8HaQbp7StnOR9lL+x/H1kIiRZwkHeN/OASoIECbzkuSXYkun3pdtfXuPFbod015YfACRzL0sASBZs7ty56lrWgndbyL8RyRrL0gOmH5zkM+PMmTNqchPJTJtPrJOTZN9kGQl5T6UbrbQlCcRz/j2kbcoPDfK3k7YpSyTI305+yDKRc0LqIgG3vK9ybZlERl6vfKbIJEfyPshnnPQSkDrOnj1b/RsvaAygBKJ9+vRRmXgZt/fxxx+rcaXyb4OIiogDZ/AkIip0d911l1oUOikpKc8ystCxl5eXdunSpXwXAJdFoKdMmaKmwpfFt+V5ZSp2WcQ3Kioq33rIY2WhZ1m4XBZdlinXZfr7nNOcm6ZI3759u8XjTVO/m08TL4sST5s2TU0pf6sLnZtvMhW+LB0hCxvHxMTku0yCuaVLl2rdu3dXiyrLgs5Sn4EDB6pFuQsii47LQsmy5EPOqeB///13tWCyvLbg4GD1t7yZhc5Nm9RJ6taqVSv1tzp9+rTVx127dk2dl0WipT7yt5IlDt5++22L6fbzq/OJEyfUMg4RERGqTcki9H379lXvUUF/Y/OFznMyLSydU862mt9C59aulXOKf1vfg7xIm5Q6yN9N/mbyb0Rej7TTxMTEPF+XLPnQsGFDtXRD7dq1sxd2Nzd37ly1TIG0U1sWOs/5HHm97/L3yzm1/y+//KLqI/WvXLmyNmPGDLX4ec731pZlEkxkSYzPP/9c69Chg1p2RdqHvH75XDBfQsHa31De1+eff179PeSzRz4/jh8/nuvf+uuvv661bNlSCw0NVf9u5L38v//7P4u/ndTjqaeeUou4y7IROb8KfvbZZ6p9y+ODgoLU593EiRO1Cxcu5Pq75bRu3Tq1BIksLi/tR/ayPEXOpTeIqHDp5D9FFUwSERERmcgYO8l+yoytRERkHxyDR0RERERE5CYY4BEREREREbkJBnhERERERERugmPwiIiIiIiI3AQzeERERERERG6CAR4REREREZGb4ELnTkwW571w4QKCgoLUwrxERERERFQ8aZqGa9euoWzZstDr887TMcBzYhLcVahQwdHVICIiIiIiJ3H27FmUL18+z/MM8JyYZO5Mf8Tg4GB1Oz09HWvWrEH37t3h5eXl4BqSK2NbInthWyJ7YVsie2FbIndsRwkJCSr5Y4oR8sIAz4mZumVKcGce4Pn7+6v7ztDQyHWxLZG9sC2RvbAtkb2wLZE7t6OChm5xkhUiIiIiIiI3wQCPiIiIiIjITTDAIyIiIiIichMcg0dEREREREU21X9GRgYyMzPhCmPwPD09kZKSUiT19fDwUNe73eXRGOAREREREVGhS0tLQ1RUFJKTk+EqwWhERISa0b6o1qSWSV0iIyPh7e19y8/BAI+IiIiIiAqVwWDAyZMnVZZKFuqWAKaogqbbqXNiYiICAwPzXVjcXsGkBMAXL15U71ONGjVu+ZoM8IiIiIiIqFBJ8CIBk6zjJlkqV2AwGFS9fX19Cz3AE35+fmo5htOnT2df91ZwkhUiIiIiIioSRREoFff3h+8wERERERGRm2AXTSqYIRM4vQlIjAECywCV2gJ6D0fXioiIiIiIcmCAR/k7+Au0Vc9Dl3Ah+5AWXBa6njOAunc7tGpEREREVPxkGjRsO3kFsddSEB7ki5ZVwuChd+4JW4oSu2hS/sHd98OhmQV3Qu7LcTlPRERERFRUVu2PQvsZ6zF47hY8/d1utZf7crywbd68Wc0C2qdPH4vjp06dUjOC7t692+L4Dz/8gE6dOiEkJETNxNmwYUO8+uqruHLlSqHWkwEeWWfIxPVfn1NTtuZsJHJfjst51X2TiIiIiKiQSRA35utdiIpPsTgeHZ+ijhd2kPfFF1/gqaeewsaNG3HhgmUCJKcXX3wRAwcORIsWLbBy5Urs378f77zzDvbs2YOvvvqqUOvJLppkVeapf+B3PRrII9stWXA5L+U8qnYs6uoRERERkYtTCYP0TJu7ZU795QA0a88D41fWV345iHbVS9nUXdPPy+Om1uGT9fAWL16MHTt2IDo6Gl9++SVeeOEFq2W3bduGN954A7NmzcLTTz+dfbxy5cro1q0b4uLiUJgY4JFVJ/47gZq2lmOAR0REREQ3SYK7ulNW2+W5JMiLTkhBg1fW2FT+4Ks94O9teyj0/fffo3bt2qhVqxaGDh2KcePGYfLkyVaDxEWLFqkumU888YTV5woNDUVhYhdNsipWC7VrOSIiIiIiV/XFF1+owE707NkT8fHx+PPPP62WPXbsGKpWraoWLXcEZvDIKo/K7XDh7zBE4IrqjpmTpgHRCFPliIiIiIhulnSTlEyaLWTWzBHztxdY7suHW6hZNW25tq2OHDmiul3+9NNP6r6np6caXydBn0yiYq3rqSMxwCOrWlYrjRe9HsUb6TNh0Ixj7kykzUo2OhNeaBnhyFoSERERkauS7o22dpPsUKM0IkN81YQq1sIn+aoaEeKrytl7yYR58+YhIyMDZcuWtQjifHx88OGHH+YqX7NmTfz9999IT093SBaPXTTJKvmH0anfI3gifZzK1Jm7hBAkaH4ojxh4zO8JXD3tsHoSERERUfH4bjr1rrrqds7wzXRfznvYObiTwE5mvZQZMGUZBNMms2FKwPftt9/mesyQIUPUpCwff/yx1efkJCvkMD3rRwJDHsf9v7RDhcQ9CEccYhGKA571UCr9Ar7yno7yV04AX3QHhv0IlKnn6CoTERERkRt/N/1kaFNM+/WgxVIJkrmT4E59d7Wz1atX4+rVqxg5cqRaz87cgAEDVDdNGZNnrlWrVpg4cSImTJiA8+fPo3///ioYPH78OObMmYP27dtbzK5pbwzwKF/yD6Vb3QhsO9kMsddSEB7kixaVS+C934/i3j+mYaH3m6ideBba/F7QDfkeqNja0VUmIiIiIrf/bnol+7upjLmzd+bORLJ3Xbp0yRXcmQK8mTNnIiEhIde5GTNmoFmzZvjoo49UUGcwGFCtWjXcd999eOihh1CYGOBRgeQfTJtqJS2OPdejtuoz/cDql/GF99tokXIU2sJ7oLt/AVDL8lcMIiIiIqLC/G5aWL777jsEBwdbPdeyZcvsCVWsTazywAMPqK2ocQwe3bInO1fH031bYljaZKzLbAJdRgq074YAu3P3RSYiIiIiosLHAK+QSVpWVq339fVV/XFlilV3MrJ9FUzp3xyPZzyDHzI7QKdlAsseBzZ94OiqEREREREVOwzwCtHixYsxfvx4TJ06Fbt27UKjRo3Qo0cPxMbGwp0MaVURMx9ohuczH8dnGX2MB9e8BKydYlxTgYiIiIiIigQDvEL07rvvYtSoUXj44YdRt25dNcDS399fraXhbvo3KY8PBjfDW9pQvJE+2Hjwn9nAz2OBzAxHV4+IiIiIqFjgJCuFJC0tDTt37sTkyZOzj+n1enTt2hWbN2+2+pjU1FS1mZhm5JFFEmUz3TbfO5OutUvh4yGNMfZbHa6mB2GG1+fQ7/4ahqRLyOw/F/Dyc3QVyYwztyVyLWxLZC9sS2QvbEvOR/4WMhGJzCYpmyvQzCZQKao6y3XkevJ+eXh4WJyztT3rNGtTvtBtu3DhAsqVK4dNmzahTZs22cdlTYw///wTW7duzfWYV155BdOmTct1/JtvvlGZP1dxNF6HuYf16Ihd+Mj7ffggHZcCamFr1XHI8AxwdPWIiIiIqIh5enoiIiICFSpUgLe3t6Or49RJorNnzyI6Olotsm4uOTlZLaIeHx+f58yeghk8JyLZPhmzZ57Bk38E3bt3z/4jSuS+du1adOvWDV5eXnBGvQF0PBOHkQu9MCx1Eub5votSSUfQO+ZDZAxaDARFOLqK5CJtiVwD2xLZC9sS2QvbkvNJSUlRgUtgYKCafNAVaJqGa9euISgoCDpd4ayzZ+198vPzQ8eOHXO9T9bW27OGAV4hKVWqlEqrxsTEWByX+/LrhTU+Pj5qy0k+mHJ+OFk75kxaVSuNb0e1xrB5Otx//SUs8p2JsNgD8FrYBxj2E1CymqOrSC7Slsh1sC2RvbAtkb2wLTmPzMxMFSTJkCXZXIEhq1umqd5FQa4j18vr+79Nz1FIdSv2JPUsq9evW7fOopHIffMum+6sQfkQLB7dBhcDauKelCk4r4sA4k4D83oAUXscXT0iIiIiIrfDAK8QSXfLuXPnYsGCBTh06BDGjBmDpKQkNatmcVErIgjfP9YaGcGVcM/1qTiqqwIkXQTm9wFO/uXo6hERERGRqzFkGr9H7ltq3Mt9ysYArxANHDgQb7/9NqZMmYLGjRtj9+7dWLVqFcqUKYPipGrpQHz/WBv4h0ViwPUXsVNXH0i7Bnx9L3DwF0dXj4iIiIhchXx3nFUfWNAX+GGkcS/3C/E75cMPP6y6TZq2kiVLomfPnti7d292GTm+bNkyi8f98ccf6N27tyovEybKsmkTJkzA+fPnUZgY4BWysWPH4vTp02r5A5k5s1WrViiOKoT5qyAvvHRpDLn+LNbrWgGZacCSh4CdXzq6ekRERETk7CSI+344kHDB8nhClPF4IQZ5PXv2RFRUlNpkyJXMCtq3b988y3/66adqeTSZe+OHH37AwYMH1ZrYMgPmO++8g8LESVaoyESE+GLxY20w9POteDT6KbzlG4gB2jrg16eBpEtAhwny84ejq0lERERERUFWa0tPtq2sdMNcOVEeZO2JJIcGrHoeqNoJ0FuuH2eVl/9Nfe+UiRBNEyXKftKkSejQoQMuXryI0qVLW5Q9d+4c/ve//6ntvffeyz5euXJlNTtmXFwcChMDPCpSpQJ98N3o1nho3jZMOPcILvuEYLTuR2D9a8Ygr8cbMn2Qo6tJRERERIVNgrs3ytrpyTRjZu/NCrYVf+EC4H1r6zMnJibi66+/RvXq1VX3y5yWLFmi1rOT9a+tCQ0NRWFigEdFLtTfG18/2gojv9yBN07dh0veQXhBvwDY+gmQfAm452PjLy+nNwGJMUBgGaBSW9t+jSEiIiIisrPly5erNfyETJoYGRmpjllbPuHYsWNqDWsp4wgM8Mghgny9sOCRlhj91Q58dqwHrngFYabnHOj3LQEuHjHOtHkt6sYDgssCPWcAde92ZLWJiIiIyF6km6Rk0mwhP/wvuq/gcg8uNSYGbLn2TejcuTM++eQTdfvq1av4+OOP0atXL2zbtg2VKlXKtUB6US2Mbg37wpHD+Hl7YO7w5uhaJxxL09vi0fQJyNR7A9F7LYO7Iho8S0RERERFSIIg6SZpy1btTuMP/jLWzvqTAcHljOVseb6bDMACAgJUl0zZWrRogc8//1xl8mRJtJxq1qypJlORCVkcgQEeOZSvlwc+GdoMfRtGYkNGA1zN9LU6dDZ7QO2qSVzrhIiIiKi4kaE60ptLyRmcZd3v+WaRDemRDJ10z7x+/Xquc/fddx+8vb0xc+ZMq4/lJCvk9rw89Jg9qAnqpe1FqVMJBQyePW9M0VfpUIQ1JCIiIiKHk6E6Dyw0zpZpvlSCGsrzZqEO5UlNTUV0dHR2F80PP/xQTbZy11135SpboUIFNXumLJeWkJCA4cOHqxk0ZXbNhQsXqrF8hblUAgM8cgoeeh0eaxoAnLKhsEy8QkRERETFjwRxtfsU+WR8q1atyp40JSgoCLVr11azZXbq1Mlq+SeeeEJ11Xz77bfRv39/lemTIE/Wzhs/fnyh1pUBHjkNTf6B2iAzIBycT5OIiIiomJJgrgh7c82fPx8LFizIt4xMrJKTLHQuW1HjGDxyGtsya+OCFgaDlvdamBe0kqocERERERHlxgCPnEZsUjqmpQ9Xt/MK8pZltFPliIiIiIgoNwZ45DTCg3yx2tASY9LHIRphFueSNB81m+1wzzWonGHLQD0iIiIiouKHY/DIabSsEobIEF+siW+JtanN0VJ/GOGIQyxCsctQHV96zURbj4No+PfjQJ0NQEBJR1eZiIiIiMipMINHTjWT5tS76qrbGvTYYqiLXwxt1T4N3ngi/WnEeJaFLu6McdHzjDRHV5mIiIiIboK1yUjIvu8PAzxyKj3rR+KToU0REeJrcbyEvxfiEIQHk8Yh3TMAOP03sHKiceYVIiIiInJqXl5eap+cnOzoqjg10/tjer9uBbtoklMGed3qRmDbySuIvZaixuZJ98131x7BR38AY1OfxByPt6DbOR8oUw9oOcrRVSYiIiKifHh4eCA0NBSxsbHqvr+/P3QywYITMxgMSEtLQ0pKCvR6faFn7iS4k/dH3id5v24VAzxy2u6abapZjrEb360W9p9PwOqjjfGxzzA8mbEQWPk8UKoGUNX6IpNERERE5BwiIiLU3hTkOTtN09QC5X5+fkUWjEpwZ3qfbhUDPHKpoO/9QU1w14d/460rPdAw7AI6JP8OfP8QMGo9ULKao6tIRERERHmQICkyMhLh4eFIT3f+Za/S09OxceNGdOzY8ba6TNpKrnE7mTsTBnjkUkL8vfDZ8Gbo/9EmPHplKNaXika5xP3At4OAR38HfEMcXUUiIiIiyocEMfYIZAqbh4cHMjIy4OvrWyQBnr1wkhVyObUjgvHW/Q2RCm/0uzQG133LAJeOAktHAoZMR1ePiIiIiMhhGOCRS+rbsCweu6MqLqIEhiaNg8HTFzi+Fvh9qqOrRkRERETkMAzwyGVN7FEbHWqUws70SnhVP9Z4cNMHwO5vHF01IiIiIiKHYIBHLj/pSvkSfvgyoSmWBT9oPPHr08CZrY6uHhERERFRkWOARy6tRIA3Ph3WDL5eejwT2wtHwzoBmWnA4qFA/DlHV4+IiIiIqEgxwCOXV69sCGYMaAgNevS7MBwJIbWApFjg28FAWpKjq0dEREREVGQY4JFbuKdxOYxsXwXJ8MW9V59Chm9JIHovsGwMYDA4unpEREREREWCAR65jcm9aqN11TAcTwvDM7pnoem9gIM/AxtnOrpqRERERERFggEeuQ1PDz0+GtIUZUN88evVSviyxP+MJzZMNwZ6RERERERujgEeuZWSgT74dFhzeHvqMe18M+yKHGw88dPjQNReR1ePiIiIiKhQMcAjt9OgfAim92+gbt9/sjcuRXQA0pONk64kxjq6ekREREREhYYBHrmlAc3KY0TbysiEB+6KegRpoVWBhHPAdw8CGamOrh4RERERUaFggEdu68U+ddCychiiUn0wKn0CNJ9g4Nw2YPkzgKY5unpERERERHbHAI/clpdMuvJgU0QE++LPyyUwu8SL0HR6YPciYPNHjq4eEREREZHdMcAjt1Y6yAdzhjWDt4ces05VwF9VnjGeWPsycGyto6tHRERERGRXDPDI7TWuEIrX+9VXtx861BQXqt4HaAZg6SPAxaOOrh4RERERkd0wwKNi4YEWFTC0dUVomg59/rsXKZEtgdQE4NuBQPIVR1ePiIiIiKh4BXj/93//h7Zt28Lf3x+hoaFWy5w5cwZ9+vRRZcLDw/Hcc88hIyPDosyGDRvQtGlT+Pj4oHr16vjyyy9zPc9HH32EypUrw9fXF61atcK2bdsszqekpODJJ59EyZIlERgYiAEDBiAmJuam60JFa0rfemhWqQSupgDDro2FIbg8cOU/YOnDQCb/NkRERETk+lwmwEtLS8P999+PMWPGWD2fmZmpAiopt2nTJixYsEAFb1OmTMkuc/LkSVWmc+fO2L17N8aNG4dHH30Uq1evzi6zePFijB8/HlOnTsWuXbvQqFEj9OjRA7GxN9ZPe+aZZ/Drr79iyZIl+PPPP3HhwgXce++9N1UXKnqy+PknDzZFeJAPtl/yxBshU6F5BQD/bQBWv+Do6hERERERFZ8Ab9q0aSqwatDAuIB1TmvWrMHBgwfx9ddfo3HjxujVqxdee+01lY2TQEvMmTMHVapUwTvvvIM6depg7NixuO+++/Dee+9lP8+7776LUaNG4eGHH0bdunXVYyQLN2/ePHU+Pj4eX3zxhSp35513olmzZpg/f74K5LZs2WJzXcgxwoN98cnQZvDy0OHzYwFYVfMV44ltnwI75gEn/wL2LTXuDZmOri4RERER0U3xhJvYvHmzCv7KlCmTfUwyb5LxO3DgAJo0aaLKdO3a1eJxUkYyeUKCr507d2Ly5MnZ5/V6vXqMPFbI+fT0dIvnqV27NipWrKjKtG7d2qa6WJOamqo2k4SEBLWX68lmum2+p5vXsGwgpvSpg5d/OYgndpXD782eRrX9s6EtfwY6s3JaUFlkdn8DWu2+cEdsS2QvbEtkL2xLZC9sS+SO7cjWerhNgBcdHW0RUAnTfTmXXxkJpK5fv46rV6+q7pXWyhw+fDj7Oby9vXONA5QyBV3HvC7WTJ8+XWUqc5KMoGQRza1dyyn+b0cwgDbhemyO1WP2bmC2JyyCO+XaBXj8MALbqzyFqNAWcFdsS2QvbEtkL2xLZC9sS+RO7Sg5Odn5A7xJkyZhxowZ+ZY5dOiQypAVB5I5lPF/JhJ4VqhQAd27d0dwcHB25C6NrFu3bvDy8nJgbV1flwwDhn2+BZMufWX1vAR8GnRocflHZAx6CdB7wJ2wLZG9sC2RvbAtkb2wLZE7tiNT7z6nDvAmTJiAESNG5FumatWqNj1XRERErtkuTTNbyjnTPudsl3Jfgic/Pz94eHiozVoZ8+eQrpxxcXEWWbycZQqqizUys6dsOUmDytmorB2jmyNv3xedMxC2NO9lEnTQgITz8LqwHajSAe6IbYnshW2J7IVtieyFbYncqR3ZWgeHTrJSunRplZ3Lb5PukLZo06YN9u3bZzHbpUTcErzJZCmmMuvWrbN4nJSR40KuJZOmmJcxGAzqvqmMnJc317zMkSNH1LIIpjK21IWcQ5h21baCiZZBPxERERGRM3KZMXgSQF25ckXtZZycLHMgZC07WYtOujFK8DRs2DDMnDlTjXV76aWX1Hp1pqzY448/jg8//BATJ07EI488gvXr1+P777/Hb7/9ln0d6SL50EMPoXnz5mjZsiVmzZqFpKQkNaumCAkJwciRI1W5sLAwFbQ99dRTKqiTCVaELXUh55AZEA4PO5YjIiIiInIklwnwZA05WU/OxDQT5R9//IFOnTqprpXLly9XM1VKsBUQEKACtVdffTX7MbJEggRzstzC7NmzUb58eXz++edqhkuTgQMH4uLFi+p6EpjJMgerVq2ymDRFllWQ2TVlgXOZ9VIe//HHH2eft6Uu5By2ZdZGJS0MEbgCfa5ZVoziNX8czKwNY36WiIiIiMh5uUyAJwuFy5afSpUqYcWKFfmWkWDw33//zbeMrI8nW158fX3Vmnay3U5dyPFik9LxZfpwfOI1CwYNFkGepgE6HRCEZHge/RWoMdKRVSUiIiIicp+FzokKQ3iQL1YbWmJM+jhEI8ziXBTCsCGzoQr6mu2cZFz8nIiIiIjIiblMBo+oMLSsEobIEF+siW+JtanN0VJ/GOGIQyxCsc1gXJ7jC68P0dmwBfhuCPDwSiCivqOrTURERERkFTN4VKx56HWYepdxZlMNemwx1MUvhrZqb4Bebb9WmwZUbAukJgCL7gPizji62kREREREVjHAo2KvZ/1IfDK0KSJCfC2Oh/gZ1xr5cd9lrKj/DlC6DnAtCvh6AJCc99p5RERERESOwi6aRFlBXre6Edh28gpir6WosXnSffPNlYcw96+TGPfzaUQO/gJN1twPXDoKfDMQGP4z4O3v6KoTEREREWVjBo/IrLtmm2olcU/jcmov9yf3qoOe9SKQlmnAwz+ex9neXwG+IcC5bcAPI4HMDEdXm4iIiIgoGwM8onzo9Tq8N7AxGlUIRVxyOob+moD4fl8Bnr7AkRXAb+ON6ykQERERETkBBnhEBfDz9sDnw5ujfAk/nL6cjEf+8ELaPZ8BOj2wawGw4U1HV5GIiIiISGGAR2SD0kE++PLhFgj29cTO01fxzL4KMPR623jyzzeBHfMdXUUiIiIiIgZ4RLaqHh6EOcOawctDh9/2RuGtK+2AjhONJ6Wr5uHfHF1FIiIiIirmGOAR3YS21UrhzXsbqtufbDiBbwOGAk2GAZoBWPoIcGaLo6tIRERERMUYAzyimzSgWXk83aWGuv3SzwewsdaLQM2eQEaKcfmE2MOOriIRERERFVMM8IhuwbiuNXBvk3LINGh44tu9ONLhfaB8CyAlzrgQesIFR1eRiIiIiIohBnhEt0Cn02H6gAZoVSUMiakZePjr/Yi9awFQsgaQcM4Y5F2Pc3Q1iYiIiKiYYYBHdIt8PD3w2bDmqFo6ABfiU/DI9/8h+YHvgcAyQOxB4LshQHqKo6tJRERERMUIAzyi2xDi74UvR7REyQBv7D+fgKdWXkbmkKWATzBw+h/gp9GAIdPR1SQiIiKiYoIBHtFtqljSH3Mfag4fTz3WHY7Fq9v10AZ+DXh4Awd/BlY+D2iao6tJRERERMUAAzwiO2hasQRmDWwMnQ5YsPk05l2oCPSfYzy5fS7w97uOriIRERERFQMM8IjspFeDSEzuVVvdfv23g1itawf0fNN4ct2rwL+LHFtBIiIiInJ7DPCI7GhUh6p4sFVF1SPz6e/+xZ5yg4F2TxtP/vIUcGyto6tIRERERG6MAR6RnZdPmHZ3PXSqVRop6QaMXLADZ5tOBBoOArRM4PvhwLmdjq4mEREREbkpBnhEdubpoceHQ5qiTmQwLiWm4pEFOxHf/T2g2p1AejLwzf3A5ROOriYRERERuSEGeESFINDHE/NGNEeZYB8ci03EE9/tRdq9XwKRjYHky8BX/YFrMY6uJhERERG5GQZ4RIUkMsQP80a0QIC3B/45fhkvrjgFbcj3QIkqQNxpYNF9QEqCcZ28k38B+5Ya91w3j4iIiIhukeetPpCIClavbIjqrjlywXYs2XkOFcP88dSwH4HPuwHRe4H5PYHkq8C1CzceFFwW6DkDqHu3I6tORERERC6IGTyiQta5djim3VNf3X5n7VH8fMYHeHAJ4OEDxBywDO5EQpRxMpaDvzimwkRERETkshjgERWBYa0rYXTHqur2c0v2YltKBcAnMI/SmnG3ahK7axIRERHRTWGAR1REJvWsjV71I5CWacBnX39tnGwlTxqQcB44vakIa0hEREREro4BHlER0et1eG9gYzSuEAr/1Eu2PSiRM20SERERke0Y4BEVIV8vD3z+UHNoQWVse0CgjeWIiIiIiBjgERW9UoE+ePrh4YjSwmDIGm6Xk6YBad6hQKW2RV09IiIiInJhDPCIHKBKeAje8XhE3c4Z5Elwp9MB3mlxMKx+EchMd0wliYiIiMjlMMAjcoBtJ69gaXJTjEkfh2iEWZyLQhhWZTZXt/VbPwG+7AMk5FhKgYiIiIjICi50TuQAsddS1H61oSXWpjZHS/1hhCMOsQjFNkNtGKBHt8wd+Nh/LrzObgU+7QgM+AKoeoejq05ERERETowZPCIHCA/yzb4twdwWQ138Ymir9nJfrDU0x/4+PwNl6gNJF4Gv+gF/vQsYDA6sORERERE5MwZ4RA7QskoYIkN8ocunTOkgHzRs1BQYuRZoNATQDMC6acDiB4HrcUVYWyIiIiJyFQzwiBzAQ6/D1Lvqqtt5BXnXrqdj49GLgLc/0O9j4K7ZgIc3cGQF8FknIGpvkdaZiIiIiJyfSwR4p06dwsiRI1GlShX4+fmhWrVqmDp1KtLS0izK7d27Fx06dICvry8qVKiAmTNn5nquJUuWoHbt2qpMgwYNsGLFCovzmqZhypQpiIyMVNfq2rUrjh07ZlHmypUrePDBBxEcHIzQ0FBVt8TExJuuCxVvPetH4pOhTRERcqO7pigT7INqpQOQkmHAIwu2Y86fJ6Am2mw2AnhkNRBSEbh6EviiG/DvIkdVn4iIiIickEsEeIcPH4bBYMCnn36KAwcO4L333sOcOXPwwgsvZJdJSEhA9+7dUalSJezcuRNvvfUWXnnlFXz22WfZZTZt2oTBgwergOzff/9Fv3791LZ///7sMhKIvf/+++r5t27dioCAAPTo0QMpKcZJMYQEd1KPtWvXYvny5di4cSNGjx59U3UhMgV5fz9/J74d1RqzBzVW+02TumDl0x0xuGVFtWTCmysP45nFu5GSngmUawo89idQvRuQkQL8/ATwy/+A9Bvtk4iIiIiKMc1FzZw5U6tSpUr2/Y8//lgrUaKElpqamn3s+eef12rVqpV9/4EHHtD69Olj8TytWrXSHnvsMXXbYDBoERER2ltvvZV9Pi4uTvPx8dG+/fZbdf/gwYOSTNG2b9+eXWblypWaTqfTzp8/b3NdbBEfH6+uJXuTtLQ0bdmyZWpP7k3a48JNJ7Vqk3/TKj2/XLvrg7+0C3HJxpOZmZq2YYamTQ3RtKnBmjang6ZdOXlTz8+2RPbCtkT2wrZE9sK2RO7YjqzFBta47DIJ8fHxCAu7sX7Y5s2b0bFjR3h7e2cfk8zbjBkzcPXqVZQoUUKVGT9+vMXzSJlly5ap2ydPnkR0dLTqlmkSEhKCVq1aqccOGjRI7aVbZvPmxnXKhJTX6/Uq49e/f3+b6mJNamqq2swzgSI9PV1tptvme3Jvg5qXQ5WSfnjquz3Yey4ed3/wNz4a3BhNKoYCbZ+BLqIxPJY9Bl3UHmif3oHMez6BJtk9G7Atkb2wLZG9sC2RvbAtkTu2I1vr4ZIB3vHjx/HBBx/g7bffzj4mgZmM0TNXpkyZ7HMSVMnedMy8jBw3lTN/XF5lwsPDLc57enqqYNO8TEF1sWb69OmYNm1aruNr1qyBv7+/xTHpHkrFx1O1gLlHPBCVmIbBn2/FA1UNaB2uRubBr+pLaHHyQ5RI/g+eiwfjSMQ9OBzRH9DZ1gObbYnshW2J7IVtieyFbYncqR0lJyc7f4A3adIkldXKz6FDh9SkKCbnz59Hz549cf/992PUqFFwJ5MnT7bIMEoGTyZokfF8MqGLKXKXRtatWzd4eXk5sLZU1O5NzcDEH/djzcFYfHvCA97hFTGpR014euiBjIHI/P1leOych1rRP6OGXzwy+30K+JfM8/nYlshe2JbIXtiWyF7Ylsgd25Gpd59TB3gTJkzAiBEj8i1TtWrV7NsXLlxA586d0bZt21wTlkRERCAmJsbimOm+nMuvjPl50zGZRdO8TOPGjbPLxMbGWjxHRkaGmlmzoOuYX8MaHx8fteUkDSpno7J2jNxbqJcX5gxtjvfXH8Os349hweYzOHExGR8OaYJQ/0DgrveAiq2BX5+G/uQG6L/oAjywACh/ozuxNWxLZC9sS2QvbEtkL2xL5E7tyNY6OHQWzdKlS6vsXH6baRybZO46deqEZs2aYf78+WrMm7k2bdqo2SzN+6ZKxF2rVq3sLpFSZt26dRaPkzJyXEi3SgnAzMtIpCxj60xlZB8XF6dmxzRZv369muVTxurZWheiW6HX6zCua03MGdoU/t4e+Pv4Jdzz0T84GnPNWKDRQGDUOiCsGpBwDpjXE9g2V2ZTcnTViYiIiKgIuMQyCabgrmLFimrc3cWLF9VYNtOYNzFkyBAVDMoSCLKEweLFizF79myLLo9PP/00Vq1ahXfeeUctvSBLF+zYsQNjx45V53U6HcaNG4fXX38dv/zyC/bt24fhw4ejbNmyajkFUadOHdVFVLqHbtu2Df/88496vEzAIuVsrQvR7S6v8MOYtihfwg+nLyej/0f/YO3BrKxxmXrA6A1AnbsAQzqw4lngx9FAWpKjq01EREREhcwlAjzJfsnEKpJZK1++vOo+adrMZ7uUyUhkJkzJ8kn3T1mw3Hx9Ouna+c0336junY0aNcLSpUvVDJr169fPLjNx4kQ89dRT6nEtWrRQC5hLUCgLlpssWrRIZRe7dOmC3r17o3379hZdRm2pC9HtqhMZjF/GtkfrqmFISsvE6K924MP1x2TpE8A3GHjgK6D764DOA9j3PTC3C3DpuPHBhkzoTv+Nclc2q73cJyIiIiLXp5O1EhxdCbJOuodKsChLQphPsrJixQoVWDpDX2ByvPRMA1799SC+2nJa3e/TMBJv3dcQ/t5ZQ2xP/QMsfRhIjAG8g4DmI4D9PwAJF248SXBZoOcMoO7dDnoV5Mr4uUT2wrZE9sK2RO7YjqzFBi6bwSOivHl56PFav/p4o38DeOp1+G1vFO77ZDPOx103FqjcDnhsI1CxLZB2Ddj0gWVwJxKigO+HAwd/cchrICIiIiL7YIBH5CaGtKqIb0a1RskAbxyMSlCLom87ecV4MigCGPYT4B2Yx6OzEvmrJrG7JhEREZELY4BH5EZaVgnDz2PboW5kMC4npeHBz7fg221njCfPbQfSEvN5tAYknAdObyqq6hIRERGRnTHAI3Iz5Uv4Y+mYNujTIBLpmRom/7gPU37ejwzphmkLGatHRERERC6JAR6RG5IJVmQB9Ge711T3F24+jTc2ZnXXLEhgmcKtHBEREREVGgZ4RG5K1nUce2cNzB3eHAHeHvjyfDnEoiQ06PIehedfEqjUtqirSkRERER2wgCPyM11q1sGPz3ZDhVKBuLltGFqnTxDjsVRZLEUCfsMyXHA4eWOqioRERER3SYGeETFQM0yQfhxTFv8oWuNMenjEI0wi/NRCMP2zJrQIxPakhHA7m8cVlciIiIiunVZKyETkbs7GpOItEwDVqMl1qY2R0v9YYQjDrEIxTZDbVVmuvY5BnpuAJaNAdKSgJajHF1tIiIiIroJDPCIionYaynZtw3QY4uhbq4ykzIeRfOa5VHtv6+BFc8ag7z244q4pkRERER0q9hFk6iYCA/yLbCMBj1i204DOkwwHvh9KrD+deMgPSIiIiJyegzwiIrRIuiRIb55zKFpFBHsi5ZVSwJdpgBdphoPbnwLWP0CgzwiIiIiF8AAj6iY8NDrMPUuY7fMvIK8ED9PpGUYjHc6jAd6vWW8veVj4Nf/AYbMIqotEREREd0KBnhExUjP+pH4ZGhTRIRYdtcsGeANH089jsQk4pEvtyM5LcN4otVo4J6PAJ0e2LUQ+HE0kJnumMoTERERUYE4yQpRMQzyutWNwObjsVjz11Z079AKbaqHY/fZq3ho3nZs/u+yCvLmjWgBf29PoMlQwDsA+OFRYP9SID0ZuG8+4FXwmD4iIiIiKlrM4BEV0+6araqEoVkpTe3lfrNKYVjwSEsE+nhiy39X8PB8s0xevf7AoG8ADx/gyArg24HGGTaJiIiIyKkwwCOibM0qlcDCkS0R5OOJrSevYMT87UhKzQryavYAhi4FvAKA/zYAX90LpMQ7uspEREREZIYBHhFZaFrxRpC3TQV525BoCvKqdASGLwN8QoCzW4AFdwFJlx1dZSIiIiLKwgCPiHJpUrEEvnq0FYJ8PbH91FWMmGcW5FVoCYxYDviXAqL2AF/2Bq5FO7rKRERERMQAj4jy0rhCKL4eaQzydpyWCVi24VpK1gyakQ2Bh1cCQZHAxcPAvJ5A3BlHV5mIiIio2GOAR0R5alQhFIsebYVgX0/szBnkla5pDPJCKwFXTxqDvEvHHV1lIiIiomKNAR4R5atheQnyWiPEzwu7zsRh+LxtSDAFeWFVgEdWAaVqAgnngfm9gOj9jq4yERERUbHFAI+ICtSgfIjK5EmQ968EeV+YBXnBZYERK4CIBkBSLPBlH+DcTkdXmYiIiKhYYoBHRDapX84Y5IX6e2H32TgM+2Ib4q9nBXmBpYGHfgXKtwBS4oCFdwOn/nZ0lYmIiIiKHQZ4RHRLQd6es5LJ23ojyPMrAQz7CajcAUhLBL4eABz73dFVBgyZwMm/gH1LjXu5T0REROSmGOAR0U2pVzYE3zzaGiUkyDsXj2ES5CVnBXk+QcCDS4AaPYCMFODbQcDBXxxXWbn2rPrAgr7ADyONe7nvyDoRERERFSIGeER00+qWDcY3o1ojLMAbe8/FY6h5kOflBwz8GqjbDzCkA0tGAHu+K/psmgRx3w8HEi5YHk+IMh5nkEdERERuiAEeEd2SOpES5LVSQd6+8/F48IstiEtOM5709AYGfAE0fhDQMoGfHgN+ebrosmkSOK56HoBm5WTWsVWT2F2TiIiI3A4DPCK6ZbUjgvHtqNYoGeCN/ecTMGTuVlxNygryPDyBuz8EWo423t/1pX2zaZnpQPIV4Opp49IMZ7YAx9YC+38Efn8l97UsaMZlHU5vuvnrEhERETkxT0dXgIhcW62IIHw7ujWGzN2Cg1EJePDzrWoilhIB3oBeD/SYDuz+xjjxSl7ZtF+fBpIvA+nJQOq1G5s8JjUx67bpeNb9zNTbr7xct2JroGR1oFQNoGQN49p+nj6397ySGZTgMTEGCCwDVGoL6D1uv75EREREBWCAR0S3rWaZIJXJGzx3qwryhmQFedJ9E2c25xHcmbl+BVg+7tYu7ulrnNzFO9C4ly0zDTi3veDHXjlh3Mzp9EBoJWPAJwu4mwd/geGATpf/c0o2UrqHmmcQZa3AnjOAunff2mskIiIishEDPCKyixplgvDd6FYY9NlWHJIgb+4W40QsksWyRURDY0ClgjQJ1oLNgrasvXdQjvuBgIeX9QyajO+TLqBWx+HpgIDSQM/pwJX/gEtHgUvHgMvHjcHo1ZPG7dgay4dJnUwBnynok31YNcDL98bELjmvaeqK+sBCBnlERERUqBjgEZHdVA+XIE8yeVtwOPqaCvIWdw9DiC0P7vEGUKWDfSoi3SElY6aCLV2OgCsrA9fnndzBlqYB16KBy8duBHxqfwyIOwOkJgAXdhk3CzogpDyQGJvPxC4648QutfuwuyYREREVGgZ4RGRX1cMDjUHeZ8Ygb9AqfywPLAuPxHyyadKFUcap2ZMEbw8shLbqeejMuktqwWWh6/mm9UyadL8MjjRuVTpanktPMWb1zLN9puAvJR6IP1tAhcwmdrFXIEtERESUAwM8IrK7aqWzgry5W3AoNhmvhw3HFMxQwZzOLMjT1H0AEnAVQlZrlaEFXkuZjQppexCOOMQiFGdTGuFlQwP0vNknky6Y4XWMW86sX9IlYPtc4E95jQWwtcsqERER0S3gMglEVCiqqiCvDSKCfTH/SkNM9nwOsQizKBODMPzbZnahjEtbtT8KY77ehfMJ6dhiqItfDG3V/kJCujou5+1Csn6BpYHKNmblZFZNIiIiouIe4N19992oWLEifH19ERkZiWHDhuHCBct1rvbu3YsOHTqoMhUqVMDMmTNzPc+SJUtQu3ZtVaZBgwZYsWKFxXlN0zBlyhR1DT8/P3Tt2hXHjh2zKHPlyhU8+OCDCA4ORmhoKEaOHInExMSbrguRu6tSKkBl8kL9vfBdYmO0SZmNQWkv4X9pY9W+Xcps3PtHKfsFW1kyDRqm/Xowv2XO1XkpZzfSxVS6mprG+OUi3T/L2b8rKhEREZErdtHs3LkzXnjhBRV4nT9/Hs8++yzuu+8+bNpkXKg4ISEB3bt3VwHZnDlzsG/fPjzyyCMqABs92rjQspQdPHgwpk+fjr59++Kbb75Bv379sGvXLtSvX1+VkUDs/fffx4IFC1ClShW8/PLL6NGjBw4ePKiCNSHBXVRUFNauXYv09HQ8/PDD6hryfLbWhai4qBDmDy9ZD08mt4ReZdFyenbJHvx7Nk5FXwZNg8RdEnzJDy6ZWffVbYPxtkHt5ZyxfM5zl5NSERWfkmedJKyT89tOXkGbaiWLYGKXLIXUFZWIiIjI5QK8Z555Jvt2pUqVMGnSJBWcSYDl5eWFRYsWIS0tDfPmzYO3tzfq1auH3bt34913380OqmbPno2ePXviueeeU/dfe+01FaR9+OGHKhCTL4mzZs3CSy+9hHvuuUeVWbhwIcqUKYNly5Zh0KBBOHToEFatWoXt27ejefPmqswHH3yA3r174+2330bZsmVtqgtRcSFB1MXE/BclT0zNxKd//oeiNmPVIXSrG4H65UJQv2wwSgb62GVil1zr4Ok8gPvnc4kEIiIiKnQuE+Dl7CIpQVTbtm1VcCc2b96Mjh07qoDKRDJvM2bMwNWrV1GiRAlVZvz48RbPJWUkeBMnT55EdHS0yryZhISEoFWrVuqxEuDJXjJxpuBOSHm9Xo+tW7eif//+NtXFmtTUVLWZSCZQSBArm+m2+Z7oVhVVW4qKS7Kp3B01SqF6eAD0Ol3WBuj1WfusYx56nRryZn7bw6Ks8fbJS8mY+/epAq+5+2y82kwign1UoFe3bDDqyRYZhPAgH+gKWtzcXI1eyKzSDcd2rEXqpVNosu81eBjSkBEQCc1N/93yc4nshW2J7IVtidyxHdlaD5cK8J5//nmVbUtOTkbr1q2xfPny7HMSmEmXSnOSeTOdk6BK9qZj5mXkuKmc+ePyKhMeHm5x3tPTE2FhYRZlCqqLNdJ1dNq0abmOr1mzBv7+/hbHJPNIZA+F3Zb+i5fgqOBuiQ28YlDDTmPi6mpAqLcH4tLknrXgTEOgJ3BnWQPOJenUdjEFiE5IRXTCRfx++GJ2ySAvDeUDNFQIgHEfqKGEt3FuFWv2XNbhx1N6xKXJa66GD72aoq/HFmxdOguXqg+EO+PnEtkL2xLZC9sSuVM7khjI6QM86WYpWa38SJdImRRFSNdKmdDk9OnTKhAaPny4CvJu6td1JzZ58mSLDKNk8GSCFhnPJxO6mCJ3aWTdunXLzl4S3YqiaksyNm7pOxsRk5Ca1yp4iAjxwdiBHVVWzl68Ksfgqe/2qNu5lznX4c37GqFHvRs/5iSmZuBQ1DUciErAwQsJOHDhGo5fTMS1dB0Oxcl24zlC/bxQt2wQ6kVmZfrKBqFiCX+sPRSL+Zv3WFzvt8xWKsCrEL8NVyvOQI/6EXA3/Fwie2FbInthWyJ3bEem3n1OHeBNmDABI0aMyLdM1apVs2+XKlVKbTVr1kSdOnVU8LNlyxa0adMGERERiImxXF/KdF/OmfbWypifNx2TyVzMyzRu3Di7TGxsrMVzZGRkqG6jBV3H/BrW+Pj4qC0naVA5G5W1Y0S3orDbkjzzK3fXU0sT5Jx6xBTOTb2rHnx9bnRptoe+jcvD09NDzZZpPuFKRIgvpt5VFz3r3/g3Lkp4eaFtDT+0rXEjQ389LROHohNw4Hw89p9PwP4L8Tgacw1x19Ox6cQVtZkEeHsgPdOQK4j9w9AYyZoPKuovYsqKlejVaJRdA1lnws8lshe2JbIXtiVyp3Zkax1uK8CTiURk3Fq1atVUN8WbVbp0abXdCoPBoPamMWsS5L344ovZk64Iibhr1aqV3SVSyqxbtw7jxo3Lfh4pI8eFdKuUAEzKmAI6iZRlbN2YMWOynyMuLg47d+5Es2bN1LH169er+shYPVvrQlScSDD1ydCmNgdb9ryuTKIiE73EXktBeJAvWlYJsznA8vP2QNOKJdRmkpqRiaPRiSrY2y+B34UEHIpKQFJaptXnSIEP1hsao6/HVrS+vhHbTg6w38ydRERERPYI8KT/51NPPaWWEhBHjx5VmTY5Vq5cOdX10p4kwJJZK9u3b68CpBMnTqjlCySwNAVnQ4YMUd02pQunjNXbv3+/mjXzvffey36ep59+GnfccQfeeecd9OnTB9999x127NiBzz77TJ2Xrp4S/L3++uuoUaNG9jIJMjOmzNgpJHMoM3GOGjVKzbwpQdzYsWPVBCxSzta6EBU3txts3Sp5fnsGVD6eHmhQPkRtJpK5+/yv/zBj1RGrj1mhumluRW/9FvybcN1udSEiIiKyy0LnMlZsz5492LBhQ/bacKbZJBcvXgx7kwlGfvzxR3Tp0kVlwSRwatiwIf7888/sLo0y26VMRiIZRcmsSfdPWbDcfFkCmXVT1qqTgK5Ro0ZYunSpmkHTtAaemDhxogpU5XEtWrRQC5jLsgjmr1Nm8JRxgVIfWR5BAk9TkGhrXYiKI1OwdU/jcmrvLl0VvTz0aFwh7+y8dNO8rnmrbppV0o8Xad2IiIioeLmlDJ4ERRLIyUyW5hOcyHpvkl2ztwYNGqhukAWRoO+vv/7Kt8z999+vtrzI63n11VfVlheZMdO0qPnt1IWI3IdkIyNDfBEdn5JrHN51+GK9oQn6eGxF/bg/AHRyUC2JiIjI3d1SBu/ixYu5lgoQSUlJbjOjJRHRzZBspIwnFLo8umkK/aFlgGaf5SCIiIiI7BLgySLfv/32W/Z9U1D3+eefZ4+JIyIqrpPJyOQx5jz1OvR7YATg6QdcPQVEGZdvICIiInKKLppvvPEGevXqhYMHD6olAmQCEbm9adMmNS6OiKi4Mp9M5uSlRLy0bD8yDBpqVYgEanYHDv4MHFwGlDXO1EtERETk8AyeTCoik6xIcCfj42RCEemyuXnz5uylA4iIivtkMkNaVcqewXPl/iigrnE2Xhz4id00iYiIyDkCPFkW4JFHHlHdMufOnYtt27ap7N3XX3+tgj0iIrqhV9Yafyv2RwM1e7CbJhERETlXgCcLd//www+FUxsiIjfTo14EZJjynrNxOJekM3bTFNJNk4iIiMgZumjKot+yVAIREeWvdJAPWlYOU7dXSRYvu5smZ9MkIiIiJ5lkpUaNGmqduH/++UeNuQsICLA4/7///c9e9SMicnm9G0Ri68krWLk/Go+ONHXTPAlE7wUiGzm6ekRERFTcA7wvvvgCoaGh2Llzp9rMydg8BnhERDf0rB+Bqb8cwM7TVxF93QMRNboBh34xZvEY4BEREZGjA7yTJ0/asw5ERG6tTLAvmlcqgR2nr2LV/iiMqNcvK8D7CegyRX4Zc3QViYiIqDiPwTOnaZraiIgob70amM2mWUO6afre6KZJRERE5OgAb+HChWpZBD8/P7U1bNgQX331lb3qRUTkdt00xfZTVxCb5glIN00h3TSJiIiIHBngvfvuuxgzZgx69+6N77//Xm09e/bE448/jvfee89edSMichvlQv3QuEKomjhz9YEYoF7/G8slsBcEEREROXIM3gcffIBPPvkEw4cPzz529913o169enjllVfwzDPP2Kt+RERuo3eDCOw+G4eV+6IwbHhWN80r/wHR+4DIho6uHhERERXXDF5UVBTatm2b67gck3NERJRbr/rGcXhb/ruMy+leN7ppctFzIiIicmSAV716ddUtM6fFixerNfKIiCi3CmH+qF8uGAYNWHMwxmzR85/YTZOIiIgc10Vz2rRpGDhwIDZu3Ih27dqpY7Lo+bp166wGfkREdCOLt/98Albsi8LgoT3ZTZOIiIgcn8EbMGAAtm7dilKlSmHZsmVqk9vbtm1D//5ZEwcQEVEuvbJm09x04jKuZngD1bsaT7CbJhERETkqgyeaNWuGr7/+2h51ICIqNqqWDkTtiCAcjr6GtYdi8IDMpnl4uXG5hDtf5qLnREREVPQZvBUrVmD16tW5jsuxlStX3l6NiIjcXO+sRc9lNk3UNM2meQKI2e/oqhEREVFxDPAmTZqEzMzMXMc1TVPniIgo/+USxN/HLyHe4HujmyYXPSciIiJHBHjHjh1D3bp1cx2vXbs2jh8/frt1IiJya9XDg1AjPBDpmRrWHeKi50REROTgAC8kJAT//fdfruMS3AUEBNijXkREbq2XqZvm/mhjN00PH+DycXbTJCIioqIP8O655x6MGzcOJ06csAjuJkyYgLvvvvv2akREVIy6af559CIS4Xdj0XN20yQiIqKiDvBmzpypMnXSJbNKlSpqk9slS5bE22+/fTv1ISIqFmqVCULVUgFIyzBg/eHYG4ues5smERERFfUyCdJFc9OmTVi7di327NkDPz8/NGrUCB06dLiduhARFRs6nQ69GkTgoz9OqNk0776/p1k3zQNARH1HV5GIiIjcPYO3efNmLF++PPvLSffu3REeHq6ydrL4+ejRo5GamlpYdSUiciu96hvH4f1xJBbJOrNumlz0nIiIiIoiwHv11Vdx4MCB7Pv79u3DqFGj0K1bN7U8wq+//orp06ffal2IiIqVemWDUTHMHynpBmw4cvFGN00Zh8dumkRERFTYAd7u3bvRpUuX7PvfffcdWrZsiblz52L8+PF4//338f33399KPYiIim03TbFCFj2vZeqmeczYTZOIiIioMAO8q1evokyZMtn3//zzT/Tq1Sv7fosWLXD27NmbrQMRUbHVO6ubpky0kqL3v7HoObtpEhERUWEHeBLcnTx5Ut1OS0vDrl270Lp16+zz165dg5eX163Ug4ioWGpYPgTlQv2QnJaplkxAPXbTJCIioiIK8Hr37q3G2v3111+YPHky/P39LWbO3Lt3L6pVq3Yb1SEiKobdNOsbu2nKbJqoadZNM/ago6tHRERE7hzgvfbaa/D09MQdd9yhxt3J5u3tnX1+3rx5amZNIiKyXa8Gxm6avx+KRapnwI1umlz0nIiIiApzHbxSpUph48aNiI+PR2BgIDw8PCzOL1myRB0nIiLbNakQiohgX0QnpODvY5fQRbppHvnNOA6v8wuS5nN0FYmIiMgdM3jmC53nDO5EWFiYRUaPiIgKptfr0DOrm+aKfdE3umleOspumkRERFT4AR4REdmXaRze2oPRSPMMBKpnLUnDbppERER0ExjgERE5geaVw1Aq0AcJKRnYdOLSjUXPpZsmZ9MkIiIidw3wUlNT0bhxYzXznCy8bk5m8ZRZPX19fVGhQgXMnDkz1+NlnGDt2rVVmQYNGmDFihUW5zVNw5QpUxAZGQk/Pz907doVx44dsyhz5coVPPjggwgODkZoaChGjhyJxMTEm64LEZGJh+qmaVxndKV001SLnntnddM85OjqERERkYtwuQBv4sSJKFu2bK7jCQkJagbPSpUqYefOnXjrrbfwyiuv4LPPPssus2nTJgwePFgFZP/++y/69euntv3792eXkUDs/fffx5w5c7B161YEBASgR48eSElJyS4jwd2BAwewdu1aLF++XE08M3r06JuqCxFRXouerz4YjXSvIKBaVjdNLnpOREREhTGLpqOtXLkSa9aswQ8//KBum1u0aJFafF2WapCJXurVq6cyfO+++2528DV79mz07NkTzz33XPayDxKkffjhhyqgk+zdrFmz8NJLL+Gee+5RZRYuXKgWeF+2bBkGDRqEQ4cOYdWqVdi+fTuaN2+uynzwwQdqjcC3335bBZ+21CWv7KRs5oGiSE9PV5vptvme6FaxLTmfJuWDUMLfC1eT0/HPsVi0r30XPI+uhHbgJ2S0N35uOSO2JbIXtiWyF7Ylcsd2ZGs9XCbAi4mJwahRo1SgJQus57R582Z07NjRYhZPybzNmDEDV69eRYkSJVSZ8ePHWzxOyshzipMnTyI6Olp1yzSfMbRVq1bqsRLgyV66ZZqCOyHl9Xq9yvj179/fprpYM336dEybNi3XcQlqc75mCUyJ7IFtybnUDtRjc7Ien63cjqRKevTUecLj0lH89cNnuOZXHs6MbYnshW2J7IVtidypHSUnJ7tPgCeZtREjRuDxxx9XgdWpU6dylZHArEqVKhbHJPNmOidBlexNx8zLyHFTOfPH5VUmPDzc4rws/i5LRJiXKagu1kyePNkiAJUMnozfk+6eMt7PFLlLI+vWrRu8vLzyfd+I8sO25JyCjl/C5gW7cCTRF1369IDu+k/AsdW4o9QVGO7IuweAI7Etkb2wLZG9sC2RO7YjU+8+pw7wJk2apLJa+ZEukZLBunbtmgqA3JmPj4/acpIGlbNRWTtGdCvYlpxLh5plEOLnhctJadh9/hpa179XBXgeh3+FR9eX4czYlshe2JbIXtiWyJ3aka11cGiAN2HCBJWZy0/VqlWxfv161e0xZ/Aj2TyZ8GTBggWIiIhQ3TjNme7LOdPeWhnz86ZjMoumeRmZudNUJjY21uI5MjIy1MyaBV3H/BpERNZ4eejRvW4ZLNl5Div3RaF1j15Zs2keMc6mGV7H0VUkIiIiJ+bQWTRLly6tlizIb5NxbDKr5Z49e9REJbKZljZYvHgx/u///k/dbtOmjZrN0nzwoaRUa9Wqld0lUsqsW7fOog5SRo4L6VYpAZh5GUmFytg6UxnZx8XFqdkxTSQANRgMaqyerXUhIspL7wbGH5hW7o+GwTsYqHan8QQXPSciIiJ3WCahYsWKqF+/fvZWs2ZNdbxatWooX9446cCQIUNUMChLIMgSBhL8yayZ5mPann76aTUD5jvvvIPDhw+rpQt27NiBsWPHqvOytt64cePw+uuv45dffsG+ffswfPhwNTOmLKcg6tSpo2bilAlftm3bhn/++Uc9XiZgMS3fYEtdiIjy0rZ6SQT5eiL2Wip2nbkK1OtvPMHlEoiIiMgdAjxbyGyXMlZPZsJs1qyZ6v4pC5abL0vQtm1bfPPNN2o9ukaNGmHp0qVqBk0JGs3X2XvqqafU41q0aKEWMJegUBYsN5FlECS72KVLF7U8Qvv27S3WuLOlLkREefHx9EC3OsaJmVaoRc+zumlePMxFz4mIiMj1Z9HMqXLlympmzZwaNmyIv/76K9/H3n///WrLi2TxXn31VbXlRWbMlEAxP7bUhYgoL70aROLHf89j5f4ovNSnDvTSTfPoKmM3TY7DIyIiInfP4BERuZMONUohwNsDUfEp2HMuDqhr7CbObppERESUHwZ4REROyNfLA12yumnKZCuqm6beK6ub5mFHV4+IiIicFAM8IiIn1buBcVmVFfuioPmG3JhNk1k8IiIiygMDPCIiJ3VHzXD4eXng3NXr2H8+AaiX1U2TyyUQERFRHhjgERE5KT9vD3SuXVrdXrE/CqjVO6ub5iF20yQiIiKrGOARETmxXvWzFj1nN00iIiKyAQM8IiIn1rl2OHw89Th1ORmHoq6xmyYRERHliwEeEZETC/TxxB01jd00V+bspnnxiKOrR0RERE6GAR4RkZPr3cDYTfO37G6anY0nmMUjIiKiHBjgERE5uTvrhMPbQ4//LibhWGwiFz0nIiKiPDHAIyJycsG+XuhQo1T2mniondVNM/YgcPGoo6tHREREToQBHhGRC+iV1U1z5b5owK/EjW6azOIRERGRGQZ4REQuoFudMvDU63Ak5hpOXDTrpnngJ0dXjYiIiJwIAzwiIhcQ4u+FdtWN3TRX7Y9mN00iIiKyigEeEZGL6N0g4sY4POmmWbWT8QS7aRIREVEWBnhERC6iW90IeOh1OHAhAacvJ3HRcyIiIsqFAR4RkYsIC/BGm6ol1e2V0k1TLXruCcQeAC4dc3T1iIiIyAkwwCMiciG9srpprpRumv5hQFUuek5EREQ3MMAjInIh3etGQK8D9pyLx7mryWbdNDmbJhERETHAIyJyKaWDfNCyStiN2TTZTZOIiIjMMMAjInIxvbMWPV+R3U0zazZNdtMkIiIq9hjgERG5mB71IqDTAbvOxCEq/vqNRc8dsVyCIRO603+j3JXNai/3iYiIyHEY4BERuZgywb5oXqmE2aLnfYzdNGP2A7u/A/YtBU7+VfjB1sFfgFn14fl1PzQ//Ynay311nIiIiByCAR4RkQvqWd/YTXPlvmhjN83SdYwnlj0G/DASWNC3cIMted7vhwMJFyyPJ0QZjzPIIyIicggGeERELqhnfeNyCdtPX0H8zh+AmH25C9kj2NI0IP06kBgLXD4BXPgXOPEH8OvTctLaA4y7VZPYXZOIiMgBPB1xUSIiuj3lQv3QuEIo9p69As81k/MoJcGWDljxLBAUAaQlAanXcmwJeRwzO27IuMnaaUDCeeD0JqBKBzu8WiIiIrIVAzwiIhfVu0EEfM9vQkBqTD6lNCAxBvii2+1f0DsI8AkyPue1qILLy3WJiIioSDHAIyJyUb3qR2L/qjjbCvuFGbN4EqBZbMF53M9x3DsQ0Gf16pcJXGSMX0ECy9zeCyQiIqKbxgCPiMhFVQjzR0CpckCCDYUfWGi/7pKV2gLBZY1j/KyOw8tybhtQuT3Umg5ERERUJDjJChGRC6vYpAsuaGEw5FlCBwSXMwZl9qL3AHrOuPH8Oa9nsu5VYPFQICXeftcmIiKifDHAIyJyYT0blMe09OEqkablFWz1fNMYlNlT3buNWcFg43IN2SSzJ8f7zgI8vIHDy4HPOgMxB+x7fSIiIrKKXTSJiFxYlVIBOFOmK8bEAO8Ffwv/lBjLYEuCOwnGCoM8b+0+yPhvI3b/tRqNO/SAZ9WON4LJyIbA9w8BV04An3cF7poNNHygcOpCRERECgM8IiIX17t+BN6Jaomx4T0xr3OGcfZKmeBEumXaO3OXk94DWqX2OH8gAY0qtbe8XrlmwOg/gR8fBU6sB34cBZzbDnT/P8DTu3DrRUREVEyxiyYRkYvr1cDYTfKvE1cRH9EaaHCfcUKVwg7uAGQaNGw9eQU7L+nUXu5bCCgJPLgU6Pic8f62z4Av+wDx5wu9bkRERMURM3hERC6uenggapYJxNGYRHz65wnUighCeJAvWlYJg4e+8GawXLU/CtN+PYio+BQAHlh4bAciQ3wx9a666FnfbGyeBJp3vgSUaw78NNo4u+anHYH75gFV7yi0+hERERVHzOAREbmBGuGyADnw8YYTePq73Rg8dwvaz1ivgrDCIM875utdWcHdDdHxKeq41evW6mnsslmmAZB8CfiqH/D3e4CWz1ILRERE5J4BXuXKlaHT6Sy2N99806LM3r170aFDB/j6+qJChQqYOXNmrudZsmQJateurco0aNAAK1assDivaRqmTJmCyMhI+Pn5oWvXrjh27JhFmStXruDBBx9EcHAwQkNDMXLkSCQmJt50XYiI7EGCqd/25Q6o8g22boN0w5TMnbWwzHRMzufqrinCqgCPrgUaDQE0A/D7K1xKgYiIqLh20Xz11VcxatSo7PtBQcZfrEVCQgK6d++uArI5c+Zg3759eOSRR1QANnr0aFVm06ZNGDx4MKZPn46+ffvim2++Qb9+/bBr1y7Ur19flZFA7P3338eCBQtQpUoVvPzyy+jRowcOHjyogjUhwV1UVBTWrl2L9PR0PPzww+oa8ny21oWIyJ7BljWm8GrCkj3YdvKKum8waMjUNGQabty+cUyDIWuvzuc6Zrwdl5yWK3OX87pyXq7ZplrJ3AW8/IB+HwMVWgArn89aSuEQMPAroEw9e701RERExZJLBXgS0EVERFg9t2jRIqSlpWHevHnw9vZGvXr1sHv3brz77rvZQdXs2bPRs2dPPPeccbD/a6+9poK0Dz/8UAVikr2bNWsWXnrpJdxzzz2qzMKFC1GmTBksW7YMgwYNwqFDh7Bq1Sps374dzZs3V2U++OAD9O7dG2+//TbKli1rU12IiOxBgqj8gi2RlJqJef+cQlGLvZZPvXQ6oPkjQGQjYPFwLqVARERUHAM86ZIpQVnFihUxZMgQPPPMM/D0NL6EzZs3o2PHjiqgMpHM24wZM3D16lWUKFFClRk/frzFc0oZCd7EyZMnER0drTJvJiEhIWjVqpV6rAR4spdMnCm4E1Jer9dj69at6N+/v011sSY1NVVtJpIJFJIllM1023xPdKvYltxDVFySTeU61yqFWmWCoNfp4KFH1l6XvTfehsUxU1kPnQ56vQ6eWcdOXEzEe+tOFHjNkv6eBbev8IbAyHXwWPYY9Cc3qKUUMs9shaHrq8aF0qlY4ecS2QvbErljO7K1Hi4T4P3vf/9D06ZNERYWprpaTp48WXWTlKyYkMBMulSak8yb6ZwEVbI3HTMvI8dN5cwfl1eZ8PBwi/MSZEq9zMsUVBdrpOvotGnTch1fs2YN/P39LY5J5pHIHtiWXNt/8TJLZsHLIdTziEGNdONn1K2SrpeZACpqQKi3B+LS5Ki1WTo1+HkAFw9uwYpDNj55yAjULhOMWjG/wGPH54g/tAHbK49FinfYbdWZXBM/l8he2JbIndpRcnKy8wd4kyZNUlmt/EiXSJkUxTzz1rBhQ5Ude+yxx1RQ5OPjA3cgQav565QMnkzQIuP5ZEIXU+Qujaxbt27w8vJyYG3J1bEtuQcZF7f0nY2ISUi1OumJhF8RIT4YO7CjXZdM8Kocg6e+26Nu576uDtczge2Gynipd214SRrQJn2RcWw1PH55AmFJx9H95OvI7D8XWuUOdqs3OTd+LpG9sC2RO7YjU+8+pw7wJkyYgBEjRuRbpmrVqlaPS7fJjIwMnDp1CrVq1VJj82JiYizKmO6bxu3lVcb8vOmYzKJpXqZx48bZZWJjYy2eQ+ohM2sWdB3za1gjgaq1YFUaVM5GZe0Y0a1gW3Jt8pd75e56arZMXY5gyxTOTb2rHnx97NvdsW/j8vD09DBbB89I1sFrVSUMP++5gG+2ncN/l5Lx8YPNEBZg4/Xr9gUi6gGLh0EXsw+e3wwAukwF2j1tHLdX3BgygdObgMQYILAMUKltkSxg72j8XCJ7YVsid2pHttbBocsklC5dWmXn8tvMx7GZk0lLZNybqbtkmzZtsHHjRou+qRJxS/Bn6hIpZdatW2fxPFJGjgvpVikBmHkZiZRlbJ2pjOzj4uKwc+fO7DLr16+HwWBQQaetdSEishdZVPyToU0REWKc6ddE7stxi0XH7Xzdv5+/E18/0hzDa2SqvdyfNagJ5g5rjgBvD2z57wru+ehvHIm+ZvsT51pKYarlUgoS9Jz8C9i31LiX++7o4C/ArPrAgr7ADyONe7kvx4mIiFx5DJ5MWiJBVufOndVMmnJfJlgZOnRodsAkk67I+DVZk+7555/H/v371ayZ7733XvbzPP3007jjjjvwzjvvoE+fPvjuu++wY8cOfPbZZ+q8rK03btw4vP7666hRo0b2MgkyM6YspyDq1KmjZuKU5Rpk5k0J4saOHasmYJFyttaFiMjewVa3uhFqVk2ZvTI8yBctq4TZtVumNfL8krG7fEhTe9P1utYtg5+ebIdHF+zAmSvJuPfjf/DewMboXi/vXgw2LaXQ4lFg8wdAwoUbZYPLAj1nAHXvhttk0ySI+3547g6wCVHG4w8sLPzXS0RELsklAjzptijB2CuvvKJmmZTASwI88/FqMtulTEby5JNPolmzZihVqpRasNx8WYK2bduqtepkGYQXXnhBBXEyg6ZpDTwxceJEJCUlqcdJpq59+/ZqWQTTGnhClkGQoK5Lly4qizhgwAC1dt7N1IWIyN4kuLK67pyD1CwThJ+fbIcnFu3C5v8uY/RXO/Fs95p4snN19YNagawtpbB6cu5yRRH0SMC16vmiCSwlkJRr5bmUvA5YNQmo3adYdNckIqKbo9Nk8TdyStI9VILF+Ph4i0lWVqxYodbdc4a+wOS62JaoqNpSeqYBry8/iAWbT6v7fRtG4q37GsHP+yaCk2uxxu6JmTeWkrGkMwZc4/bZP+jJK5tmGuWYX2BpMABpicYt9RqQKvuE/O9fPQWc3VJwvR5aDlRxrwlo+LlE9sK2RO7YjqzFBi6bwSMiItcls2hOu6c+akUEY8rP+7F8bxROXU7CZ8Oao2yon21PculIPsGd0ICE88A3DwDB5QCdLPbnYdzrsvZ6fY775ud1ZvfNysjxP/4vn2wagJ8eA3Z/C6SbBWmmgE32hUW6ihIREeXAAI+IiIrEkFYVUa10AMYs2oX95xNw94f/4NNhzdCsUgn7BTPHf0eRS08Gjq7Iv4wEjD5BNzbvwKzbWXtv07lA4FoMsOWjgq8r4wCJiIhyYIBHRERFplXVkmpc3qiFO3A4+hoGf7YF/9e/Pu5vXsE+wUzT4UBoRWPXSJmBU8s07mVcm7pvftvKuZzn484A52/MmpynJsOAKneYBWymAC5r8/S1fZkHuf7Bn4xjC/Na3VC6o8okL0RERDkwwCMioiJVIcwfP4xpi/Hf78bqAzF4buleFexN7lUbnnktii7BjAQ1BQU9fWfZdwyeLMMgyxMUpOFA+42Hk/rL5C1q3F/O1Q2z9HyTE6wQEZHzrYNHRETFU4CPJz55sBme7lJD3f/i75N4ZMEOxF+/sX6o1aBHyZkJ0xVe0GMKLHNd0+zaMubP3tk0mbRFJm8JtrKGYbv/cYkEIiLKEwM8IiJyCL1eh2e61cTHDzaFn5cHNh69iP4f/YMTFxNvLuiRAKywlkhwVGAp5PWM22+cLXPAF0CDB4zHT/wBcAJsIiLKA7toEhGRQ/VuEIlKJf0xeuFO/HcpCf0++gcfDG6CTrXCrQc9sv5bUS04brqmBJBW18F7s3CzafK6TF0/q3YGDv8GRO8Fjq0FanYvvOsSEZHLYoBHREQOV69sCH4e2w6Pf7UTO05fxSNfbscLvetgZPsquRdFNw96ioojAsucAkoCLUYCm94HNs4EanSzfeIWIiIqNthFk4iInEKpQB8sGtUKA5tXgEEDXv/tEJ5dshcp6ZlwCqbAssF9xr0jJjlpM9Y4I+e57cB/G4r++kRE5PQY4BERkdPw8fTAmwMa4JW76sJDr8MPu85h8NwtiE1IcXTVnENQGaDZCOPtjW87ujZEROSEGOAREZFTkS6ZI9pVwYKHWyLEzwv/nolTi6LvPRenzmcaNGw+cRk/7z6v9nK/WGn7P8DDGzj9t7HLKBERkRmOwSMiIqfUvkYpLHuyHR5dsB0nLibh/jmbMbR1JazYF4Wo+BsZvcgQX0y9qy561reypIA7CikHNH4Q2Dkf+HMmMHyZo2tEREROhBk8IiJyWlVKBeCnJ9uhc63SSM0wqPXyzIM7ER2fgjFf78Kq/bIIeuFxROYwz2u2fwbQewL//QGc21Ho9SAiItfBDB4RETm1YF8vfDqsOZq8ugZJabknXJGQR+aSnPbrQXSrG6HG7tmbBI/y/EWZOcz/mpWAhoOA3V8DG98ChiwulDoQEZHrYQaPiIic3s7TV60Gd+ZBngRCU37eh2+2nlEZr/WHY7D1v8s4cCEeZy4n43JiKlIzMm8p0JIMYVFmDm26ZofxgE4PHF0FRO2xex2IiMg1MYNHREROL/aabbNoLtp6FoBsefPy0CHQxxMBPp5qrzZfs9tZ54J8PeHn7YG3Vh1RAWROpmMvLduPsABvNTmMdKE0aBo0Ddm31WYAMtVxuZ//ufRMA95enfc1s7OVz98Jj/oDgH1LjDNqDvzKpveIiIjcGwM8IiJyeuFBvjaVa1+9lArKElMykJSWofaJqcYtOSsDmJ6p4Wpyutrs4VJiGh74dAuKiilbue3kFbTp8KwxwDv0CxB7CAivU2T1ICIi58QAj4iInF7LKmFq/Jl0UbSW2ZKsVkSILxY80jLPMXiSNTMFfUmpGbiWatybB4E5jx+PTcT+CwkF1q9UoLcaK6jTQV1fr9OpjJ6HHuq2ccu6rc7nKGd2LibhOvaeS7Atq1mtNlDnbmOAJ1m8+76w6f0kIiL3xQCPiIicngRDMrmIjD+T8M08yDOFc3I+vwlW5JwEYbLZSmaulIXWC/LB4KZoU62kzc9rj2tmZzU7PmcM8A78CHSaDJSqbpd6EBGRa+IkK0RE5BJktspPhjZVmTpzcl+OF8ZslqbMYV5hoxyX81LOYdeMbAjU7AloBuDvd+1WDyIick3M4BERkcuQIE6WQpDxZ9JFUbJYEugUxtII9soc2vOayLqf65odJxpn09zzHXDHRKBEZbvVh4iIXAszeERE5FIksJHukPc0Lqf2hRXcOTJzmNc1jefK5L5m+WZAtTsBLRP4e5bd60NERK6DGTwiIiInyxxau+bpy8l4d+1R/HPsMhJS0nOPJZSxeCfWA7sXGW+HlCu0uhERkfNigEdERHQTmUNHXdNg0PDrngs4FpuIrzafxpOdc0ymUqktUKk9cPpv4J/ZQO+ZRVpXIiJyDuyiSURE5AJkCYUnOldTt+f9fRLXs9b1s3DHc8b9rgXAtZgiriERETkDBnhEREQu4q6GZVEhzA+Xk9KwePuZ3AWq3AGUbwFkpACbP3BEFYmIyMEY4BEREbkITw89Hr/DmMX7bON/SMswWBaQldZlRk2xfR6QdNkBtSQiIkdigEdERORCBjQtj/AgH1yIT8Gy3edzF6jRDYhsBKQnAVs+dkQViYjIgRjgERERuRBfLw+M6lBV3Z6z4QQyDZqVLF7WWLxtnwHX4xxQSyIichQGeERERC5mSKuKCPHzwn+XkrByf1TuArX6AOF1gdQEYOunjqgiERE5CAM8IiIiFxPg44mH21VWtz/64wQ0LUcWT68HOj5rvC3dNFOvOaCWRETkCAzwiIiIXNCItpXh7+2BQ1EJ2HDkYu4CdfsBJWsAKXHA9s8dUUUiInIABnhEREQuKNTfG0NbV1K3P/zjuJUsngfQYYLx9qYPgbQkB9SSiIiKGgM8IiIiF/Vo+yrw9tBj5+mr2HbySu4CDe4HQisByZeAnQscUUUiIipiDPCIiIhcVHiwL+5vXl7d/mjDidwFPDyBDuONt/+ZDaSnFHENiYioqDHAIyIicmGy8LmHXoeNRy9i37n43AUaDQGCywOJ0cDurx1RRSIiKkIuFeD99ttvaNWqFfz8/FCiRAn069fP4vyZM2fQp08f+Pv7Izw8HM899xwyMjIsymzYsAFNmzaFj48Pqlevji+//DLXdT766CNUrlwZvr6+6nrbtm2zOJ+SkoInn3wSJUuWRGBgIAYMGICYmJibrgsREdHtqhDmj3salVW3P95wPHcBT2+g/Tjj7b9nARlpRVxDIiIqSi4T4P3www8YNmwYHn74YezZswf//PMPhgwZkn0+MzNTBVRpaWnYtGkTFixYoIK3KVOmZJc5efKkKtO5c2fs3r0b48aNw6OPPorVq1dnl1m8eDHGjx+PqVOnYteuXWjUqBF69OiB2NjY7DLPPPMMfv31VyxZsgR//vknLly4gHvvvfem6kJERGQvYzpVU/tVB6JxPNbKkghNhgKBZYD4s8De74q+gkREVHQ0F5Cenq6VK1dO+/zzz/Mss2LFCk2v12vR0dHZxz755BMtODhYS01NVfcnTpyo1atXz+JxAwcO1Hr06JF9v2XLltqTTz6ZfT8zM1MrW7asNn36dHU/Li5O8/Ly0pYsWZJd5tChQzJ1mbZ582ab62KL+Ph49byyN0lLS9OWLVum9kS3g22J7IVtyTmMXrhdq/T8cm384t3WC/zzgaZNDda0WY00LSNdc0ZsS2QvbEvkju3IWmxgjSdcgGTSzp8/D71ejyZNmiA6OhqNGzfGW2+9hfr166symzdvRoMGDVCmTJnsx0nmbcyYMThw4IB6nJTp2rWrxXNLGcnkCcm47dy5E5MnT84+L9eUx8hjhZxPT0+3eJ7atWujYsWKqkzr1q1tqos1qampajNJSEhQe7mebKbb5nuiW8W2RPbCtuQcRrevjNUHYrBs93mM7VQF5Uv4WRZoNBSef78L3dWTyNizGFqDB+Bs2JbIXtiWyB3bka31cIkA77///lP7V155Be+++64aH/fOO++gU6dOOHr0KMLCwlTQZx5QCdN9OWfaWysjgdT169dx9epV1b3SWpnDhw9nP4e3tzdCQ0NzlSnoOuZ1sWb69OmYNm1aruNr1qxRY/nMrV27Ns/nIboZbEtkL2xLjlcrRI8j8XpMWfQn7qtqyHW+RsidqJu8BNdXv4b1Z/wBnXOO1GBbInthWyJ3akfJycnOH+BNmjQJM2bMyLfMoUOHYDAY/yf14osvqglNxPz581G+fHk1Du6xxx6DO5DMoYz/M5HAs0KFCujevTuCg4OzI3dpZN26dYOXl5cDa0uujm2J7IVtyXmUrHMFQ+ftwNbLnpjxUAeUDvKxLJDaAdqHaxGUEoU+VTOh1ekLZ8K2RPbCtkTu2I5MvfucOsCbMGECRowYkW+ZqlWrIioqSt2uW7du9nGZBVPOyWyVIiIiItdsl6aZLeWcaZ9ztku5L8GTzMzp4eGhNmtlzJ9DunLGxcVZZPFylimoLtbIa5ItJ2lQORuVtWNEt4JtieyFbcnx2tUIR9OKodh1Jg4Ltp7F5F51LAt4hQGtxwAbpsPzn/eA+vfKWAQ4G7Ylshe2JXKndmRrHRz6qV66dGk1fi2/TbpDNmvWTAU+R44csYioT506hUqVKqn7bdq0wb59+yxmu5SIW4I3U2AoZdatW2dRBykjx4XpWuZlJHso901l5Ly8ueZlpF4SaJrK2FIXIiIie9PpdHiyc3V1++vNpxGfbGW8RqvHAO8gIGY/cHRl0VeSiIgKlfP9bGeFBEaPP/64WrpAxqNJQCUTloj7779f7aUbowRPspSCLKMgSx+89NJLar06U1ZMnkPG802cOFGNqfv444/x/fffq2UPTKSL5Ny5c9XSBtI9VK6TlJSklmcQISEhGDlypCr3xx9/qElX5JwEdTLBiq11ISIiKgx31g5H7YggJKVlYsHmU7kL+JUAWo4y3t74lkynXeR1JCKiYh7gCZkxc9CgQSpoatGiBU6fPo3169erBc+FdK1cvny52kuwNXToUAwfPhyvvvpq9nNUqVJFLZYu2TRZ304mavn888/VDJcmAwcOxNtvv63WrJOZOmW9vFWrVllMmvLee++hb9++ajxgx44dVbfLH3/8Mfu8LXUhIiIqrCzeE1lZvHn/nERSakbuQm2eBLz8gQv/Ascte7YQEZFrc4lZNIV0i5TAS7a8SHfNFStW5Ps8MvPmv//+m2+ZsWPHqi0vvr6++Oijj9R2O3UhIiIqDH0aROLdNUdw6nIyvt12Bo92qGpZIKAU0PwRYPOHwMaZQPUuEhk6qrpERFQcM3hERERkGw+9DmM6VVO35/71H1IzMnMXavsU4OEDnN0KnPqr6CtJRESFggEeERGRG+rfpDwiQ3wRk5CKH3edz10gKAJo9pDx9p8zi7x+RERUOBjgERERuSFvTz1GZXXNnPPnCWRk5l74HO2eBvRexgzemS1FX0kiIrI7BnhERERualDLCggL8Mbpy8n4bZ9xTVkLIeWBxkNuzKhJREQujwEeERGRm/L39sQj7Sqr2x//cQIGg5UlEdo/A+g8gOO/A+d3Fn0liYjIrhjgERERubFhbSoj0McTR2KuYf3h2NwFwqoADR8w3t6Y90zVRORkDJnAyb+AfUuNe7lPxACPiIjIvYX4eWFYm0rq9od/HIdmbWHzDhNkBT3gyAogel/RV5KIbs7BX4BZ9YEFfYEfRhr3cl+Ok30YMqE7/TfKXdms9q4UQDPAIyIicnOPtKsCH089dp+Nw+YTl3MXKFUDqNffeJtZPCLnzqZJEPf9cCDhguXxhCjj8cIO8opD5vCgMYD2/Lofmp/+RO1dKYB2mYXOiYiI6NaUDvLBoBYVsGDzaXy04TjaVi+Vu1DHZ4EDPwIHlwG7vwE8vIHAMkCltoDewxHVJnIN8qV/1fOWAVdwWaDnDKDu3fa9lgRTci1YycSrYzpg1SSgdp/C+XdblK/VUQ5mBdA532NTAP3AQqd/rQzwiIiIioHRd1TDoq1n8M/xy/j3zFU0qVjCskCZekC5ZsaJVpaNcd8vb0TOFAwYDEB6snFLS8ray/2krL358STg4pHcmTsLGpBwHlj1AlCuCeATBPgEG/e+ss/aPL2L/rW6AoODA2g7YYBHRERUDJQL9UP/JuWwZOc5fLzhBOYOb577y5u1WTTd6csbFcOxU8FA1Y6F82U8PQVY8Ww+wQCAH0cDu74CMq5bD+DkeGHYNif/856+eQd/FvezbnsFAMufcfnAp0Cn/7EtgD69CajSAc6KAR4REVEx8Xinali66xzWHozBkehrqBURlONXa7j3lzcqWtKu5ItwYkzRdffN6kLomXAB6ieM05/cfBZaJiJKvgJcuwBcizZ+4Ze93JcfPK5lbUkXC34uCeCOr7HtuhJEefsDXn5mt/0B74CsvT9wPR44/GvBz1WpHeDpA6QkAKnXgNSsfVpiVr1SjJstr8EmWYHPP+8DtXsDoRWNr8NZ21LqNeDyceDSceDysazbx4wZUltIPZwYAzwiIqJiolrpQPSuH6kWPf9kw3HMGtTEeEK+OLnBr9YuEYAUF44Yq2VLF8LqXW8EaObBmnkQJ/vMNPvVq+kIYxYxO2izErxJMKTT2dZmZbIPqbvVbJrO+D4/9Kv1tiyPNwV8OYO/lPgc9xNu3L56Cog/W3D91r1i3ERgBFCiEhBaybgvUfnG7eBytv9bu9W2lJkBxJ2+EbypQO6E8XZiNG6LfF44MQZ4RERExciYTtVUgPfLngsY360WKpb0t/3X6F+eMmYGwmsDpesY9/JFzZYvps7Sra44TRbhKIU9Vsti3FqisetjyjVg+bj8u0taq1N+/EsBwZFAkNmm7pcFgiKAuDPA4gcLfp4G99nvhxH5NyFtVL0WXY7Xk/XvsOebef/bkeN+ocbtZshsmbIUQ0FKVAGSLxsDQwmiZDu71Uo9PIGQClYCwMrG2/4ljZ8rBbalBUDFtpZZuMuSlTsOXDkJGNLzrmtAaaBkDaBUdaCkbDWAsKrAV/2NQX9+AbT8GOTEGOAREREVI/XLhaBTrdLYcOQi5mw8gTf6N7D91+irJ42bORmnU7q2ZdAne/kCbGvgZ49udTejOEwW4ahsZYGTVMA4lktuqnFpiTcmEFHBmvntJOvnZPzaLcm6vmTMVLAmgZoEbBFZtyOMwZsEcfIeSRfH/MjERPK4hCIOBqRtShu1+gPFm4XTduU12PJan9oJ6PTA9avGrJ9k0K6eztqfMt6WTKBkSK19nph4BwIhFYGr/xUQtD+Uf9Du6QeUrGYM4GQ5GFMgJ8fyCnJ73UYA7SQY4BERERUzT3aurgK8pTvO4ekuNVDGli9vgeHGLzaXjgKxB4HYw8CVE8Zf6s9tM27mfEOyAr6sTQWBdYy/mpsHfkUZbEmXrZS4AibGcMPxhoWVrcxMv9G9Ubrwyv7stgK6+wJIvgQsGQa7kEBAujlqBtvGk939AdBkmH2yzrebTbsd8neTNlpUXYxv9rX6hxm3ck2tZ2Cl3eQVAMo5CegvHrShYln1kDF/puCtVFYAJ7dVV1C98wfQdsYAj4iIqJhpUTkMLSuHYdupK/j8r//wYp+6BX956/127i82GWnGrlAXDxkDPgn8Lkrg959xPM/ZLcbNnF/YjaCvVE3gz5kFB1s1exozOebjgyzGDJm2nGOKzMrKZlPmJ2u84eKhxu6o0mUrrIqx+5g9Jo0o6nF/txpAZ6Qav2jHn7cM4Mz3ibE31+XRXFg145dyCc7MNzU+zdoWeGPMmgrq/I3ZGdOX95vpQmiP4M4ZggFpN0U5JtZer1X+ZiHljBvaWW97cWeBf78C/plV8PP1+wRoPASFEUBn/LcRu/9ajcYdesCzsLuN2xEDPCIiomLoic7VsG3+FbU23hOdqqPErXx5k7W0ytQ1bjmnj5cxMRL0qeAva5Nf6K9fMU5FLputwdbrpVHkjqwwbuak+54K+Cob9xIsmAJAyVg627g/W7pL/vo/Y1Y2ZybO1tkV9V7G1xCc9YVdMmn7fyj4cXfNtm9wYmsXwsIYO1XU2TRHKorXKl1jZVycTIhjS4AnY/kKg94DWqX2OH8gAY0qtXepvycDPCIiomLojpqlUa9sMA5cSMD8TacwvltN+3158/IFIhoYN3MyhkqCCcnyScB3Yj0Qvdf25/XwMVujy2wNr+x9UO41vHKWi9oLfN2v4GvVvx/QMozZSJmsQbKCaobFC8Dpv3OXl0khzAM+8wAwoBRw6Ff7dEWVbqZp5lnLxNyZTdN0+PJeF9RdUsZKrX8t77XSTMGb2pvfln054+s27wInQeWZzUUfaDmyu6Tp+u40w6wzvFZHBu0ujgEeERFRMaTT6dRYvCcW7cKX/5zE6I5VEejjWbhf3qRbXdnGxk3IL/S2dKsb+A1Qo2vBk17YQrpZ2fKl8d5PbwQDpnXRZEIIU8Bnfjsp1jhzoGznd+R+Sul2qKbdzyeT9vOTxsfKJCL5BW3SVdXeKrYxdkfNGcDJGKqb7c7o6HFpLj52ipwoaHdhDPCIiIiKqR71IlC1dAD+u5iERVtO47E7qhVtBWz9hb5WT/t9ibuVL40S5ASUNG7l1TyflkzrhJkCPtmrADBr7TBbxv5JMPfP7JvPZlpkKQMtj0nA+e/XBT9X5xftG9Q7MtBy8bFTlAOD9lvCAI+IiKiY8tDr1Pi7Z5fswdy/TuKhtpXh6+Xh/r/Q2/tLowRT1rqkmiaM2PYZsOalgp+nWlfjrIMWgVvOLdg4yYiMfyyIdJeUbrDFbVyaC4+domI+xtFOGOAREREVY/c0Lov31h7F+bjrWLLzHIa1rlQ8fqEvqi+N0q00MqtLakHaj7NvJs3RXdyK07g0KlxsSzflJheGICIiInfi5aHHY3dUVbc//fME0jMNRV8JCbbG7UfG0GXYUWmM2mPcvsLvfmX60tjgPuO+sAIdU1dUU1BlNZNWrvAyaRJAy+Ld5qQ+7rigOxExg0dERFTcPdC8At5fdwznrl7Hr3su4N6m5Yu+Eu7crc7RmTR2cSMqVpjBIyIiKuZk3N3I9sYs3scbTsBguMXFq8l5M2lFla0kIodjBo+IiIgwtHVFfLzhOI7HJuKD9cdRuZQ/woN80bJKmJqMheyAmTQiKgIM8IiIiAhBvl5oX70UVu6Pxnu/H80+Hhnii6l31UXP+jkyT3RrOFkEERUydtEkIiIirNofhVX7o3Mdj45PwZivd6nzRETk/BjgERERFXOZBg3Tfj1odaU00zE5L+WIiMi5McAjIiIq5radvIKo+JQ8z0tYJ+elHBEROTeOwSMiIirmYq/lHdyZe2bxv2hfozQaVQhFkwqhqBURpNbRIyIi58EAj4iIqJiT2TJtEZ2QiqU7z6lN+HjqUa9ssAr4GmdtFcP8odPd/Kyb0v1z68kr2HlJh5Inr6BN9fBCn71TrilZSQlwOWMoEbkLBnhERETFnAQ2MlumTKhibZSdhDzhwT547e762HchHrvPxmHP2TgkpGRg15k4tZmE+nuhUfnQrKAvRN0uGeiT7/VlAhcZ42fsJuqBhcd2FPrsnZbXNOKMoeRKPxbwBwrKCwM8IiKiYk6+FEpgI7NlytdD8yDP9HVx2t310L1+hNqEpmk4eSkJe85JsGcM+g5eSEBccjr+PHpRbSYVwvxUoGfK8tUrGwI/b4/sQEuuq+Uxe+cnQ5vaPeByxDXJfTnixwL+QEH5YYBHRERE6kuhBDY5vzRG5PGlUbphVi0dqLb+TcqrY2kZBhyKSlBBnynLd+JiEs5eua625XujsgPKWmWC0KB8iFqaIa/ZOyW4lPp0qxtht8yEZD1eyWfG0MK4ZnHlqAxTUXb35Q8U5IwY4BEREZEiXwolsLnVL+XennrVNVO24W2Mx+Kvp2P/eWOGz7RdvJaKg1EJasuPafbOvu//hUBfT2QYNBgMGjI1DZkGqNsZBgNk9Qb5Ui+bQdNylNMsz2VqVoO7nNf8/WA0evBLsstlmIqyu29By4sU1g8URX1Na3Vg11Dn5hIB3oYNG9C5c2er57Zt24YWLVqo23v37sWTTz6J7du3o3Tp0njqqacwceJEi/JLlizByy+/jFOnTqFGjRqYMWMGevfunX1eupxMnToVc+fORVxcHNq1a4dPPvlElTW5cuWKeu5ff/0Ver0eAwYMwOzZsxEYGJhdxpa6EBERORv5otamWkm7PV+InxfaVS+lNtP/Z6MTUlR2b8nOc1h3KLbA5zgUfQ1F7bGvdyE8yAe1I4NRJzIIdSJkH4yqpQNua+ZQR2a1iuq6jsow2eu60kavp2fiWkoGEq6nq7GmCSnp2ffVPiUdx2Ku2bS8SPs312d3Sc5m41ufs9j1tEybrvnh+uPoULMUygT7onSgj/rxxR7YNdQ1uESA17ZtW0RFGbt1mEiQtm7dOjRv3lzdT0hIQPfu3dG1a1fMmTMH+/btwyOPPILQ0FCMHj1aldm0aRMGDx6M6dOno2/fvvjmm2/Qr18/7Nq1C/Xr11dlZs6ciffffx8LFixAlSpV1HV69OiBgwcPwtfXOMvYgw8+qOqzdu1apKen4+GHH1bXkOeztS5ERETFkXTtjAzxU1uIn7dNAd7/ulRXAZZer4OnXqf2HjqdClBMmz7rvjqffQ7qtqdeD73eGLzuPhOHMYt22VTX2GupiL12ERvNxhN6e+hRPTwQtSODUDcyGLVV4BdU4EQyzpPVKtzr2pph6lqnjPp7aJrxuARVpjJZNyG5VtNtdV+VzSqX43GStZ36y4E8rysm/bAP565eR2JqRq5gzWJ/PV09n71EJdi2DIk9vff7UbWZhAV4qx8swoN9USbIRwV+MnGSBPuytyUQLG5dQzMdMLOvveg0078MFyJBVbly5VRWTAIwIVm2F198EdHR0fD29lbHJk2ahGXLluHw4cPq/sCBA5GUlITly5dnP1fr1q3RuHFjFYjJW1G2bFlMmDABzz77rDofHx+PMmXK4Msvv8SgQYNw6NAh1K1bV2XmTMHlqlWrVBbw3Llz6vG21MUWEiiGhISoOgQHB2e/9hUrVqjreXl52e09peKHbYnshW2JbucLVPsZ6/OdvVPGAP79/J127eJmyzVXj+uI4xcT1ZjCw1HXjPvoayo4sKZ0kI/K8NWJCFJ7CQCrlQ7Mzvbl9eXY9KqKOqt1s9fNyDSoTJZ0uc21Jadl35aJd7afugp3IE0uyNcLwX6eCPLJ2st9Xy8E+XqqgPDHXecLfB4JpGViofzY+nX8wIV4vLr8UIHlqocH4HqaQWVs0zNt/6pvCgRVAGgWCJYK8MHLP+/H5aQ0q48rjH+rjrTKSTOV1mIDl83g5fTLL7/g8uXLKnNmsnnzZnTs2DE7oBKSeZMumFevXkWJEiVUmfHjx1s8l5SRwEucPHlSBWWSeTORN7FVq1bqsRLgyV4ycabgTkh56aq5detW9O/f36a6WJOamqo28z+i6cuTbKbb5nuiW8W2RPbCtkS348VetfDUd3vynL1TzhsyM2DILNpr+nkCDSID1Wb+Jfxc3HUciU5U3UYl4JPbZ64mq3GFF3Nk+7w8dCrIq10mAOsOXyogq3UAnWqUtOuXYzWhjA1ZrQtxyUjMCt5MQZxkseKuG7NZ8SnpSEq14x/AgRqXD0GtiCAE+0qw5qn2gSpou3Ffgji5HeDtke+ajvL+bjp+CTEJqfn8WOCDwc3L2e3v2qhcED7b+F+B11z+ZFt1TRmLGnc9XWWjpY3GZO3lvjzHxcRUxGbtJRC8kpSmNmnbN8PUNXTz8Vi0qhIGV7b6QIz6fMgrU/nBoEboUa+MQ+pm6/9nXTLA++KLL1TAVL68cdYuIYGZdKk0J5k30zkJqmRvOmZeRo6bypk/Lq8y4eHhFuc9PT0RFhZmUaagulgjXUenTZuW6/iaNWvg7+9vcUy6hxLZA9sS2QvbEt2qh2vq8OMpPeLSbnwJDvHWcG9lAzJP78SK0853zWqyhQB9QgCJfaKSgfPJOlxI0hn3ycbj8kW5oC/Lxi/Hqej05hr4ekBNGmPI6oaYvc/qkmixzzpvum06bnqMJG60AgZ7yZf/V5fb3rvIx0ODvwfg7wn4eWrGfdZ9f08NienAn9E5xptZMbJmJqoGG79Cm9fQPJ6Sm9l3dTnK5XjM8QQd5hwq+Lrtg6+ghtdlQOLVpKxNxrZlbQV3GLbUO0KHeQl6K7UydibtVSYZq1etvMlnLbxryrfJSrLJw0Oztqx2k5wBxKcBCek6415tOsSnQ7XrS6kFB6mjFmxHpUANkf5ApL/sNUT4Sdfm23vNUr8TCTokpAPBXkC1YE1lWO3NoAHTdnlkBXeWFzB1In7px91IP5VZKNcvSHJysvMHeNJtUbJa+ZEukbVr186+L90gV69eje+//x7uZvLkyRYZRsngVahQQY3nM++iKV+iunXrxq5QdFvYlshe2JbodslUZxMNGracuIj1m3fizjbN0Lpa6ULt6mW65o7TV1U2Q7qjNa9Uwm7XNM/2Ldt9AasPFhw6RF93TNe2+mVlLGEQQvwkg+Vl3PvJ3pjZksXr5bjc9ixgghnJanV6Z2OBGabnHuxo92zlMhuuO3agfa8r7ajpgRi8vuIwohNSLbrzvdirdqFkehxxTRmLNnTejgLLXc/U4XC8bJYBeMUS/qhZJtC4hQeiRplAVC7pb9OERZJRm57jtUYE++Cl3rf/WpNSM1SbkYmfZL/91BXEpV3I5xE6xKUBpeu2dkim0tS7z6kDPBnrNmLEiHzLVK1a1eL+/PnzUbJkSdx9990WxyMiIhATE2NxzHRfzuVXxvy86Vhk5I3+tXJfxumZysTGWn5IZ2RkqJk1C7qO+TWs8fHxUVtO8oUp55cma8eIbgXbEtkL2xLdDmk57WqEI/6YpvZF0ZbkCu1rFl5Xq6rh3qgaHoLQAF+bArxnutZQ4/dMk8aYJpORCWJME8fc2N84lvO+6bEyocyT3xQ8ocyLferabeZUeU9fubue6sqWVxfYqXfVg6/PjWEsrnxd0bdxefRqWK5IZ0ct6mvKBCMSQOY3drVMsA/eH9wUJy4m4ojqvnwNR2KuqS6fp68kq22t2aRKMmGRzEorXWbVViYINcsEoVyon2q/prFw1rpLSjAmx/MaQ6ppGuKS01W30ZiEFLWXIC46/rrFMZlU51ZcTs5wyP/vbL2mQwM8WT5ANlvJH0sCvOHDh+d6gW3atFETm8gvyaZz8otyrVq1srtEShmZeXPcuHHZj5MyclxIt0oJwKSMKaCTSFnG1o0ZMyb7OWT5hJ07d6JZs2bq2Pr162EwGNRYPVvrQkRERMWDfPEu6MuxTFAx9s4adv2CHhHsa9N1pX72JF+45Yt3zkkqIgp5kgpHXbcwlhdxtmvKteQ9zC+AlgBb2lLO9nQpMTU74DsaY+yyLEtMJKVlWu3CLGMfa0YEoUZ4IFbtj853DOnkH2UM6XU1tjAm3jyQS0FqhnRWLligj6dqI/JvRbKNG49eKvAxElA7M5cagyeBlEyE8uijj+Y6N2TIEDV+beTIkXj++eexf/9+tTbde++9l13m6aefxh133IF33nkHffr0wXfffYcdO3bgs88+U+dlIK0Ef6+//rpa9860TILMjCnLKYg6deqgZ8+eGDVqlJp5U4K4sWPHqglYpJytdSEiIqLiwZYvx3Le3tkXR11XSDAli20X9Zp/puvKZB9r/tqK7h1audT09s7sVgPoUoE+KFXdJ3stTCGTv5xXXZiNWT4J/OS2ZP8k8Pv3TJzaCnI1OT3fWUVLBnirmUAleJN6yo8exmDOT3XZlXMyqc7NzrJr7x9FinWAJ5OryJp45mPyzGe7lMlIZHFxyayVKlUKU6ZMsVh3Th4ra9W99NJLeOGFF1QQJzNomtbAE7IYuSylII+TTF379u3VMgimNfDEokWLVFDXpUuX7IXOZe28m6kLERERFR/MahUdua6Mj7p8SFN7BnfOF7hLF8wKYf5q61r3Rjfp9EwDTl1KUkHfr2rsquWQJ2saVwhBk4olVBBnDOb81G1Z3sHH08NlfhRBcV8Hr7jgOnhUmNiWyF7YlsheikNbkgxBUWe1HHldRykObcndbT5xGYPnbimw3LejWtv9h4RVXAePiIiIiJw9q+WI6xIV9tjVwugu2dPFu/oWPDcpERERERFRETJ1lxQ5w6qi6C7pkdXVt1kp1+vqywCPiIiIiIicjmkMqWTqzMn9vJZIIHbRJCIiIiIiJ+WoGVldGQM8IiIiIiJyWhxDenPYRZOIiIiIiMhNMMAjIiIiIiJyEwzwiIiIiIiI3AQDPCIiIiIiIjfBAI+IiIiIiMhNMMAjIiIiIiJyEwzwiIiIiIiI3AQDPCIiIiIiIjfBAI+IiIiIiMhNMMAjIiIiIiJyE56OrgDlTdM0tU9ISMg+lp6ejuTkZHXMy8vLgbUjV8e2RPbCtkT2wrZE9sK2RO7YjkwxgSlGyAsDPCd27do1ta9QoYKjq0JERERERE4SI4SEhOR5XqcVFAKSwxgMBly4cAFBQUHQ6XTZkbsEfGfPnkVwcLCjq0gujG2J7IVtieyFbYnshW2J3LEdSdgmwV3ZsmWh1+c90o4ZPCcmf7jy5ctbPSeNzBkaGrk+tiWyF7Ylshe2JbIXtiVyt3aUX+bOhJOsEBERERERuQkGeERERERERG6CAZ6L8fHxwdSpU9We6HawLZG9sC2RvbAtkb2wLVFxbkecZIWIiIiIiMhNMINHRERERETkJhjgERERERERuQkGeERERERERG6CAR4REREREZGbYIDnYj766CNUrlwZvr6+aNWqFbZt2+boKpGLeeWVV6DT6Sy22rVrO7pa5AI2btyIu+66C2XLllXtZtmyZRbnZc6uKVOmIDIyEn5+fujatSuOHTvmsPqSa7ajESNG5PqM6tmzp8PqS85r+vTpaNGiBYKCghAeHo5+/frhyJEjFmVSUlLw5JNPomTJkggMDMSAAQMQExPjsDqT67alTp065fpsevzxx+GMGOC5kMWLF2P8+PFqutZdu3ahUaNG6NGjB2JjYx1dNXIx9erVQ1RUVPb2999/O7pK5AKSkpLU54780GTNzJkz8f7772POnDnYunUrAgIC1GeUfMEisrUdCQnozD+jvv322yKtI7mGP//8UwVvW7Zswdq1a5Geno7u3burNmbyzDPP4Ndff8WSJUtU+QsXLuDee+91aL3JNduSGDVqlMVnk/x/zxlxmQQXIhk7+XXhww8/VPcNBgMqVKiAp556CpMmTXJ09ciFMnjyi/nu3bsdXRVyYfLL5U8//aR+5RTyvxLJyEyYMAHPPvusOhYfH48yZcrgyy+/xKBBgxxcY3KFdmTK4MXFxeXK7BEV5OLFiyr7Il/WO3bsqD6DSpcujW+++Qb33XefKnP48GHUqVMHmzdvRuvWrR1dZXKRtmTK4DVu3BizZs2Cs2MGz0WkpaVh586dqsuTiV6vV/flQ4roZki3OfkyXrVqVTz44IM4c+aMo6tELu7kyZOIjo62+IwKCQlRP0zxM4pu1oYNG9SXq1q1amHMmDG4fPmyo6tELkACOhEWFqb28r1JMjHmn0syJKFixYr8XKKbaksmixYtQqlSpVC/fn1MnjwZycnJcEaejq4A2ebSpUvIzMxUv4abk/vyaxSRreQLt2RU5IuTdC+YNm0aOnTogP3796u+50S3QoI7Ye0zynSOyBbSPVO60FWpUgUnTpzACy+8gF69eqkv5B4eHo6uHjkp6dU0btw4tGvXTn35FvLZ4+3tjdDQUIuy/Fyim21LYsiQIahUqZL6gXzv3r14/vnn1Ti9H3/8Ec6GAR5RMSNflEwaNmyoAj75wPr+++8xcuRIh9aNiMi8O2+DBg3U51S1atVUVq9Lly4OrRs5Lxk/JT9Uckw5FVZbGj16tMVnk0woJp9J8kOUfEY5E3bRdBGSDpZfLnPO/CT3IyIiHFYvcn3yy2bNmjVx/PhxR1eFXJjpc4ifUWRv0pVc/h/IzyjKy9ixY7F8+XL88ccfKF++fPZx+eyRIS4yptMcP5foZtuSNfIDuXDGzyYGeC5Cuhg0a9YM69ats0ghy/02bdo4tG7k2hITE9WvT/JLFNGtku508oXJ/DMqISFBzabJzyi6HefOnVNj8PgZRTnJ5E7yhVwm6lm/fr36HDIn35u8vLwsPpekS52MO+fnEt1MW7LGNFmdM342sYumC5ElEh566CE0b94cLVu2VLP4yPStDz/8sKOrRi5EZjiUNaikW6ZMFy3Lbkh2ePDgwY6uGrnAjwHmv1TKxCryPzgZhC6TFsiYhddffx01atRQ/3N8+eWX1VgF8xkSifJrR7LJuGBZq0x+MJAfnyZOnIjq1aurJTeIcnalkxkyf/75ZzWG3DSuTiZ4krU4ZS9DD+T7k7St4OBgNfO4BHecQZNupi3JZ5Gc7927t1pTUcbgyRIcMsOmdCN3OrJMArmODz74QKtYsaLm7e2ttWzZUtuyZYujq0QuZuDAgVpkZKRqQ+XKlVP3jx8/7uhqkQv4448/ZFmdXNtDDz2kzhsMBu3ll1/WypQpo/n4+GhdunTRjhw54uhqkwu1o+TkZK179+5a6dKlNS8vL61SpUraqFGjtOjoaEdXm5yQtXYk2/z587PLXL9+XXviiSe0EiVKaP7+/lr//v21qKgoh9abXK8tnTlzRuvYsaMWFham/v9WvXp17bnnntPi4+M1Z8R18IiIiIiIiNwEx+ARERERERG5CQZ4REREREREboIBHhERERERkZtggEdEREREROQmGOARERERERG5CQZ4REREREREboIBHhERERERkZtggEdEREREROQmGOARERHl4dSpU9DpdNi9ezecxeHDh9G6dWv4+vqicePGt/Vc8tqWLVtmt7oREZHjMcAjIiKnNWLECBWEvPnmmxbHJSiR48XR1KlTERAQgCNHjmDdunV5louOjsZTTz2FqlWrwsfHBxUqVMBdd92V72Nux4YNG9TfJC4urlCen4iIbMMAj4iInJpkqmbMmIGrV6/CXaSlpd3yY0+cOIH27dujUqVKKFmyZJ6Zx2bNmmH9+vV46623sG/fPqxatQqdO3fGk08+CWemaRoyMjIcXQ0iIpfFAI+IiJxa165dERERgenTp+dZ5pVXXsnVXXHWrFmoXLmyRTawX79+eOONN1CmTBmEhobi1VdfVcHEc889h7CwMJQvXx7z58+32i2ybdu2KtisX78+/vzzT4vz+/fvR69evRAYGKiee9iwYbh06VL2+U6dOmHs2LEYN24cSpUqhR49elh9HQaDQdVJ6iFZN3lNEpiZSIZs586dqozcltdtzRNPPKHOb9u2DQMGDEDNmjVRr149jB8/Hlu2bLE5AyddU+WYBIzi9OnTKgtYokQJlUWU51yxYoU6L8GjkHPyGHm/Ta9J/nZVqlSBn58fGjVqhKVLl+a67sqVK1VQKq/777//xp49e9RzBgUFITg4WJ3bsWOH1boTEdENDPCIiMipeXh4qKDsgw8+wLlz527ruSSjdeHCBWzcuBHvvvuu6u7Yt29fFZRs3boVjz/+OB577LFc15EAcMKECfj333/Rpk0bFeRcvnxZnZOA6M4770STJk1UACIBWUxMDB544AGL51iwYAG8vb3xzz//YM6cOVbrN3v2bLzzzjt4++23sXfvXhUI3n333Th27Jg6HxUVpYIqqYvcfvbZZ3M9x5UrV1QdJFMnQVhOEtjeKnnO1NRU9f5JVlAyqxLUSvfPH374QZWRrqNSN3ktQoK7hQsXqtd84MABPPPMMxg6dGiuIHnSpEmqK+6hQ4fQsGFDPPjggyrQ3b59uwpq5byXl9ct152IqLjwdHQFiIiICtK/f3+VzZKA7Isvvrjl55Es3fvvvw+9Xo9atWph5syZSE5OxgsvvKDOT548WQUZkkEaNGhQ9uMk+yaZMPHJJ5+oAErqMXHiRHz44YcquJMg1GTevHkq6Dl69KjKnokaNWqo6+VHArvnn38++9oSQP3xxx8qG/nRRx+pTKanp6cKquS2NcePH1fdHGvXrg17O3PmjHofGjRooO7L+D7z91aEh4dnB5ESDMr78vvvv6vA2PQYeX8//fRT3HHHHdmPl6xkt27dLK4lgbXpdcj7R0REBWOAR0RELkGCHcmUWcta2UqyXxLcmUh3SulyaZ4tlHFtsbGxFo8zBSdCAqzmzZurTJOQroQShEnQZW28nCnAky6G+UlISFDZxXbt2lkcl/tyDVtJcFdY/ve//2HMmDFYs2aN6jorwZ5k2/IiwaYE0OaBm2kMogTF5uQ9NSfdSR999FF89dVX6lr3338/qlWrZudXRETkfthFk4iIXELHjh1Vl0XJsuUkQVvOwCY9PT1XuZxd/GTsl7VjMm7MVomJiarLpoxXM9+kW6XU2cRad8n/b++OcUwLwziMn7sIDa2GUmEJItHpNBI2YAUKYQ0aCxANyaCwAp1SyQLUopJ783yJm3NcXHJnbuLM80sUDOeMb5r553vf9/sK7HTxHegbfMUl+MbX8XoNCVy73S70GFKiSSijdPbR2mC5XCbWZrvdJvrwbq0P/YWUdNZqtVBaWywWo9ls9tJ3kqTvyIAnSXoblE/O5/NovV4nXs9kMuFYgHg4+cyz6+KDSRjKQk9YoVAIz0ulUggiDHTJ5/OJxyuhjkEi2Ww29OjF8Zxw8yxKJQnClHQej8c/fn7vGAPWEPTPPVpDSk/pVZxOp6EXcDQahdfpL8T5fP79Xn5vhqZQbnm9Nlznb9j9pGePHcN6vX5zAI4kKcmAJ0l6G/R+MXyDPro4plQeDofQ40ZZJOGGqYyfheuxe8SuGINGOLKh3W6Hn/GcwSaNRiMMBOH+q9UqarVaibDzDHrOKEWdTCZhWAmDRQhZnU7n5d+Xe5fL5TD8hN1ESkpZt3i5adwldLFzxvvZdWPgSxxTQPlu+/0+2mw2oTT1EnQ5toGdw8ViEf4W7N4xAZOSWkIaQ2ZYGz7Hrh/P7zmdTqHvkQmbTO4k5LK2l3tJku4z4EmS3grDOK5LKPnHfzgchmDDGH6OB/iXXr1bO4c8uDYDQj4+PsJxB7jsuhGoKpVKCKEEIQaNxPv9nu1xo/eMnTGuwzAX7vXqgBEGmRCkOGaAa9FnSB8ch5wzJOYWSlXH43EIsfTVETQHg0HiPXxHAi3rXa1Www4b645cLhf1er0QSultJKCh3+9H3W43TNO8fI7wyLEJ99ALyZTSZrMZ7sFEUo6h4PqSpMd+/PzKbmxJkiRJ0n/jDp4kSZIkpYQBT5IkSZJSwoAnSZIkSSlhwJMkSZKklDDgSZIkSVJKGPAkSZIkKSUMeJIkSZKUEgY8SZIkSUoJA54kSZIkpYQBT5IkSZJSwoAnSZIkSVE6/AJLEQkzJ5ha8AAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1000x500 with 1 Axes>"
       ]
@@ -7170,6 +6490,674 @@
      "text": [
       "No valid model found for cluster 9.\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 10: Best model is RandomForestRegressor with CV MAE -0.61\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 11: Best model is RandomForestRegressor with CV MAE -0.45\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 12: Best model is GradientBoostingRegressor with CV MAE -1.95\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 13: Best model is RandomForestRegressor with CV MAE -0.42\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 14: Best model is Ridge with CV MAE -0.30\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 15: Best model is GradientBoostingRegressor with CV MAE -1.78\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 16: Best model is Ridge with CV MAE -0.25\n",
+      "FeatureStacker - Transformer 'gmm' output shape: (860, 18)\n",
+      "FeatureStacker - Combined features shape: (860, 28)\n",
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FeatureStacker - Transformer 'gmm' output shape: (3437, 18)\n",
+      "FeatureStacker - Combined features shape: (3437, 28)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3wAAAHWCAYAAAAsDIuDAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAn8xJREFUeJzs3Qd4U1UbB/B/0r1LoaVsyt6g7CnIXgqigqgMERUFRfhEcCE4EFRERUURFRQVEEVAZAjIkCUge8gG6WJ1UTqT73lPmpK0aZtCRpv+f89zucm9J8lJchry5j1Do9fr9SAiIiIiIiKXo3V2BYiIiIiIiMg+GPARERERERG5KAZ8RERERERELooBHxERERERkYtiwEdEREREROSiGPARERERERG5KAZ8RERERERELooBHxERERERkYtiwEdEREREROSiGPAREbmYqlWrYtiwYc6uBjnBN998A41Gg7Nnz6Kk6Nixo9pc5bFL4ntIRPbFgI+ISpRPP/1UfZlq2bJlnmXk/OjRo3MdT0hIwJQpU9C4cWP4+/vDx8cHDRo0wIsvvojIyEgUN/I8TTc/Pz/Uq1cPb775JpKTk83KSgApz9mSX375BT179kSZMmXg6emJ8uXL48EHH8SGDRvyfXx5jNdffx1//vmnTZ+XfFE2fV4eHh6qbm3atMFLL72E8+fP3/J926vOrkKv1+Pbb79Fhw4dEBwcDF9fXzRs2BBTp07F9evXb/l+jxw5ol734hwEZWZm4uuvv1YBYkhICLy8vNSPM8OHD8fu3bsdVo9Vq1ap15KISg53Z1eAiMiRFi5cqL5k7dq1CydPnkSNGjWsut3p06fRpUsXFSw88MADeOKJJ1Rwc+DAAcybN08FPf/++y+Km65du2LIkCHqclJSErZs2YJXX30V+/fvx5IlSwr8cv/YY4+pjMQdd9yBcePGITw8HFFRUer16Ny5M/766y8VaOUVPEkALeyRoXnooYfQq1cv6HQ6XLt2DX///TdmzZqFDz/8UL1ngwYNKvR92rvOt+vRRx9Vz0uCCWcENIMHD8bixYvRvn17FVRIwCdtSl4zaU9//PEHypYte0sBn9yHvOby92tq7dq1KOpu3LiB++67D6tXr1bBsPzwIEGfBLDyes2fP199tlSsWNEhAd8nn3zCoI+oBGHAR0QlxpkzZ7Bt2zb8/PPPePLJJ1XwN3ny5AJvl5GRob6sxcTEqMxOu3btzM6/9dZbmD59OoqjWrVq4ZFHHsm+/tRTTyEtLU29RikpKfD29s7ztu+//74K9saOHYuZM2eqbJrRyy+/rDI97u7O+2/mzjvvNHtu4ty5c+jWrRuGDh2KunXrqmxtUSDZL8mw3i43Nze1OcOMGTNU8PK///0P7777bvZx+XFEMr79+vVTmeLff//dpo8rP7wUdS+88IIK9j744AP192JKPoPkeHEmP/7I54X0eiCiIkhPRFRCvPHGG/pSpUrpU1NT9aNGjdLXrFnTYjn5aHzmmWeyr//444/q2FtvvXXLj3327Fn1mLVq1dJ7e3vrQ0JC9Pfff7/+zJkzZuW+/vpr9Vhbt27VP//88/oyZcrofX199f369dPHxsaaldXpdOo5VahQQe/j46Pv2LGj/tChQ/oqVarohw4dWmCdcj5Po9GjR+vd3Nz06enp2cfk/vz8/LKvJycnq+dQp04dfUZGRqFfD3ne8vg5t8mTJ2eXWb9+vb5du3bq+QcFBenvuece/ZEjR6y+73fffdfi+W3btqnzgwcPNjt+7do1/XPPPaevWLGi3tPTU1+9enX9O++8o8/MzLS6zkePHtUPGDBAtTMvLy9906ZN9b/++qvF9/jPP/9UbSI0NFQfHByszt111136+vXr6/fv36/v0KGDel+lHkuWLFHn5TYtWrRQbUja0rp16yzet2m7kvbQu3dv/ZYtW/TNmzdX9YqIiNDPnz8/12tT0GuQF2kP8pylTqbtxtTw4cNV3bZv356rbmvWrNE3btxY1a1u3br6pUuX5npOObeNGzdmv2ayGclxOb9o0SL966+/ri9fvrze399fvS9xcXH6lJQU9RzldZc2PWzYMHXM1FdffaXv1KmTKiOvg9Tp008/zfWccj62JRcuXNC7u7vru3btmm+5/N7DnO3M9PUz/VtPS0tTz7lGjRrqtZS/0bZt2+rXrl2rzktZS6+lkbzPH3zwgb5evXrq9mFhYfonnnhCf/Xq1VyPK+/b6tWrVRuXsnI7IY8ljyl/s/L6SpuYNGmSVc+diOyDGT4iKjEkoyeZOskISHe/zz77THXza968eb63W758eXZ3uVsljyPZReluJ922pCuXPL50UZPuatL1zdSYMWNQqlQp9eu/lJWuiDKucNGiRdllXnvtNTXeTrotyrZ3716VvZIMnbXkV/nLly9nZ5mkC6Z0L5Ouefll57Zu3YqrV6+qbMWtZJRCQ0PV8x81ahT69++v3hfRqFEjtZeufzIusFq1aqrrmXSJ+/jjj9G2bVv1PHN26yuM1q1bo3r16li3bp1ZV8277roLFy9eVNnfypUrq/dr0qRJqouqvP4F1fnw4cOqfhUqVMDEiRNVxk4yXpLZWrp0qbqNqaefflrdp7yPpuPbpPtpnz59VFuR7sPymHJZ2q+83pKFlfdHsmj3338/Lly4gICAgHyfs3RflrIjRoxQ2c2vvvpKZduaNm2K+vXrW/0a5NcepN7PPfdcnu1Gug7LGLaVK1eiVatW2cdPnDiBgQMHqucldZMy8rwlIyZdjqUL5LPPPouPPvpIdYWUzKww7vMybdo0lXGS90Kev7QfGc+p1WpVXaVd7dixQ2WpIyIi1PtgJK+5vC733HOPej4rVqxQ75d0D37mmWdQGJLRlF4Ct/P5YS15TvK8H3/8cbRo0UKNO5bxgfI3I6+lvK8y3ljavmTgc5Lz8nrIuEJ5zaVXxOzZs/HPP/+ozwZ5/YyOHz+uPkflNiNHjkTt2rXV34C0XfmbkHGb0rVYXnu5LRE5kZ0CSSKiImX37t3ql2xjRkSyY5LFkF/6C8p83XHHHerX6tshGZCcJNMhj7VgwYJcv+536dJF1dFIsn2SdZMMhZBsn2Qe5Fd203IvvfSSur21GT5Lm2QTc2Y8cmb4PvzwQ1X2l19+0d+qS5cu5Zm5aNKkicouXLlyJfuYZL20Wq1+yJAht5XhE/fee68qEx8fr65LplSe37///mtWbuLEiep1P3/+fIF17ty5s75hw4Zmr528N23atDHLJhvfY8le5syOSrZIzn3//ffZx44dO6aOyXPfsWNH9nHJislxub+CMnxybPPmzdnHpP1IVmb8+PHZx6x9DSyZNWtWge1BskRS5r777stVN9OMnrwn5cqVU393RpLhNM3q5XzNLGX4GjRooDJeRg899JBeo9Hoe/bsaXb71q1bq3oU9PfavXt3fbVq1fJ9bEvkb1fq888//+jtneGTLKl8JuRHPtssff2TDLAcX7hwodlxyeLlPG583+ScKcnyyXH5OyGiooOzdBJRiSDZEZksolOnTuq6jDeTrMKPP/6oJpvIj/xKXlAGpSCmY1vS09Nx5coVNWGMzGQov77nJOOeTMfEySQYUk8Zg2bMgEkmTzKBpuVyjg8qyL333qt+7Zft119/VdkcyaxIBsnwPTPv10Tc7utiiWST9u3bpzJQMrGFkWQNJEshk07cLuOMo4mJiWovE4rIayxZVcl4GjeZqEde982bN+d7f5LtlFlJZaya3Kfx9vI+d+/eXWWxJHNmSrIilrKjUjfTCWUkcyLtRDJaprPLGi/LhEIFkdlX5fkZSWZR7tf0trfzGhhfx/zag/Gcse0YyayuptnPwMBAlQ2UrFJ0dDRuldyHaUZKXi/jREOm5LhkSSULZ+nvNT4+Xr0Okv2U10uuF4Y9/1ZyknYiWTZpb4Ul739QUJD6GzN9/yULLG1y48aNZuUlKyptO+fjC/kskWwoERUN7NJJRC5PvqxKYCfBnnRRMv2iJxOPrF+/XnWFzIt8AbXmS3V+pEuidLWS7mryxd80mLL0BVK605mSL+FCuqIJY+BXs2ZNs3LyRd5Y1hrSvVS+0BtJF7bSpUuriTek613fvn3zfE1Mv+jbkvG5SUCSkwQ9a9asue1JTmRGUtMv4fIFWWZcldfPktjY2HzvT7qtyXsqM5zKltd9SHdP0y/Meb0npkG8kC/ilSpVynXMtE3kJ2d7EtJOTG97O6+B8XXMrz3kFRTKDx85n69MJiSkO7PM/Horcj5n4+tl6XWU4ET+DqXtC+mCKN2pt2/fnmuJEilnvC9r2PNvJSfpRik/4sjrJ0vG9OjRQ3UlNXY7zo+8//LcwsLCrHr/LbVf+RHtyy+/VF1KpSutzNQrXZ+lO7F0pSUi52DAR0QuTzIvkjWSoE82S9m//AK+OnXqqGyDZAFyflm0lmTiJNiTDJyMIZMvjPIlVzI5ln4Jz2tcXH5ZN1uRL2lCMjp5BXzymoiDBw+qMWrFzaFDh9QXW+OXcXkPJLMxYcIEi+WNAUhejO+hBMo5sx5GOZcAyWtGw7ze+9tpE9bc9nZeA+N4OgkY82oPcs6YbXSEW30dT506pf4GpI3L7LPyNy/jfiWzLLNpFjZzZfq30qRJE9hSzt4JMt5R6i8ZNlmuQoIvqfOcOXNUEJYfeV7yNyGfh5bk/CHAUvuVY/K5IdnA3377TfUWkHHHd999t6qPs2aQJSrpGPARkcuTLzDyRUbWnspJlh+QNePkC1FeX8Al6Pnhhx/w3XffqS6Pt+Knn35SE1JIRtF0wpS4uLhbur8qVapk/yovE5sYXbp0yaqMT36MXduMWTBLZGkKyRDJ6yITadzKF7mcWZ2cz00mhcjp2LFjahH128nuSdZGvhSbLtkgk7jI8zXNdhamzsb3QLoQFnQfRZW1r0Fe7UG6833//fdqSQ5L7WHBggVqL5N6WMqOmr62xjUtjZPz5PW624NM0JKamqomazLNEubs0mgtmXxIXg/5/LjViVvkby3nZ4V06ZYfsnKSbtAy6Yps8n5KECiTuRgDvrxeS3n/pau4TDx0O8srSCZPAmbZJGB+++23VZuQ16+4/m0QFXfMrxORS5OulBLUyZdM6VaUc5OZL6WrlXEmTkukXMOGDdV6exIs5CS3ly80+ZEvfDkzMTJrYEHjB/MiX5wkuJD7ML3f/GZSLMwXXpHfGnUyq+iLL76Io0ePqr2lLJN8wZUF7vO7D5Hzi2y5cuVUJkRmCzU9J1k5yRLIjKS3011UxgZKxkbWRjOSsXfy3kp30ZykDsYgOK86yw8KMuPq559/bvFLuATiRZ21r4El8rpIdlOCdEt/C5LtkdkfJftpOkOnkFkj5UcX0zFvEhxKGzB25zQG+Lf6A0lhGIPVnN2uJUN/KyRDKOM1pe3K36ulzJr8EPTff//leR8SjOUcQ/nFF1/k+vyQMaOmZOydZJYlgDXK67WU91/u74033sj1+PLeW/Pay1jWnIxZTdM6EJFjMcNHRC5NAjkJyGRsmiXy5VO6KkkWUMafWCKBlQSNEmTJr+XyxUh+BZfjMkGCZDXkF3gJCPMiAadMgy5dOaVLm3yxll/TjWOGCkvqLF+wZVyg3LcEQdLtVKaAlwyYtSSTIoGZkLFKMk29BFryJbGgbIQETPL85cuq/HovgbF8QZeJNpYtW6aCPZnWPy+SRZDXQrp8SXdByUzIuCPZZMkByYxI91dZSsC4LIO8fpKtsIZMhiPPTb5Qy5dVWRpDlkeQDIe8F6bjmuS5SFuR19K4XIGME5RueJKdlbFk8rrmV2fJIEumS34ckC/4kvWLiYlR77V8md+/fz+KMmtfg7zImC1pg9OnT1fPecCAAer1kiUb5H2Qbp/StnKS11HeY3l/ZGIlWTJCXjfTAEuCBgnE5L4l+JLp/qWbYF7jzW6HdO+WHwQksy9LDkiWbO7cueqxLAXz1pC/Eckqy1IHxh+g5DPj/PnzarIUyVybTtSTk2TnZNkKeU2l2620JQnMc74f0jblhwd576RtypIM8t7JD1tGck5IXSQAl9dVHlsmpZHnK58pMmmSvA7yGSe9CKSOH374ofobL2gMoQSmvXv3Vpl6Gff36aefqnGp8rdBRE7i7GlCiYjsqW/fvmqR6uvXr+dZRhZe9vDw0F++fDnfBcllUerXXntNTb0vi4HL/crU77KocFRUVL71kNvKwtOykLosAi1TvMt0+zmnVTdOyf7333+b3d441bzptPSySPKUKVPUFPa3uvC66SZT78tSFbLQckxMTL7LMpj66aef9N26dVOLPMsC01KfgQMHqkXCCyKLoMvCzbLERM6p5//44w+1gLM8t8DAQPVeFmbhdeMmdZK6tWzZUr1X586ds3i7xMREdV4WrZb6yHslSyq89957ZtP751fnU6dOqWUjwsPDVZuqUKGCvk+fPuo1Kug9Nl14PSfjQtc55Wyr+S28bumxci4pYO1rkBdpk1IHed/kPZO/EXk+0k6TkpLyfF6yxESjRo3UUhF16tTJXmje1Ny5c9WyCNJOrVl4Ped95PW6y/uXcymB5cuXq/pI/atWraqfPn26Wow952trzbIMRrIEx5dffqlv3769WuZF2oc8f/lcMF2ywdJ7KK/riy++qN4P+eyRz4+TJ0/m+lt/88039S1atNAHBwervxt5Ld966y2z907qMWbMGLWovCxTkfOr4BdffKHat9w+ICBAfd5NmDBBHxkZmet9y2n9+vVqyRNZ7F7aj+xlOYycS30QkWNp5B9nBZtERERUcskYPcmOyoywRERkHxzDR0RERERE5KIY8BEREREREbkoBnxEREREREQuimP4iIiIiIiIXBQzfERERERERC6KAR8REREREZGL4sLrRZgsFhwZGYmAgAC1UDAREREREZVMer0eiYmJKF++PLRa6/N2DPiKMAn2KlWq5OxqEBERERFREXHhwgVUrFjR6vIM+IowyewZ39TAwECkp6dj7dq16NatGzw8PJxdPXJBbGNkb2xj5AhsZ2RvbGPkjDaWkJCgkkHGGMFaDPiKMGM3Tgn2jAGfr6+vuswPF7IHtjGyN7YxcgS2M7I3tjFyZhsr7FAvTtpCRERERETkohjwERERERERuSgGfERERERERC6KY/iIiIiIiMhhSwtkZGQgMzPT2VUpctzc3ODu7m7z5dgY8BERERERkd2lpaUhKioKycnJzq5KkSUTtZQrV86mQR8DPiIiIiIisiudToczZ86oLJYsHO7p6WnzTFZxz3ympaXh0qVL6nWqWrWqze6bAR8REREREdmVBDMS9Mk6cpLFotx8fHzUEgznzp1TyzLYCidtISIiIiIih9BqGX5Y8/pIxs9W+IoTERERERG5KHbppILpMoFz24CkGMC/LFClDaB1c3atiIiIiIioAAz4KH9HlkO/+kVoEiKzD+kDy0PTYzpQ7x6nVo2IiIiISp5MnR67zlxFbGIKwgK80SIiBG5aTgCTF3bppPyDvcVDoDcJ9oRcl+NynoiIiIjIUVYfikK76Rvw0NwdeO7HfWov1+W4vW3fvl3NMtq7d2+z42fPnlUzju7bt8/s+NKlS9GxY0cEBQXB398fjRo1wtSpU3H16lU4EgM+skyXiRsrXlADRnM2Erkux+W86u5JRERERGRnEtSN+m4vouJTzI5Hx6eo4/YO+ubNm4cxY8Zg8+bNiIw0T4jk9PLLL2PgwIFo3rw5fv/9dxw6dAjvv/8+9u/fj2+//RaOxC6dZFHm2b/gcyMayCM7LllzOS/l3Kp1cHT1iIiIiKiYUwmE9Eyru3FOXn4YluaulGPylfX15UfQtkYZq7p3+ni4FWodwKSkJCxatAi7d+9GdHQ0vvnmG7z00ksWy+7atQtvv/02Zs2aheeeey77uKyt17VrV8TFxcGRGPCRRadOn0Ita8sx4CMiIiKiQpJgr95ra2xyXxL0RSekoOHra60qf2Rqd/h6Wh8KLV68GHXq1EHt2rXxyCOPYOzYsZg0aZLFoHHhwoWqC+fTTz9t8b6Cg4PhSOzSSRbF6oNtWo6IiIiIqLiaN2+eCvREjx49EB8fj02bNlkse+LECVSrVk0tol4UMMNHFrlVbYvIrSEIx1XVfTMnWQsyBsGqHBERERFRYUm3Ssm0WUNm5Rz29d8FlvtmeHM1a6c1j22t48ePq26av/zyi7ru7u6uxudJECiTsuRky0XTbYEBH1nUonooXvZ4HG+nz4BObxizZyRtWLLXPshAC79oAGHOrCoRERERFUPSHdLabpXta4aiXJC3mqDFUjglX1XDg7xVOVsv0TBv3jxkZGSgfPnyZkGdl5cXZs+enat8rVq1sHXrVqSnpxeJLB+7dJJF8ofSsd9jeDp9LKJh/itJLIIRqQtBEJKg/aYXcGqD0+pJRERERCXju+nkvvXU5ZzhnPG6nLd1sJeRkYEFCxaoGTZl2QXjJrNtSgD4ww8/5LrN4MGD1SQvn376qcX75KQtVGT0aFAOGPwUHljeFpWS9iMMcSrYO+bZALrURHzu8QFapx2BfuED0PT9ELjD0K+ZiIiIiMge300/e+ROTFlxxGxpBsnsSbCnvrva2MqVK3Ht2jWMGDFCradnasCAASr7J2P6TLVs2RITJkzA+PHjcfHiRfTv318FhydPnsScOXPQrl07s9k77Y0BH+VL/nC61gvHrjNNEZuYgrAAb9UveuWBSIxY7IW38Dn64y/g12eAuAtAx4mG/p5ERERERHb7bnrV7LuprTN7RhLQdenSJVewZwz4ZsyYgYSEhFznpk+fjqZNm+KTTz5RQZ5Op0P16tVx//33Y+jQoXAkBnxUIPkDal29tNmxe5tUQLCvJ5761hMXM8pgtPuvwKZ3gPgLgGT73JzfX5mIiIiISsZ3U3tZsWJFnudatGiRPUGLpYlaHnzwQbU5G8fw0S27q1YoFo5shS89H8Gk9BHIlOa0byGw8AEgJfcvHURERERE5FgM+OxM0rhVq1aFt7e36s8rU7q6kjsrl8KSJ1tjo19vjEgbj2R4A6c3Al/3BBIinV09IiIiIqISjQGfHS1atAjjxo3D5MmTsXfvXjRu3Bjdu3dHbGwsXEnNsgH4aVRrnA9phwdTX8FlBAMxh4AvuwAxh51dPSIiIiKiEosBnx3NnDkTI0eOxPDhw1GvXj01YNPX1xdfffUVXE3FUr5Y8lRraCvcgX6pU3BKXwFIuAh81QM4tdHZ1SMiIiIiKpE4aYudpKWlYc+ePZg0aVL2Ma1Wq2b52b59u8XbpKamqs3IOOOPLNpo3IzXi6JALy3mD2uKZ753Q//TkzHX8wO0TD0K/cL7kdl7FvSNBjm7ilSAot7GqPhjGyNHYDsje2MbKzx5rWRiE5mtUjayTF4beZ1k/b+cbexW25tGb2lKGbptkZGRqFChArZt24bWrVtnH5c1OTZt2oSdO3fmus3rr7+OKVOm5Dr+/fffq8xgcZGhA749ocWRq5l4z2MO7nEzBLhHy92Hf8vey2UbiIiIiEoYd3d3hIeHo1KlSvD09HR2dYp00ujChQuIjo7ODvqMkpOT1aLu8fHxCAwMtPo+meErQiQbKGP+TDN88kfRrVs39aZKVL9u3Tp07doVHh5Fe9mD3jo9Xl95FM/9/Qwu6stglPsK1I36GbXDfJDZ4z0u21BEFac2RsUT2xg5AtsZ2RvbWOGlpKSoQMbf319NZkh5v04+Pj5o06YNNm/ebNbGLK33Zw0GfHZSpkwZuLm5ISYmxuy4XJdfNyzx8vJSW07yJpt+mOS8XhRJ7abd1wihAd6YvuEhFfRN9ZgP7f6F0CZFAw98A3hb/8sEOVZxaGNUvLGNkSOwnZG9sY1ZLzMzExqNRg1xko0sk9dGXifJiOZsY7fa1vhq24mkqps2bYr169eb9cmV66ZdPF2ZNNbx3Wpjct96+C6zKx5PG4dUjTdwaj3wdS8gIcrZVSQiIiIicmkM+OxIumfOnTsX8+fPx9GjRzFq1Chcv35dzdpZkgxvG4FZA5tgM5rigZSXEa+VZRsOZi3bcMTZ1SMiIiKi4kSXCZzZAhz8ybCX65QnBnx2NHDgQLz33nt47bXX0KRJE+zbtw+rV69G2bJlUdL0u6MC5g5phn/da6L3jddx0a0ikPCfYdmG05ucXT0iIiIiKg6OLAdmNQDm9wGWjjDs5boct5Nhw4apnmvGrXTp0ujRowcOHDiQXUaOL1u2zOx2GzduRK9evVR5mYBRlmkbP348Ll68CEdiwGdno0ePxrlz59RyCzIzZ8uWLVFSdaoThu9GtESCV3n0uv4aDrnVA1Ljge8GAPsXObt6RERERFSUSVC3eAiQEGl+XIYJyXE7Bn09evRAVFSU2mSIloyx69OnT57lP//8c7Ucm8zdsXTpUhw5ckStyS0zbL7//vtwJE7aQg7VrGoIFj/VGkPm7cKAxAn41HcuOuv+An55Aog/D7T/H5dtICIiIioJZHW49GTrykq3zd8nyI0s3ZHk2IDVLwLVOgJat4Lvz8O3UN85ZWJF48SLsp84cSLat2+PS5cuITQ01Kzsf//9h2effVZtH3zwQfbxqlWrokOHDoiLi4MjMeAjh6sTHoilo9rg0Xk78fiVUXjdpwyG6n8FNrwJxF0Aes8E3Ng0iYiIiFyaBHtvl7fRnekNmb93KllX/KVIwNPvlh4pKSkJ3333HWrUqKG6a+a0ZMkStZ6erL9tSXBwMByJ36rJKSqF+OKnUW0w9KtdmBw5EBe8SuNl7TfQ7J0PJFw0LNsgv7yc2wYkxQD+ZYEqbaz7xYaIiIiIyIZWrlyp1hAUMgljuXLl1DFLS0ycOHFCraEtZYoCBnzkNGX8vfDjE60wcsFufHm6Cy66h2C212y4nfwD+KwtkJEKyJp9RoHlgR7TgXr3OLPaRERERGQL8uO+ZNqsIUmAhfcXXO7hnwxJAmseuxA6deqEzz77TF2+du0aPv30U/Ts2RO7du1ClSpVzMrq9Xo1iUtRwUlbyKkCvD3wzfAW6F6/LH7PuBP333gJae7+QNw582DPQQNyiYiIiMhBJCiSbpXWbNXvNvz4L2P1LN8ZEFjBUM6a+9MULiDz8/NTXThla968Ob788kuV6ZMl2HKqVauWmpxFJngpChjwkdN5e7jhk8F3YmCzStivq4a4dDeLw3GzB+munsj1VoiIiIhKEhnWIz29lJzBWtb1Hu84bPiPRqNR3Tlv3LiR69z9998PT09PzJgxw+JtOWkLlUjublq8M6AhGmceRNjR+AIG5F40pPUj2juwhkRERETkVDKs58EFhtk4TZdmUMN+3rHrsJ/U1FRER0dnd+mcPXu2mrylb9++ucpWqlRJzc4py7MlJCRgyJAhaoZOmb1zwYIFaiygI5dmYMBHRYb8UjK4nhdw1IrCMpELEREREZUsEtTV6e3wif1Wr16dPQlLQEAA6tSpo2bj7Nixo8XyTz/9tOra+d5776F///4qEyhBn6zdN27cODgSAz4qUjL9wuBmw3JERERE5GIkuHNgT69vvvlGbfmRiVpykoXXZXM2juGjImVXZh1E6kOg0+e9PmeUPkSVIyIiIiKi/DHgoyIl9no6pqQPUZdzBn0S7MmESpd1gbiUmHuALBERERERmWPAR0VKWIA31uhaYFT6WEQjxOzcZQQiTe+Ghm5n0eL4u4YIkIiIiIiI8sQxfFSktIgIQbkgb6yNb4F1qc3QQnsMYYhDLIKxS1cH3bS78annhwg//i2wox7Q+mlnV5mIiIiIqMhiho+KFDetBpP71lOX9dBih64eluvaqL0OWqzWtcAsPGIovOYl4OhK51aYiIiIiKxmaXITyv36yOz1tsKAj4qcHg3K4bNH7kR4kLfZ8fBAL4QHeuOjlB743buXYU2+pY8DF/c6ra5EREREVDAPDw+1T05OdnZVijTj6+PubruOmOzSSUU26OtaLxy7zlxFbGKKGtsn3T3/u5aMez/5C6PjHsKK0pdR7/ou4PuBwMj1QHBlZ1ebiIiIiCxwc3NDcHAwYmNj1XVfX1+bZrFcIbOXnJysXh95neT1shUGfFSku3e2rl7a7FiV0n747OGmeHTeTjx45Qn8Wfoaylw/ASx8EBixBvAOclp9iYiIiChv4eHham8M+ig3CfbkdcrIyICtMOCjYkeCwKn3NsBLvxxE3yvPYmPwG/C+dBRYPBR4eAngZugyQERERERFh2T0ypUrh7CwMKSnpzu7OkWy26stM3tGDPioWBrcsjL+jUnEN9uAh68/j8Veb8Dt9Ebgt3FA348MC/YRERERUZEjQY09AhuyjJO2ULH1Su+6aF+zDPakV8GLGAu9RgvsXQD8NcvZVSMiIiIiKhIY8FGx5e6mxezBd6JaqB9+SmqAL/2eMJz443Xg0M/Orh4RERERkdMx4KNiLcjHA/OGNlf7ty53wKZS9xtO/PIUcGGXs6tHRERERORUDPio2Iso44dPH75Tzeo5PKofzpS+C8hMBX4YBFw97ezqERERERE5DQM+cglta5TB633rQQctekcORUJwfSD5imG5huSrzq4eEREREZFTMOAjl/Fo66p4tFUVJOu90ffqaKT7lweunAAWPQpkpDm7ekREREREDseAj1zKa33roW2N0jiXFoTH0iZA5+kPnNsKLB8D6PXOrh4RERERkUMx4COX4uGmxaeDm6pxfVsSwvCW70ToNW7AgR+BTTOcXT0iIiIiIodiwEcuJ8jXA3OHNEOAtzvmRVfDT+HPG078+Tawf5Gzq0dERERE5DAM+Mgl1QjzxyeDDTN3vnDmTuyrPNRw4tdngLN/Obt6REREREQOwYCPXFaHWqF4tXdddfm+E10RW7E7oEsHfhwMXD7h7OoREREREdkdAz5yaUPbVMXglpWh02vR4/wjuBF2B5ASByy8H7h+2dnVIyIiIiKyKwZ85NI0Gg2m3FMfraqF4GqaGx5IeBaZgZWBa2cNmb70FGdXkYiIiIjIbhjwUYmYufOzh5uiSmlfHIrzwv88X4HeOwi4sBNYNgrQ6ZxdRSIiIiIiu2DARyVCKT9PzBvaDAFe7vjlP398ET4Feq07cPhnYOObzq4eEREREZFdMOCjEqNGWAA+HnwHtBpg2rEwbK79quHElveBvd86u3pERERERDbHgI9KlI61w/By73rq8vB9NXG2/tOGEyvHAqc2OrdyREREREQlNeB766230KZNG/j6+iI4ONhimfPnz6N3796qTFhYGF544QVkZGSYlfnzzz9x5513wsvLCzVq1MA333yT634++eQTVK1aFd7e3mjZsiV27dpldj4lJQXPPPMMSpcuDX9/fwwYMAAxMTGFrgs5x2Ntq2Jgs0rQ6YG+h+5CQs1+gC4DWDwEiD3q7OoREREREZW8gC8tLQ0PPPAARo0aZfF8ZmamCrCk3LZt2zB//nwVzL322mvZZc6cOaPKdOrUCfv27cPYsWPx+OOPY82aNdllFi1ahHHjxmHy5MnYu3cvGjdujO7duyM2Nja7zPPPP48VK1ZgyZIl2LRpEyIjI3HfffcVqi7k3Jk73+jXAC0iQpCYmon+/z2M9AotgdQEYOGDQKJ58E5EREREVFwVm4BvypQpKtBq2LChxfNr167FkSNH8N1336FJkybo2bMn3njjDZWtk8BLzJkzBxEREXj//fdRt25djB49Gvfffz8++OCD7PuZOXMmRo4cieHDh6NevXrqNpKl++qrr9T5+Ph4zJs3T5W7++670bRpU3z99dcqsNuxY4fVdSHn8nTXYs4jTVEpxAenrqXjqYzx0IdUB+LPAz8MAlISgTNbgIM/Gfa6TGdXmYiIiIio0NzhIrZv366CwbJly2Yfk8ycZAQPHz6MO+64Q5Xp0qWL2e2kjGT6hARje/bswaRJk7LPa7VadRu5rZDz6enpZvdTp04dVK5cWZVp1aqVVXWxJDU1VW1GCQkJai+PZ9yM1+n2BXhq8PngO/DA3J1Yfy4D7zacihdujIEmci/079WAJuPmGn36gPLI7PY29HX6wJWxjZG9sY2RI7Cdkb2xjZEz2tittjeXCfiio6PNAixhvC7n8isjgdWNGzdw7do11R3TUpljx45l34enp2eucYRSpqDHMa2LJdOmTVOZzJwkYyhZRqN169bl+1pQ4TwcocHcY1p8elCDBmXuRk/8ZBbsKYmRcFs6DH9HjEFUcHO4OrYxsje2MXIEtjOyN7YxcmQbS05OLn4B38SJEzF9+vR8yxw9elRl0EoCySzK+EEjCUQrVaqEbt26ITAwUEX18qZ37doVHh4eTq2rK+kl6/RtPYt31xzDHYkbAE3uMnJIDw2aX/kZGYNeAbRucEVsY2RvbGPkCGxnZG9sY+SMNmbs/VesAr7x48dj2LBh+ZapVq2aVfcVHh6eazZN48yZcs64zzmbplyXYMrHxwdubm5qs1TG9D6k62dcXJxZli9nmYLqYonMHCpbTvImm36Y5LxOt++pjjWAc3+h3NmreZbRQA8kXIRH5N9ARHu4MrYxsje2MXIEtjOyN7YxcmQbu9W25tRJW0JDQ1X2Lr9Nuk9ao3Xr1jh48KDZbJoSFUswJ5OvGMusX7/e7HZSRo4LeSyZhMW0jE6nU9eNZeS8vNimZY4fP66WYTCWsaYuVPRm7ny8yc1us/lK4iyeRERERFQ8FJsxfBJQXb16Ve1lnJ0sqyBkLT1ZC0+6PUow9eijj2LGjBlqrNwrr7yi1sszZs2eeuopzJ49GxMmTMBjjz2GDRs2YPHixfjtt9+yH0e6VA4dOhTNmjVDixYtMGvWLFy/fl3N2imCgoIwYsQIVS4kJEQFcWPGjFFBnkzYIqypCxU92sC8s6+mMv3C4JodOomIiIjI1RSbgE/WsJP17IyMM11u3LgRHTt2VF0xV65cqWbClODLz89PBW5Tp07Nvo0sySDBnSzv8OGHH6JixYr48ssv1QyaRgMHDsSlS5fU40mgJssqrF692mwSFlnGQWbvlAXXZVZNuf2nn36afd6aulDRsyuzDqroQxCOq9BaGMen1wOXEIRTmXVgyOUSERERERVtxSbgk4XLZctPlSpVsGrVqnzLSHD4zz//5FtG1ueTLS/e3t5qTT3ZbqcuVLTEXk/HN+lD8JnHLOj0MAv6JNjTaAAvfRqux5wAaoY5s6pERERERK618DqRvYUFeGONrgVGpY9FNELMzkWjFM7rQhGkuYH220YA8f85rZ5ERERERC6X4SOytxYRISgX5I218S2wLrUZWmiPIQxxiEUwdunqoBQS8bPPG6iSHAks6AcM/x3wD3V2tYmIiIiI8sQMH1EWN60Gk/saZlHVQ4sdunpYrmuj9jpocQVB2NRiLhBUCbhyAviuP3AjztnVJiIiIiLKEwM+IhM9GpTDZ4/cifAgb7PjXu6GP5WZfyfjXO+FgF8oEH0Q+GEQkJbspNoSEREREeWPXTqJLAR9XeuFY9eZq4hNTFFj++qXD8Sj83Zi/3/xGPzzFSy//0eUXnIfcH47sPhRYNAPgLt1a0YSERERETkKM3xEeXTvbF29NO5tUkHtA3088NWw5ogo44eLcTfw8MpkJN3/PeDhC5z8A/h5JKDLdHa1iYiIiIjMMOAjslJpfy8seKwFQgO8cCw6EY9tcEPagPmA1gM4sgxY8Zxh/QYiIiIioiKCAR9RIVQK8cU3w5vD38tddfl8bndpZN73JaDRAv98C6x9hUEfERERERUZDPiICql++SB8MaQpPN20+P1QNF4/WQP6vh8aTm6fDWx5z9lVJCIiIiJSGPAR3YI21ctg5sDG0GiAb3ecw+xrrYHubxtObngT2PmFs6tIRERERMSAj+hW9WlUHpP7GNbte3/dv/jRrS9w14uGk7+/AOxf5NwKEhEREVGJx4CP6DYMaxuBpztWV5df+uUg1oU9BrR8ynBy2Sjg2G/OrSARERERlWgM+Ihu0wvda+OBphWh0wOjf/gHe+q+ADQeDOgzgSXDgNObnF1FIiIiIiqhGPAR3SaNRoNp9zXE3XXCkJqhw2Pz9+JEq7eBOn2AzDTgh4eA/3Y7u5pEREREVAIx4COyAXc3LWYPvgNNKgUj/kY6hnyzF1FdPwGqdQTSrwPfDQBijji7mkRERERUwjDgI7IRX093fDWsOaqF+iEqPgVDF+xH/D3fABWbAylxwLf9gaunnV1NIiIiIipBGPAR2VCInycWPNYCZQO98G9MEh7/8ShSHvwRCKsPJEUDC/oBCZHOriYRERERlRAM+IhsrGIpX8x/rAUCvN3x99lreHbZWWQ8vBQoFQHEnTNk+pKvOruaRERERFQCMOAjsoM64YGYO6QZPN21WHskBq+uvwz9kGVAQHng0jHgu/uAlARnV5OIiIiIXBwDPiI7aVWtND4c2AQaDfDDrvP4cE8aIEGfTwgQ+Y9h9s70G86uJhERERG5MAZ8RHbUs2E5TL23gbo8648TWHjaG3j0Z8AzADi31bBOX2a6s6tJRERERC6KAR+RnT3aqgqevbuGuvzqskNYc60cMHgR4O4N/LsaWDYK0OmcXU0iIiIickEM+Igc4PmutTCoeSXo9MCYH/7BLn1d4MEFgNYdOLgEWPU/QK93djWJiIiIyMUw4CNyAI1Ggzf7NUCXumWRlqHD4/P/xvHANkD/z+UssHsesH6qobAuEzizBTj4k2Ev14mIiIiIboH7rdyIiArP3U2Ljx+6A4/M24k9565h6Fe7sPTp3qjQZyaw8nlg60wg4SJwdov5Wn2B5YEe04F69ziz+kRERERUDDHDR+RAPp5umDe0GWqG+SM6IUUFfXH1HgG6TDEUOLAo98LsCVHA4iHAkeVOqTMRERERFV8M+IgcLNjXUy3MHh7ojZOxSXjsm79xo9nTgKd/HrfIGtu3eiK7dxIRERFRoTDgI3KC8sE+WDCiBQK93bH3fBxmfzMfSEvK5xZ6Q3fPc9scWEsiIiIiKu4Y8BE5Sa2yAZg3rDm83LW4cP6sdTdKirF3tYiIiIjIhTDgI3Ki5lVD1EQulxBs3Q38y9q7SkRERETkQhjwETlZt/rhuOee+xGpD1Hr9FkiS/SleQYDVdo4unpEREREVIwx4CMqAh5sURUzMFxdzhn0SbCn0QCeaXHQrRwHpN9wTiWJiIiIqNhhwEdUBOw6cxXLUptiVPpYRCPE7FwUQrAqswV0eg20e78B5nYGLh13Wl2JiIiIqPjgwutERUBsYorar9G1wLrUZmihPYYwxCEWwdilqwMdtGinPYgvA76Ad+xh4IuOQO/3gSaDnV11IiIiIirCmOEjKgLCAryzL0twt0NXD8t1bdReroutuoY41HcVEHEXkJ4MLBsF/PwkkJrfcg5EREREVJIx4CMqAlpEhKBckDc0+ZQJDfDCHfVqA4/+Atz9CqDRAgd+NGT7og86sLZEREREVFww4CMqAty0GkzuW09dzivoS7yRjnVHogGtG9DhBWDYb0BAeeDKCcO4vr/nGWZ4ISIiIiIqTgHf2bNnMWLECERERMDHxwfVq1fH5MmTkZaWZlbuwIEDaN++Pby9vVGpUiXMmDEj130tWbIEderUUWUaNmyIVatWmZ3X6/V47bXXUK5cOfVYXbp0wYkTJ8zKXL16FQ8//DACAwMRHBys6paUlFTouhCZ6tGgHD575E6EB93s3inKBnqhRpg/UjJ0eOq7vXjn92PIyNQZlmh4aitQszuQmQr8Ng5YMhS4Eee050BERERERUuxCPiOHTsGnU6Hzz//HIcPH8YHH3yAOXPm4KWXXsouk5CQgG7duqFKlSrYs2cP3n33Xbz++uv44osvssts27YNDz30kArQ/vnnH/Tr109thw4dyi4jgdlHH32k7n/nzp3w8/ND9+7dkZJimFRDSLAn9Vi3bh1WrlyJzZs344knnihUXYjyCvq2vng3fhjZCh8OaqL22yZ2xu/Ptcfj7SJUmTmbTmHIV7twOSkV8CsNDF4EdHsL0LoDR34FPu8AXNzj7KdCREREREWBvpiaMWOGPiIiIvv6p59+qi9VqpQ+NTU1+9iLL76or127dvb1Bx98UN+7d2+z+2nZsqX+ySefVJd1Op0+PDxc/+6772afj4uL03t5eel/+OEHdf3IkSPSZ07/999/Z5f5/fff9RqNRn/x4kWr62KN+Ph49ViyF2lpafply5apPZVMK/Zf1Nd99Xd9lRdX6lu9/Yd+77mrN09e2K3Xf9BQr58cqNdPKa3Xb5stjbpQ9882RvbGNkaOwHZG9sY2Rs5oYzljA2sV22UZ4uPjERJyc72y7du3o0OHDvD09Mw+Jpm56dOn49q1ayhVqpQqM27cOLP7kTLLli1Tl8+cOYPo6GjVjdMoKCgILVu2VLcdNGiQ2ks3zmbNmmWXkfJarVZlBPv3729VXSxJTU1Vm2mmUKSnp2dvxutUMnWvG4pqT7bEM9/vw5kryXjw8+14tXcdDGpWEZqyjYARG+D22/PQHlsOrHkJulN/IrPvbMDXfG2/vLCNkb2xjZEjsJ2RvbGNkTPa2K22t2IZ8J08eRIff/wx3nvvvexjEqjJGD9TZcuWzT4nQZbsjcdMy8hxYznT2+VVJiwszOy8u7u7Cj5NyxRUF0umTZuGKVOm5Dq+du1a+Pr6Zl+XrqRUsj1VDVio1+LAVS1eW34UK7cfxgMROni6AfAegKoVS6HBxe/hdnItUme3wu6qo3DVv7bV9882RvbGNkaOwHZG9sY2Ro5sY8nJycUv4Js4caLKeuXn6NGjapIVo4sXL6JHjx544IEHMHLkSLiSSZMmmWUgJcMnE77IeECZIEaiennTu3btCg8PD6fWlZyvv16PL7acxcw/TmDXJS2S3IMw+6HGqFRKfhzoDV3McGh/HgGfq6fQ7uQ70HV4Ebo2zxlm+cwD2xjZG9sYOQLbGdkb2xg5o40Ze/8Vq4Bv/PjxGDZsWL5lqlWrln05MjISnTp1Qps2bXJNgBIeHo6YmBizY8brci6/Mqbnjcdklk7TMk2aNMkuExsba3YfGRkZaubOgh7H9DEs8fLyUltO8iabfpjkvE4l1+jOtXBHlRCM+eEfHIlKRP/PdqrJXjrWDgMq3gE8uVnN3qk5sAhum96G24VtQP8vgADzLHZObGNkb2xj5AhsZ2RvbGPkyDZ2q23NqbN0hoaGquxdfptxHJxk9jp27IimTZvi66+/VmPmTLVu3VrNlmnat1Wi4tq1a2d3oZQy69evN7udlJHjQrphSkBmWkYiaRmbZywj+7i4ODX7ptGGDRvULKIy1s/auhDZStsaZbBiTDs0rhiE+BvpGP7N3/ho/QnodHrAyx/o/zlw76eAhy9w+k9gTjvg1EZnV5uIiIiIHKBYLMtgDPYqV66sxu1dunRJjYUzjpkTgwcPVsGhLLkgSyYsWrQIH374oVkXyeeeew6rV6/G+++/r5Z6kKUSdu/ejdGjR6vzGo0GY8eOxZtvvonly5fj4MGDGDJkCMqXL6+WbxB169ZVXUqlO+muXbvw119/qdvLhC5Sztq6ENlShWAfLH6qNQa3rKzWXp+57l+MXLBbBYDQaIA7Hgae+BMIqwdcjwW+7Q+sfwPIzHB21YmIiIiopAd8kh2TiVok81axYkXV3dK4mc6mKZObyEybkgWU7qKygLrp+njSFfT7779X3UEbN26Mn376Sc3Q2aBBg+wyEyZMwJgxY9TtmjdvrhZUlyBRFlA3Wrhwoco+du7cGb169UK7du3MuphaUxciW/Nyd8Pb/Rtixv2N4Omuxfpjsbhn9lYcjcrq7x1aGxi5AWgq3aj1wJb3gPl9gPiLhvO6TGjObUWFq9vVXq4TERERUfGmkbUZnF0Jsky6k0rwKEtQGCdtWbVqlQoy2V+c8nPoYjye+m4P/rt2A94eWky7ryH631HRpMBSYPlzQFoi4BNiCAIP/AgkRN4sE1ge6DEdqHePU54DuSZ+jpEjsJ2RvbGNkTPaWM7YwKUyfERUOA0qBGHF6HboUCsUKek6PL9oPyb/eghpGbqsAgOAJzcB5ZoAN64CW2eaB3siIQpYPAQ4stwpz4GIiIiIbh8DPiIXVcrPE18Pa45n766hrs/ffg4Pzd2BmIQUQ4HS1YHhvwOefnncQ1byf/VEdu8kIiIiKqYY8BG5MDetBuO61ca8oc0Q4O2OPeeuofdHW7Hj9BVDgYt7gLTr+dyDHki4CJzb5qgqExEREZENMeAjKgE61y2runjWCQ/A5aRUPPzlTny55TT0iTdnus1Xkvm6kkRERERUPDDgIyohqpbxwy9Pt0W/JuWRqdPjzd+O4sNdidbd2D//hdqJiIiIqGhiwEdUgvh4uuGDgU0w5Z76cNdq8NHJUMRqSkMPTd438goAKrd2ZDWJiIiIyEYY8BGVMBqNBkPbVMWiJ1uhTIAPXk19FLI6iy7HAi3ZC7akJgK/T+DELURERETFEAM+ohKqaZUQ/Dq6LTZqWmJU+lhEI8TsfBRK4/uMTtBJ9m/3POCn4UBGqtPqS0RERESF534LtyEiF3H2cjLSMvVYgxZYl9oMLbTHEIY4xCIYu3R1oIMWW3UNMdt7DrRHfgWSrwKDvge8rV/sk4iIiIichxk+ohIsNjFrTT5ABXc7dPWwXNdG7eW6WKVrhe2t5wCe/sDZLcA3vYGkWCfWmoiIiIisxYCPqAQLC/C2qpy2Wkdg2ErAtwwQfQCY1w24esbu9SMiIiKi28OAj6gEaxERgnJB3vnN0YmwAC9VDuXvAEasBYIrA9fOAF91B6IPOrC2RERERFRYDPiISjA3rQaT+9ZTl/MK+tIydDhz+brhSunqwIh1QNkGhsXYv+4FnN3quAoTERERUaEw4CMq4Xo0KIfPHrkT4UHm3TvLBnqhXKA34m6kY+Dn23EkMsFwIiAcGPYbUKUtkJoAfHsfcHSFcypPRERERPliwEdEKujb+uLd+O6xZhhSM1Ptt03sjN+ea48GFQJx5XoaBn2xHf+cv2a4gU8w8MjPQJ0+QGYqsHgIsGe+s58GEREREeXAgI+Isrt3towIQdMyerWX6yF+nvh+ZCs0rVIKCSkZeOTLndh+6orhBh7ewAPzgTuHAHodsOJZYPO7Jiu2ExEREZGzMeAjonwFentgwWMt0KZ6aVxPy8Swr3dh4/GsZRnc3IG+HwHt/2e4vuFN4PcXAZ3OqXUmIiIiIgMGfERUID8vd3w1rDk61wlDaoYOTyzYjd8PRhlOajRA51eBnjMM13d9Dvz8OJCR5tQ6ExEREREDPiKykreHG+Y82hS9G5VDeqYez3y/Fz/v/e9mgZZPAgPmAVoP4NBS4PsHgdREZ1aZiIiIqMRjwEdEVvNw0+KjQXfggaYVodMD45fsx8Kd524WaHg/MHgR4OEHnN4IzO8LXL/szCoTERERlWgM+IioUGQyl+kDGmFYm6pqfpaXfzmEuZtP3yxQozMwdAXgEwJE/mNYoP2aSVBIRERERA7DgI+ICk2btWD70x2rq+tvrTqKWX/8C71xhs6KTYERa4GgSsCVk4agL+awcytNREREVAIx4COiW6LRaDChRx280L22uj7rjxN4e9XRm0FfmZqGoC+0LpAYBXzdEzi33bmVJiIiIiphGPAR0W15plMNle0Tc7ecwSvLDkEnA/xEYHlg+CqgUksgJR74th9w/HfnVpiIiIioBGHAR0S3bXjbCMwY0Eit0LBw53n8b8l+ZGRmrcXnGwI8ugyo1QPISAF+fBj45zsUGbpM4MwW4OBPhr1cJyIiInIR7s6uABG5hgebV4K3pxvGLdqHn/+5iOS0THz00B3wdNcCnr7AwO+AFc8B+xYCvz5jmL2z7XOGdfyc5chyYPWLQELkzWOSlewxHah3j/PqRURERGQjzPARkc3c07g8PnukKTzdtFh9OBpPfLsbKelZGTM3D+DeTwxBnvhjMrD2FUCnc06WTYK9xUPMgz2REGU4LueJiIiIijkGfERkU13rlcW8Yc3g4+GGP49fwtCvdiEpNcNwUrJ5XacC3d4yXN8+G5jfB/iggWG/dIRhP6uBfQMuCSgls4essYZmso6tnsjunURERFTsMeAjIptrXzMUC0a0QICXO3aeuYpHvtyJ+OT0mwXajAb6fw5otMC5v4BEG2fZMjOAG3FA/H9A7DHgv93AqY3A0RXAvh+ANS/lzuyZ0QMJF4Fz227t8YmIiIiKCI7hIyK7aF41BN+PbIVHv9qJfRfiMGjuDnw7ogXK+HsZCjR8wBB4JV/JO8u2ciyQdh1Ivw6kJgFpSTf3ppfVPvHmdZkcxhZWPg9UbgmUrgGEVM/aRwAePrd/35I9lIAyKQbwLwtUaQNo3WxRayIiIqJsDPiIyG4aVgzCoida45F5O3E0KgEPfr4dCx9viXJBPoZgx2KwZ0LOL3vq1iug9QC8/AHPgKy9v2GffgM4b8WagFdOGDYzGiCoIhBSDShtDAKz9qWqGMYqFoSTxRAREZGDMOAjIruqHR6AxU+2xsNzd+D0pet4YM52fP94K1SWzJY1ZOF2CayMwVr2PiD3dU8/83PuWdlES9k1GScoXUctjuPTAH5lDGMNr50BrpwErpwybKnxQPwFw3ZmU46buRmCPmMAqALC6obrEiRKBs84WUzOxzV2Y31wAYM+IiIishkGfERkdxFl/LBkVBsV9J29kqwyfUt7BqKCNTfu9S4Q0d62FZLAS7JpKvDS5Ai+spaJ6D0zd+Cl1xuyjtkB4EngalYgKFvGDeDqacN2cp35bd28gFJVgbhz+UwWozFMFlOnN7t3EhERkU0w4CMih6gQ7KMyfdK989+YJPRb4YZtfuXgcT067yybdHOUsW32IMHcgwugX/0iNCZdK/WB5aHp8Y7lLJsmK/MnW+VW5udkeYnEqKwAMCsglMBPBYVngMxU4PLxAiplMlmMrYNcIiIiKpEY8BGRw4QFeqsxfUO+2oWDF+MxQTcYMzFTBXcak6BPr64DkMDLjpmu1brmeCPlQ1RK248wxCEWwbiQ0hiv6hqiR2HvTKsFgioYtogOuWcNlS6ge74B/ppV8H1Z292ViIiIqABcloGIHKqUnycWjmyJ5lVL4ZeUphiT+TxiEGJWRq7/0/pDu45lW30oCqO+24uLCenYoauH5bo2ah+ZkK6Oy3mbcXM3zO5Zo4t15WXWTiIiIqKSFPDdc889qFy5Mry9vVGuXDk8+uijiIw0X0frwIEDaN++vSpTqVIlzJgxI9f9LFmyBHXq1FFlGjZsiFWrVpmd1+v1eO2119Rj+Pj4oEuXLjhxwnyWvqtXr+Lhhx9GYGAggoODMWLECCQlJRW6LkQlVaC3B+Y/1gJ1wgOwMr0Z2qR8iEFpr+DZtNFq3zblQ9y3sYxtgy4TmTo9pqw4kt+y6+q8lLMp6Z4q3VSN4wQtdmOtYL9urERERFTiFJsunZ06dcJLL72kArGLFy/if//7H+6//35s22ZYGDkhIQHdunVTAdqcOXNw8OBBPPbYYyoge+KJJ1QZKfvQQw9h2rRp6NOnD77//nv069cPe/fuRYMGDVQZCcw++ugjzJ8/HxEREXj11VfRvXt3HDlyRAVvQoK9qKgorFu3Dunp6Rg+fLh6DLk/a+tCVNJ5ubshLjlNXdZBq7JrOf1vyQG1hp8EQvJjjARgEoPp9HqTDbnP5SynM70NcOV6KqLi816rT8I8Ob/rzFW0rl7aQZPFZLFzN1YiIiIqWYpNwPf8889nX65SpQomTpyogjUJuDw8PLBw4UKkpaXhq6++gqenJ+rXr499+/Zh5syZ2UHWhx9+iB49euCFF15Q19944w0VtM2ePVsFZvKlcdasWXjllVdw7733qjILFixA2bJlsWzZMgwaNAhHjx7F6tWr8ffff6NZs2aqzMcff4xevXrhvffeQ/ny5a2qC1FJJ8FUdEJqvmWSUjMwZ9NpOMu7a46hW/1w1CsXiHrlA28uGm+DyWJyrcMnSzo88DWXZCAiIqKSGfDl7FIpQVWbNm1UsCe2b9+ODh06qADLSDJz06dPx7Vr11CqVClVZty4cWb3JWUkmBNnzpxBdHS0yswZBQUFoWXLluq2EvDJXjJ1xmBPSHmtVoudO3eif//+VtXFktTUVLUZSaZQSFBr3IzXiezBkW0sKu66VeXa1yyNmqH+aoJMrUYDN63m5mWNxvJxszIyuaZGXdbKMa0GZy5fxxdbzhb42HvPx6nNKCzAC3XDA1C3XED2vkqIr7rPQqnZE5kRXXFi9zqkXDmHOw+8CTddCjJ8QqF38b9vfo6RI7Cdkb2xjZEz2tittrdiFfC9+OKLKhuXnJyMVq1aYeXKldnnJFCTLpimJDNnPCdBluyNx0zLyHFjOdPb5VUmLCzM7Ly7uztCQkLMyhRUF0ukq+mUKVNyHV+7di18fX2zr0tWksieHNHGTsdLkFRw18XGHrGoqY+52fsx8/Yfu64eCPZ0Q5zqUWopWNPDzx3oWE6HyGQNLl7X4FIKEJuYqrZNJy5nl/TU6lHeF6jgp0dFPz0q+OpRzhfwzOep7b+iwc9ntYhLk0LVMNOjGe5z24o9S2ciuuajKAn4OUaOwHZG9sY2Ro5sYxIDFbuAT7plStYrP9KFUiZZEdIVUyZIOXfunAqMhgwZooI++fXeFUyaNMksAykZPpnwRcYDygQxEtXLm961a9fszCaRLTmyjcmYu5/e34yYhNS8VuFDeJAXRg/soDJ2tuZRNQZjftyvLudedl2D6fc3Rvf6N3/8SU7LwPGYJByNSsTR6EQciUrA8egkpGbocDYJOJt0s45S3Wpl/AyZQJUNDFT70n6eWHM4Bl9v32/2mMszW6uAr1riLlyu9B66NbRqSfpiiZ9j5AhsZ2RvbGPkjDZm7P1XrAK+8ePHY9iwYfmWqVatWvblMmXKqK1WrVqoW7euCoZ27NiB1q1bIzw8HDEx5mtXGa/LOePeUhnT88ZjMjmMaZkmTZpkl4mNjTW7j4yMDNXNtKDHMX0MS7y8vNSWk7zJph8mOa8T2Zoj2pjc++v31FdLIOScvsQYOk3uWx/eXje7RttSnyYV4e7upmbjNJ3AJTzIG5P71kOPBjc/A0SQhwdaVPNBi2qh2ccyMnU4e+U6DkcmqADwiOwjE3DlehpOXrquthUHDJl/ERbgifgbGbkC3K26hriq90eoJh5rfv8ZPZo8b5cgtyjh5xg5AtsZ2RvbGDmyjd1qW7utgE8mJpFxb9WrV1fdGgsrNDRUbbdCJ9PuZY17ExL0vfzyy9mTuAiJimvXrp3dhVLKrF+/HmPHjs2+Hykjx4V0w5SATMoYAzyJpGVs3qhRo7LvIy4uDnv27EHTpk3VsQ0bNqj6yFg/a+tCRFBB1WeP3Gl10GWPx+9aL1xNIBObmIKwAG+0iAixOthyd9OiRliA2u5tYsjKyeRPlxJTcdgYAEYl4GhkAs5cuY7YRMOspDllwB2/Z7bEw+7r0ebGJuw6M9S2s4MSERFRiXVLAZ/0Hx0zZoxaukD8+++/KhMnxypUqKC6atqSBFwyK2a7du1UwHTq1Cm1XIIEmsZgbfDgwaqbp3T5lLF+hw4dUrNyfvDBB9n389xzz+Guu+7C+++/j969e+PHH3/E7t278cUXX6jz0jVUgsE333wTNWvWzF6WQWbelBlBhWQWZabPkSNHqpk9JagbPXq0mtBFyllbFyKyTdB1u+RxbBlcyedIWKC32jrVvjne93pqBuZuOY1Zf5iv62m0QtcaD2M9errtwuY46bLBgI+IiIictPC6jDXbv38//vzzz+y16YyzVS5atAi2JhOW/Pzzz+jcubPKkkkg1ahRI2zatCm7C6TMpimTm0jGUTJv0l1UFlA3XQZBZvWUtfIkwGvcuDF++uknNUOncQ0+MWHCBBW4yu2aN2+uFlSXZRhMn6fMECrjCqU+shyDBKLGoNHauhBR7qBLsmSyd8XujH5e7mgZkXcQt0tXB9H6UgjSJKNm4i6H1o2IiIhc1y1l+CRIksBOZso0nTBF1puT7JutNWzYUHWbLIgEgVu2bMm3zAMPPKC2vMjzmTp1qtryIjNyGhdZv526EFHJIpnLckHeiI5PyTWOTxafX5nZCo+7/45al9YAGOikWhIRERFKeobv0qVLuZYmENevX3eZGTOJiGxNMpcyNlFY+qRckdlG7bX//g6kWbdOIREREZHNAz5ZdPy3337Lvm4M8r788svsMXVERJT3RDUyMY0pd60GowbfD5SKANKTgeO/O62OREREVMK7dL799tvo2bMnjhw5opYkkAlJ5PK2bdvUuDoiIrJuopozl5PwyrJDyNDpUSs8EGh4P7D5XeDgT4bLRERERI7O8MkkJTJpiwR7Mr5OJiiRLp7bt2/PXqqAiIgKnqhmcMsq6FDLsDzNygNRQIOsIO/kH0DyVedWkoiIiEpewCfLEDz22GOqG+fcuXOxa9culd377rvvVPBHRESF06eRYUmX5fsjoQ+tDYTVB3TpwLGVzq4aERERlbSATxYSX7p0qX1qQ0RUAnWrXxaeblqcjE3C8ZhEoOEAwwnp1klERETk6C6dsgi5LM1ARES3L9DbAx1rZ3Xr3C/dOrMCvrNbgMQY51aOiIiISt6kLTVr1lTr1P31119qzJ6fn5/Z+WeffdZW9SMiKhH6NC6PtUdisOJAJMZ36whNxebAf38Dh38BWj3l7OoRERFRSQr45s2bh+DgYOzZs0dtpmRsHwM+IqLC6VI3DD4ebjh3JRmHLiagoUzeIgHfoZ8Y8BEREZFjA74zZ87c+iMSEVEuvp7uuLtuGH47EKWyfA3b9wfWTDIEfdfOAqWqOruKREREVFLG8JnS6/VqIyKi29M3a7bOlfsjofMLA6q2N5w4xImyiIiIyMEB34IFC9QyDD4+Pmpr1KgRvv3221u9OyKiEk8mbvH3ckdkfAr+uXDt5sLrh352dtWIiIioJAV8M2fOxKhRo9CrVy8sXrxYbT169MBTTz2FDz74wPa1JCIqAbw93NCtXll1eYXM1lm3L6D1AGIOAbHHnF09IiIiKikB38cff4zPPvsM06dPxz333KO2GTNm4NNPP8VHH31k+1oSEZUQfRsbunX+djAKmV7BQI0uhhMyeQsRERGRIwK+qKgotGnTJtdxOSbniIjo1rStUQZBPh64lJiKnWeu3OzWKYuwc7w0EREROSLgq1GjhurGmdOiRYvUGn1ERHRrPN216Nkg/Ga3zto9AQ9f4NoZIHKvs6tHREREJWFZhilTpmDgwIHYvHkz2rZtq47JIuzr16+3GAgSEVHhunX++PcFrD4Uhan31oeHBH0yU+fBpUCFps6uHhEREbl6hm/AgAHYuXMnypQpg2XLlqlNLu/atQv9+/e3fS2JiEqQlhEhKOPviWvJ6fjr5GVAFmEXh38GdJnOrh4RERG5eoZPNG3aFN99951ta0NERHB306JXw3JYsP0cVh6IQsf+nQHvICAxCji3DYjIWp+PiIiIyB4ZvlWrVmHNmjW5jsux33///VbukoiITPTJWoR9zaFopMpvc7JEg+Ai7ERERGTvgG/ixInIzMzdrUiv16tzRER0e5pVKYXwQG8kpmZg0/FLN7t1HvkVyEx3dvWIiIjIlQO+EydOoF69ermO16lTBydPnrRFvYiISjStVoPejcqpy9KtExEdAL8w4MZV4NRGZ1ePiIiIXDngCwoKwunTp3Mdl2DPz8/PFvUiIirxjIuw/3E0BjcyANTPmhSLi7ATERGRPQO+e++9F2PHjsWpU6fMgr3x48fjnnvuuZW7JCKiHBpXDEKlEB8kp2Viw7HYm4uwH/sNSEt2dvWIiIjIVQO+GTNmqEyedOGMiIhQm1wuXbo03nvvPdvXkoioBNJoNNmTt6zYHwlUbA4EVwbSkoATuSfOIiIiIrLJsgzSpXPbtm1Yt24d9u/fDx8fHzRu3Bjt23OqcCIiW+rbqDw++/MUNhyPVRO4BDQYAGz9ADj4080unkRERES2yPBt374dK1euzP7luVu3bggLC1NZPVmM/YknnkBqamph7pKIiPJRt1wAqoX6IS1Dp8byQQI+cWIdkBLv7OoRERGRKwV8U6dOxeHDh7OvHzx4ECNHjkTXrl3VcgwrVqzAtGnT7FFPIqISSX5ckyyfWLE/CijbAChTG8hMNYzlIyIiIrJVwLdv3z507tw5+/qPP/6IFi1aYO7cuRg3bhw++ugjLF68uDB3SUREBejb2LA8w5YTlxB3I/3m5C3SrZOIiIjIVgHftWvXULZs2ezrmzZtQs+ePbOvN2/eHBcuXCjMXRIRUQFqhAWgTngA0jP1WHM4+ma3ztN/AtcvO7t6RERE5CoBnwR7Z86cUZfT0tKwd+9etGrVKvt8YmIiPDw8bF9LIqISzrgmn+rWWbo6UP4OQJ8JHP7F2VUjIiIiVwn4evXqpcbqbdmyBZMmTYKvr6/ZzJwHDhxA9erV7VFPIqISzTiOb9upy7iclAo0yOrWeWipcytGRERErhPwvfHGG3B3d8ddd92lxu3J5unpmX3+q6++UjN3EhGRbVUu7asWYtfpgd8PRgEN7pMpXYDz24E4dqUnIiIiG6zDV6ZMGWzevBnx8fHw9/eHm5ub2fklS5ao40REZJ9unfv/i8eKA1F4tHVroEob4NxfwOGfgbbPObt6REREVNwzfKYLr+cM9kRISIhZxo+IiGynV0PDbJ1/n72K6PiUm5O3cLZOIiIismXAR0REjlc+2AfNq5aCXg/8Jt066/UDtO5A9AHg8glnV4+IiIiKIAZ8RETFSJ/sRdgjAb/SQLVOhhOcvIWIiIhcIeBLTU1FkyZNoNFo1ELwpmSWUJk11NvbG5UqVcKMGTNy3V7GGdapU0eVadiwIVatWmV2Xq/X47XXXkO5cuXg4+ODLl264MQJ81/Or169iocffhiBgYEIDg7GiBEjkJSUVOi6EBEVVs+G4dBqgH0X4nDharL5IuyS+iMiIiIqzgHfhAkTUL684RduUwkJCWqG0CpVqmDPnj1499138frrr+OLL77ILrNt2zY89NBDKkD7559/0K9fP7UdOnQou4wEZh999BHmzJmDnTt3ws/PD927d0dKSkp2GQn2Dh8+jHXr1mHlypVqIpsnnniiUHUhIroVYQHeaF29tLq88kAUUKc34O4NXDlh6NpJREREdKuzdDrb77//jrVr12Lp0qXqsqmFCxeqxeBlaQiZOKZ+/foqAzhz5szsYOzDDz9Ejx498MILL2QvMyFB2+zZs1WAJ9m9WbNm4ZVXXsG9996ryixYsEAtOL9s2TIMGjQIR48exerVq/H333+jWbNmqszHH3+s1ih87733VDBqTV3yyl7KZho4ivT09OzNeJ3IHtjGioee9cvir5NXsHzfRTzetjLcanSD9thyZO5fDF2ZeijK2MbIEdjOyN7YxsgZbexW21uxCfhiYmIwcuRIFXjJgu85bd++HR06dDCbJVQyc9OnT8e1a9dQqlQpVWbcuHFmt5Mycp/izJkziI6OVt04TWckbdmypbqtBHyyl26cxmBPSHmtVqsygv3797eqLpZMmzYNU6ZMyXVcglzT5yxBKpE9sY0Vbdp0QKtxw9HoRHy9dBWapFZBC/nRaM/3WJfSDNAU/c4bbGPkCGxnZG9sY+TINpacnOy6AZ9k3oYNG4annnpKBVpnz57NVUYCtYiICLNjkpkznpMgS/bGY6Zl5LixnOnt8ioTFhZmdl4Wo5clKUzLFFQXSyZNmmQWkEqGT8b/SfdQGS8oUb286V27doWHh0cBrxpR4bGNFR9r4vdi04nLSAqpjTvadYJ+1tfwTbuK3o3KQF+pFYoqtjFyBLYzsje2MXJGGzP2/itWAd/EiRNV1is/0oVSMlyJiYkqIHJlXl5eastJ3mTTD5Oc14lsjW2s6LunSQUV8K06FIPnu9aGpm5fYP8PcD+6DKjWHkUd2xg5AtsZ2RvbGDmyjd1qW3Nqv5/x48ergC6/rVq1atiwYYPqJinBkGTTatSooW4v2b6hQ4eqy+Hh4arbpynjdTmXXxnT86a3y6tMbGys2fmMjAw1c2dBj2P6GEREt6Nr/bLwdNfiZGwSjsckAg2yZus8vAzIzHB29YiIiKiIcGrAFxoaqpZIyG+TcXAya+b+/fvVxCeyGZdSWLRoEd566y11uXXr1mq2TNPBjJIGrV27dnYXSimzfv16szpIGTkupBumBGSmZSR1KmPzjGVkHxcXp2bfNJKAVKfTqbF+1taFiOh2BHp7oGOt0Jtr8lW7C/AtDSRfBs5scnb1iIiIqIgo+iP7AVSuXBkNGjTI3mrVqqWOV69eHRUrVlSXBw8erIJDWXJBlkyQYFBm5TQdE/fcc8+pGTbff/99HDt2TC2VsHv3bowePVqdl7X9xo4dizfffBPLly/HwYMHMWTIEDXzpizfIOrWratm+pQJZHbt2oW//vpL3V4mdDEuF2FNXYiIblffxuWzl2fQa92BeobPKS7CTkRERMUq4LOGzKYpY/1kps2mTZuq7qKygLrpMght2rTB999/r9bDa9y4MX766Sc1Q6cEkabr/I0ZM0bdrnnz5mpBdQkSZQF1I1l2QbKPnTt3VssxtGvXzmyNPWvqQkR0uzrXDYOPhxvOXUnGwYvxNxdhP7oCSL+5digRERGVXMVils6cqlatqmbuzKlRo0bYsmVLvrd94IEH1JYXyfJNnTpVbXmRGTklcMyPNXUhIrodvp7uKuiTDJ9062zUsxUQWAFIuAicXAfIRC5ERERUorlMho+IqCR36/ztQBR00AD1+xtOHPzJuRUjIiKiIoEBHxFRMXZXrVAEeLkjMj4Fe89fu9mt89/VQGqis6tHRERETsaAj4ioGPP2cFNLNAjp2olyTYCQ6kBGCnD8d2dXj4iIiJyMAR8RUTHXt9HN2TozZXizMcvHbp1EREQlHgM+IqJirm2NMgj29cDlpFTsPH3l5iLsp9YDyVedXT0iIiJyIgZ8RETFnKe7Fj3qh6vLK6RbZ2gtILwhoMsAjvzq7OoRERGREzHgIyJyodk6fz8UhfRM3c0sHxdhJyIiKtEY8BERuYBW1UqjjL8X4pLT8dfJy0CD+wwnzm4FEiKdXT0iIiJyEgZ8REQuwE2rQa+GWd0690cBwZWBSi0B6IHDvzi7ekREROQkDPiIiFysW+faw9FISc+82a2Ts3USERGVWAz4iIhcRNPKpRAe6I3E1Axs/vcSUL8foNECkXuBq6edXT0iIiJyAgZ8REQuQqvVoE+jcjdn6/QPAyLuMpzk5C1EREQlEgM+IiIX7Nb5x5EYJKdlmCzCzoCPiIioJGLAR0TkQhpVDELlEF/cSM/EhmOxQJ0+gJsncOkoEHPY2dUjIiIiB2PAR0TkQjQak26d+yMBn2CgZjfDSU7eQkREVOIw4CMicjF9Ghm6dW48fgmJKek31+STcXx6vXMrR0RERA7FgI+IyMXULReA6qF+SMvQYd2RGKBWT8DDD4g7B/y329nVIyIiIgdiwEdE5ILdOo2Tt6yU2To9fYE6vQwnD7FbJxERUUnCgI+IyIW7dcp6fHHJaTcXYT/8C6DLdG7liIiIyGEY8BERuaAaYf6oWy4QGTo9Vh+KBqrfDXgHA0kxwNmtzq4eEREROQgDPiIiF2WcrVN163T3BOrdazjBbp1EREQlBgM+IiIX1TerW+e2U5dxKTH15iLsR5YDGWmOr5AuE5pzW1Hh6na1Z9dSIiIi+3N3wGMQEZETVC7ti8aVgrH/QhxWH4rCoy3bAv7hQFI0sO0joFRVwL8sUKUNoHWzb2UkyFz9ItwTItFMrp/7DAgsD/SYDtS7x76PTUREVIIxw0dE5ML6Zi/CHmUI6so1NpzY8AawdAQwvw8wq4EhILMXue/FQ4CESPPjCVGG4/Z8bCIiohKOAR8RkQvrnRXw7Tp7Fdd2/wScWJO7kK0CL1nUPT0FuH4ZuHoaiDoAnN4MrBwrJy3dwLBbPZHdO4mIiOyEXTqJiFxYuSAfNK9aCnvOXoHHupfyKCWBlwZY9T8gqBKQcQNITby5pSVlXZZ9Qo7rct5YNgnQpReyhnog4SJwbhsQ0d4Gz5iIiIhMMeAjInJxsgi72/m/4J8ak08pvWHJhrkdbfOgHn6Al7/hstxvQawpQ0RERIXGgI+IyMX1bFAOe1bGWVfYKxDwCzUEa3LZU/YBWddlHwB4Bpgfy3Xd/+YkMGe2GMYJFsTN6/aeJBEREVnEgI+IyMWFBnghtFxl4LIVhQd9b9uulTIDqMzGKeMELY7jy/LbOMAnCIjoYLvHJiIiIk7aQkRUEtRs3g2R+hDo8iyhAQIrGAI0W5JMnyy9YHyMnI8p5HGvxwIL7gX+fIcTuBAREdkQAz4iohKge8MKeDNjqEqy6fMKvHq8Y5/1+GSdvQcXAIGGGUOzSebvwW+B0buBOx4B9Drgz2mGwC8x2vb1ICIiKoEY8BERlQDBvp64UaMXRqWPRZJnqIXAa4F9F0CX+x57CBmPLMPuKqPUHmMPGo57+gL3fgL0/8Iw2cvZLcCcdsCpDfarDxERUQnBMXxERCVEn0blMf54C5z27IC1D3lAkxQL+Jc1dOO0R2YvJ60b9FXa4eLhBDSu0i73YzYeCJS/A1gyDIg9DHx7H9B+PNBxEuDG/66IiIhuBTN8REQlRNf6ZeHprsWJyyk45t0EaHi/YYIWRwR7ADJ1euw8cxV7LmvUXq7nEloLGLkeaDrcMMnLlveA+X2BhEiH1JGIiMjVMOAjIiohAr090Km2oTvnnD9P4dd9F7H91BXLgZeNrT4UhXbTN+CRr3ZjwQk3tZfrcjwXDx+g7yxgwDzDkg/ntxm6eJ5YZ/d6EhERuRoGfEREJUjFUr5q/+v+SDz34z48NHdH3oGXjch9j/puL6LiU8yOR8enqON5PrZkIJ/cBIQ3ApKvAAvvB9a9BmSm262uRERErqbYBHxVq1aFRqMx29555x2zMgcOHED79u3h7e2NSpUqYcaMGbnuZ8mSJahTp44q07BhQ6xatcrsvF6vx2uvvYZy5crBx8cHXbp0wYkTJ8zKXL16FQ8//DACAwMRHByMESNGICkpqdB1ISJyJAmsvtp6JtfxAgOv2yDZwykrjlhcgc94TM7nmWUsXR0YsQ5oPtJw/a8PgW96A3EXbF5XIiIiV1SsRsFPnToVI0dm/acPICAgIPtyQkICunXrpgK0OXPm4ODBg3jsscdUQPbEE0+oMtu2bcNDDz2EadOmoU+fPvj+++/Rr18/7N27Fw0aNFBlJDD76KOPMH/+fERERODVV19F9+7dceTIERW8CQn2oqKisG7dOqSnp2P48OHqMeT+rK0LEZEjWRN4jV+yH7vPXYNebyiv0+vN9pk6mB3L67jhmOFyXHJarsxezseW87vOXEXr6qUtF/LwBnq/B1RtBywfA1zYaeji2X8OULunbV4gIiIiF1WsAj4J8MLDwy2eW7hwIdLS0vDVV1/B09MT9evXx759+zBz5szsIOvDDz9Ejx498MILL6jrb7zxhgraZs+erQIzye7NmjULr7zyCu69915VZsGCBShbtiyWLVuGQYMG4ejRo1i9ejX+/vtvNGvWTJX5+OOP0atXL7z33nsoX768VXUhInIkCajyC7zE9dRMfLkldwbQEWIT86+bUr8fUK4x8NNwIPIf4IdBQOvRQOfJgLunI6pJRERU7BSrgE+6cEqQVrlyZQwePBjPP/883N0NT2H79u3o0KGDCrCMJDM3ffp0XLt2DaVKlVJlxo0bZ3afUkaCOXHmzBlER0erzJxRUFAQWrZsqW4rAZ/sJVNnDPaElNdqtdi5cyf69+9vVV0sSU1NVZuRZAqFZBGNm/E6kT2wjbmuqLjrVpXrVLsMaob5w02jgVarMdnDsNdqoNUY9nJMutffPIZctzsVm4RZG04V+Lilfd2ta3cBFYEhv0G7YQrcdn0ObJ8N3bltyOw/FwiuYtVzJNfHzzKyN7YxckYbu9X2VmwCvmeffRZ33nknQkJCVNfMSZMmqW6VkjUTEqhJF0xTkpkznpMgS/bGY6Zl5LixnOnt8ioTFhZmdl6CTqmXaZmC6mKJdDWdMmVKruNr166Fr69hogUhWUkie2Ibcz2n4zUACl5+ob5bDGpmGD7LbpcOQBU9EOzphrg0OSJ1yE0LPfb/vQNXjhbm3tsiPMIbd5yfC8/Ivcic0x7/VH4cUcE3f4wj4mcZ2RvbGDmyjSUnJxe/gG/ixIkq65Uf6UIpk6yYZuYaNWqksmdPPvmkCpK8vLzgCiSINX2ekuGTCV9kPKBMECNRvbzpXbt2hYeHh1PrSq6Jbcx1yZi6n97fjJiEVIvj+CQUCw/ywuiBHVTGzpY8qsZgzI/71WVLj62DBrOPeeKtfvXRt1G5QtxzLyB+GHS/jITHxd1oceYjZDYbCV3n1wF31/h/gW4NP8vI3tjGyBltzNj7r1gFfOPHj8ewYcPyLVOtWjWLx6WbZUZGBs6ePYvatWursX0xMTFmZYzXjeP+8ipjet54TGbpNC3TpEmT7DKxsbFm9yH1kJk7C3oc08ewRAJXS8GrvMmmHyY5rxPZGtuY65F38/V76qvZODU5Ai9jeDe5b314e9l+LFyfJhXh7u6mJo0xHUdYLsgb47vWUktEbDlxGeOWHMShyCRM6lUHHtI/1BplqgGPrQbWTwG2fQy33XPhdvFv4IGvgRDL/3+UGLpM4Nw2ICkG8C8LVGkDaAvO8roSfpaRvbGNkSPb2K22NacuyxAaGqqyd/ltpuPgTMkkKDJuzti9snXr1ti8ebNZ31aJiiUYNHahlDLr1683ux8pI8eFdMOUgMy0jETSMjbPWEb2cXFx2LNnT3aZDRs2QKfTqSDU2roQETlajwbl8NkjdyI8yDDjsJFcl+Ny3p6PvfXFu/HdY80wpGam2sv1+5tVwjfDW+CZTtVVua/+OoOHv9xp3SQuRm4eQLc3gcGLAZ9SQNQ+4PO7gMO/mAc/Z7YAB38y7OW6KzuyHJjVAJjfB1g6wrCX63KciIhKlGIxhk8mQZGgq1OnTmqmTrkuE7Y88sgj2QGUTOIi499kTbwXX3wRhw4dUrNyfvDBB9n389xzz+Guu+7C+++/j969e+PHH3/E7t278cUXX6jzMvnA2LFj8eabb6JmzZrZyzLIzJuyfIOoW7eumulTloeQmT0lqBs9erSa0EXKWVsXIiJnkMCra71wNWunBFVhAd5oERFi826clshjtIwIwZWjerU3PqbsX+heB40qBmP84v2qbn0/3opPH26KplUK8SNZre7AU1uBn0YAF3YAS4YZgrsqbYF1rwAJkTfLBpYHekwH6t0Dl8u0SVC3eEjuDrQJUYbjDy5wzPMmIqIioVgEfNLNUYKz119/Xc1iKYGYBHym491kNk2Z3OSZZ55B06ZNUaZMGbWAuukyCG3atFFr5cmyCy+99JIK6mSGTuMafGLChAm4fv26up1k8tq1a6eWYTCuwSdk2QUJ8jp37qyyjAMGDFBr9xWmLkREziIBVp5r3jlR9/rhqDHaH099uwcnYpMw6IvteK1vfTzSsrL6Qc4qQRWBYb8BG98Cts4Eds8zbDk5KviR4Gv1i44LNiW4lMfLc8VFDbB6IlCnd4nr3klEVFJp9LL4HBVJ0p1Ugsf4+PjsSVtWrVql1vxjf3GyB7YxKgptLCk1AxN+2o9VBw2zhQ64syLe6t8A3h6FDFD+XWNYq08v84VaojEEX2MP2if4ySvTZhw1WVCwmZEGpCUBqYlZ+yQgLTFrb7ye4/LVM4bsZkGGrgQi2sNV8bOM7I1tjJzRxnLGBi6V4SMiopLD38sdnwy+E3O3nMY7vx/D0r3/4Vh0AuY80hSVQm4uUVMgD998gj2hBxIuAt8/CARWADRaQ+Ane7XJZU2O4ybntcZyJseN5YRkGfPMtAH45UngwGIg/brlIC5TrWVhH9K9lIiISgQGfEREVORIF84nOlRHg/JBGP3DPzgcmYC+s7fio0F3oEOtUNsGNSf/gFOkJwPHVhRczt0b8PQHPP0ArwDDZS9/k33AzetJ0cCOzwq+TxlLSEREJQIDPiIiKrLa1CiDlWPaYdR3e7D/v3gM/XoX/tetNkbdVR3agiaasTaouXMIEFwZ0OkMGUG1ZRr2MiYu+5guxzHjXp/7WNx54OLN2Zzz1HiwoWulpeDNuJdZSK0l9Tjyq2GMYl4rLko3Vpk4hoiISgQGfEREVKSVD/bBoidbY8qKw/hh1wW8u+Y49l2Iw/sPNkagdz7BkAQ1EtwUFPz0mWX7MXwyO6gshVCQJlkBn63I85AJYdTYwZwrLgo90OMdTthCRFSCOHUdPiIiImvIhC3T7muEd+5rCE83LdYdiUG/2X/hRExiwcGPkjMbmHXdXsGPMdjM9bgmjy/jBu2RaZOJYGRCmEAL6yqG1eOSDEREJQwDPiIiKjYGtaiMJU+1Rvkgb5y+fB33fvIXfjsgGbxCBj8SjNlzSQZnBptCntfYQ4bZOAfMAwZ8BWjcgdgjwNmt9nlMIiIqktilk4iIipXGlYKxYkw7jPnhH2w7dQXPfL8X+/+rhgnda8PdTWs5+JF15xy5+LnxcSWotLgO3zv2z7TJ8zPtLnruL8OahBvfNqxVaO3ahkREVKwx4CMiomKntL8XFjzWAu+uPY7PN53GF5tP4+B/8fh48B0o4+9VcPDjKM4KNi1pPx7451tD4HdmM1DtLsfXgYiIHI5dOomIqFiSbN6knnXx6cN3ws/TDdtPX0Hfj7eqCV2KFGOw2fB+w95ZE6YEVQCaDjdcliyfzC5KREQujwEfEREVa70alsOvo9uiWqgfouJT8OCc7fhh13lnV6toave8YV2/CzuAUxucXRsiInIABnxERFTs1QgLwK/PtEX3+mWRlqnDpJ8P4sWfDiAlPVOdz9Tpsf3UFfy676Lay/USSSavaTbCcJlZPiKiEoFj+IiIyCUEeHtgziNN8dmmU3hvzXEs2n0BR6MTMLB5JczecFJl/4zKBXljct966NHAwtIFrq7dWGD3V8DF3cCJdUCtbs6uERER2REzfERE5DI0Gg2e7lgD8x9rgVK+HjjwXzxe/uWQWbAnouNTMOq7vVh9KJ8lHWzEWdnFPB/XPwxoMdJweeNbzPIREbk4ZviIiMjltK8ZimXPtEXn9zchw0KAJUdkUYIpK46ga71wuGnts0SBBJTyGI7OLhb4uG2fA/6eB0TtA46vMswkSkRELokZPiIickmRcSkWgz0jOSMB0Wu/HsTCnedUJuyPIzEqGyZLPJy+lITYhBRcT82A/hayYBJ0SRbR0dlFqx7XrwzQ8knDiY3TAJ3OLnUhIiLnY4aPiIhcUmyiecCTl4U7LwCQLW+yRrmfpzv8vNzg5+UOfy/3rOty2eRY1ubrqcX01cdVUJmT8dgryw4hxM8LklyU7pYSm0pgmak3XNbJXpfHZeOmM70OZOh0eDefxzXLarYZA+yaC8QcBI6tAOrda9XrRURExQsDPiIicklhAd5WlWtXowx8PN1UJk+2JLXPNFxOk+yeYZibHJcNSLVJ/S4npeHBz7fDkYxZzV1nrqJ19dJA66eBTdMNWb46fQEtO/4QEbkaBnxEROSSWkSEqHFr0pXRUsZLsl3hQd5qgpe8xvBJxu1GeqZ5EGgpMMw6dj1NLmfi1KUkHIlMKLCOZfw91eyikkF002ig1WjUZdlLnaRampyXpZzWUMZw/ebl2MQbOPBfgvXZz1ZPAzvmAJeOAkd+ARoMKPiFJSKiYoUBHxERuSQJkmSSEhm3JuGcadBnDO/kfH4TtkgQ5espXTTdgQDrH1vGAT40d0eB5T5+6E5Dps1GrH3c7OynTzDQZrRhts4/3wHq9QO0bjarDxEROR/7bhARkcuSGSk/e+ROlckzJdfluL1myjRmF/MKJeW4nJdyTn/clk8B3sHA5X+BQ0ttWh8iInI+ZviIiMilSVAnk5TIuDXpyijZLQl47LUUg62yi7Z+XGRdz/W43oFA22eB9VMNWb769wFu/HpAROQqmOEjIiKXJwGOdJ28t0kFtbdnsOfs7GJejysCvN1xV62w3Ddq8QTgWxq4ego4uNgu9SIiIufgT3hEREQulF209Lil/Twx8ecD+O9ailpz8PH21cxv4BVgWIx93WuGWTsbPgC4edi1jkRE5BjM8BEREblYdjHn47arGYoxd9dUx+dsOo0baZm5b9D8ccAvFLh2Ftj/g0PqSERE9seAj4iIqAS4786KqFjKB5eTUlWWLxdPP6Dd84bLm94FMtIcXkciIrI9BnxEREQlgIebFqM71VCXP998GinpFrJ8zR4D/MsC8eeBfd85vpJERGRzDPiIiIhKUJavQrAPLiVKlu987gIePkD78YbLm98DMlIdXkciIrItBnxEREQlhKe7FqPvNmT55mw6ZTnLd+dQIKA8kHAR2DPf8ZUkIiKbYsBHRERUggwwyfL9sMtSls8b6JCV5dvyPpB+w+F1JCIi22HAR0REVMKyfE93qq4uf/ZnHlm+O4YAQZWApGhg99eOryQREdkMAz4iIqIS5oGmlVA+yBuxian40VKWz90T6PCC4fLWmUDadYfXkYiIbIMBHxERUYnM8hnG8n2W11i+JoOB4CrA9UvA3/McX0kiIrIJBnxEREQl0APNKqosX0xCKhb9fSF3ATcP4K4XDZf/mgWkJjm8jkREdPsY8BEREZVAXu5uGGXM8uU1lq/RQCCkGpB8Bdj1heMrSUREt40BHxERUQn1YLOKKBfkjeiEFCzebSnL5w7cNdFwedtHQEqCw+tIRES3hwEfERFRCc7yPd3RMGPnpxtPITXDQpav4f1A6ZrAjWvAzs8dX0kiIio5Ad9vv/2Gli1bwsfHB6VKlUK/fv3Mzp8/fx69e/eGr68vwsLC8MILLyAjI8OszJ9//ok777wTXl5eqFGjBr755ptcj/PJJ5+gatWq8Pb2Vo+3a9cus/MpKSl45plnULp0afj7+2PAgAGIiYkpdF2IiIic7cHmlRAemJXlszSWT+sGdMzK8m3/GLgR5/A6EhFRCQj4li5dikcffRTDhw/H/v378ddff2Hw4MHZ5zMzM1WAlZaWhm3btmH+/PkqmHvttdeyy5w5c0aV6dSpE/bt24exY8fi8ccfx5o1a7LLLFq0COPGjcPkyZOxd+9eNG7cGN27d0dsbGx2meeffx4rVqzAkiVLsGnTJkRGRuK+++4rVF2IiIiKzFg+Y5bvzzyyfPX7A6F1gZR4YMdnjq8kERHdOn0xkJ6erq9QoYL+yy+/zLPMqlWr9FqtVh8dHZ197LPPPtMHBgbqU1NT1fUJEybo69evb3a7gQMH6rt37559vUWLFvpnnnkm+3pmZqa+fPny+mnTpqnrcXFxeg8PD/2SJUuyyxw9elQvL+X27dutros14uPj1f3KXqSlpemXLVum9kT2wDZG9sY2VjTdSMvQt3hrnb7Kiyv1324/a7nQoV/0+smBev3bFfX661f0RRnbGdkb2xg5o43ljA2s5Y5iQDJtFy9ehFarxR133IHo6Gg0adIE7777Lho0aKDKbN++HQ0bNkTZsmWzbyeZuVGjRuHw4cPqdlKmS5cuZvctZSTTJyQjt2fPHkyaNCn7vDym3EZuK+R8enq62f3UqVMHlStXVmVatWplVV0sSU1NVZtRQoJhcLw8nnEzXieyB7Yxsje2saLJDcAT7SPwxm/H8MnGk+jXOBxe7jk6AdXsCfew+tDEHkbmXx9D1/ElFFVsZ2RvbGPkjDZ2q+2tWAR8p0+fVvvXX38dM2fOVOPr3n//fXTs2BH//vsvQkJCVBBoGmAJ43U5Z9xbKiOB1Y0bN3Dt2jXVHdNSmWPHjmXfh6enJ4KDg3OVKehxTOtiybRp0zBlypRcx9euXavGAhqtW7cun1eL6PaxjZG9sY0VPUE6INDDDVHxKZj67Rq0LSs/JJsL9+uCljgM/fZP8UdCdaS5B6AoYzsje2MbI0e2seTk5OIX8E2cOBHTp0/Pt8zRo0eh0+nU5ZdffllNkCK+/vprVKxYUY2je/LJJ+EKJLMo4weNJBCtVKkSunXrhsDAQBXVy5vetWtXeHh4OLWu5JrYxsje2MaKtrjS5/DmquPYesUPkx9tB8+cWT59T+jnbYB7zEF08z8O3d1Fc2w62xnZG9sYOaONGXv/FauAb/z48Rg2bFi+ZapVq4aoqCh1uV69etnHZZZNOSezYYrw8PBcs2kaZ86Uc8Z9ztk05boEUzLzp5ubm9oslTG9D+n6GRcXZ5bly1mmoLpYIs9JtpzkTTb9MMl5ncjW2MbI3tjGiqZHWkfg8y1nERmfgl8PxGBwy8q5C939CvDDQLjt/hJubZ8F/ENRVLGdkb2xjZEj29ittjWnztIZGhqqxr/lt0n3yaZNm6pA6Pjx42ZR79mzZ1GlShV1vXXr1jh48KDZbJoSFUswZwwUpcz69evN6iBl5LgwPpZpGckuynVjGTkvL7ZpGamXBJ7GMtbUhYiIqKjx9nDDqLsMM3bKWL60DEMPGzO1ugMVmgLpycBfsxxfSSIicr1lGSRQeuqpp9RSCTKeTQIsmQBFPPDAA2ov3R4lmJKlG2TZBllq4ZVXXlHr5RmzZnIfMh5wwoQJakzep59+isWLF6tlFoykS+XcuXPVUgrSnVQe5/r162o5CBEUFIQRI0aochs3blSTuMg5CfJkwhZr60JERFQUSVYvNMALF+NuYOne/3IX0GiATlkTtvz9JZCY99h0IiJyvmIR8AmZkXPQoEEqiGrevDnOnTuHDRs2qAXYhXTFXLlypdpL8PXII49gyJAhmDp1avZ9REREqMXbJdsm6+vJxC9ffvmlmkHTaODAgXjvvffUmnkyE6is17d69WqzSVg++OAD9OnTR40n7NChg+qm+fPPP2eft6YuRERERTXL91RBWb7qnYFKLYGMFGDrB46vJBERWU0jazNYX5wcSQZmSkYxPj4+e9KWVatWoVevXuwvTnbBNkb2xjZWPKSkZ6Ld9I24nJSKd+5riEEtLIzlO/0nsOBewM0LePYfIKgCigq2M7I3tjFyRhvLGRu4XIaPiIiIHJnlq6Yuz954EumZFrJ8EXcBVdoCmanA1pmOryQREVmFAR8RERHl8nDLKijj74n/rt3AL3sv5j+Wb898IO6Cw+tIREQFY8BHREREufh4uuHJDoaxfB9vPGE5y1e1HRDRAdClA1vec3wliYioQAz4iIiIyKKHW1VGaT9PXLh6A7/8YyHLJzpmZfn++Q64dtah9SMiooIx4CMiIiKLfD3d8aRxLN+GPMbyVWkNVL8b0GUAm991fCWJiChfDPiIiIgoT4+0qqKyfOevJmNZQVm+fT8AV045tH5E5AC6TODMFuDgT4a9XKdigwEfERER5Zvle6LDzRk7Myxl+So1B2p2A/SZzPIRuZojy4FZDYD5fYClIwx7uS7HqVhgwEdERET5erR1FYT4eeLclWQs2xdpuVDHSYb9gUXA5RMOrR9RieCMLJsEdYuHAAk5/u4TogzHHRH0Mbt429xv/y6IiIjI1bN8I9tXw/TVxzB7wwn0a1Ie7m45fjOucCdQuxdwfBXw5ztA02FAUgzgXxao0gbQujmr+kTFnwRWq180D7wCywM9pgP17rHPY0pgJY8JvYWTckwDrJ4I1Oltv79vZzxvF8SAj4iIiAo0pHUVfLH5FM5eScav+yIxoGnF3IU6TjQEfId+MmxG/IJGdPtZtpyBlzHL9uCCgv+2dDog4waQfgNIu27Yp2ft05KBdJNNXb8BXD6eO7NnRg8kXARWvwSUbwJ4BZhsgTcve/gY1u10xvMmhQEfERERFcjPyx0jO1TDjNXH1Vi+ey1l+a6ds3xjfkEjV6LLhObcVlS4uh2ac4FAtQ72y3BlZgCrXsgnywbglyeBA4stBHQmAZycs5ddc/I/r3EzCQL9cwSGOYLD7CDRF/jteedmF10IAz4iIiKyypDWVTF382mcuXwdKw5Eov8dFS10/7KEX9DIxqS9ndvm+G7DWV0M3RMi0Uyun/vs1jLYknG7cRVIjAISYwz7pGgg0WST5yYZNpkMKT8S1B1bYf1ju/sYsm6efoa9BFeyefpmXc86fuMacGRZwfdXpS3g7g2kJubYEgx/+1L/lDjDZjNZ2cVN04Fa3YHgKoBv6VvLJBa1NmYHDPiIiIjIKv5e7ni8fTW8u+Y4Pl5/Evc0rgA3bdYXLPliZE33LykX0R4ux4W+HBZ5zhrXZU0Xwzp9gOQrWQFcTI6AzuS6BHeydqWtNHkYqNrOPGBTAZzJJtcl2NNqrW/Ts3YZnp/FTJvG8LoPXWG5rev1hmxjWtLNANBSUJjrWCIQdx6Iv1BwHSXgk03IcwyubNiCKt28HFzFsPcrY31A6GJjBxnwERERkdWGtqmKuVtO47Rk+fZHot8dFQwn5MusNX4bZ8gIhNYBQmsZ9gHlbPfLvCO727nol8MizRHjuiT7JuPb1Fg22V8HUhKBlWPz71q5ZFjW1ULMIulbxtD+A8oCAeGAf7hhr7Zyhm7SSx8r+H4aP2T7H1Lk70basHq9NTmee9bfa4938v77kr9p1YXT3/B8CkNm45TlHwoSWhdIiTcE0pLpvHTMsFni7mMSBFoKCEMNdXbBsYMM+IiIiKhQWb6RWVm+jzacQN/G5Q1ZPslqWePyv4bNlGeAIfgrUxsIzdrK1AJKVS1csGar7naF4YJfDotsZrPAWSMBrJRxX1ogMyUru3TdJHiT8WxJJpev39xnB3e3Md4tO9DTGLJJuQI44/WsAM8vDHD3zP8+y98BrHul4CybvO72IG1X2rDFHzTesV/blucjj1HQ8x71l6G9ZaQC8f8ZMoPGTTKExssJkYb3VSaikc0S6ZYqmUEp72JjBxnwERER0S3M2Hkapy9dx8oDkbi3SQXrvqDJL+jd3jAEfJfki9e/wJVTQFoicHGPYTPl5gWUqWkI/kwzgiHVc39RdnTglZkO3IgDVv3P5b4cOj2zKV0BpaufvHeJkTf3/+0toNswgOTLwOKHYRuarHFuvhJtAtcvF3yTnu8CzYYDbh5FI8tmC/JeSht2ZJflwj5vdy+gdHXDZklGGpCQIyCMMw0ILwIZKcCVgtYQLZ5d0xnwERERUaEEeHvg8XYReH/dv/hw/Qn0aSRZPiu+oPV+P3cgIF/Erp42/Op+yWSTL17yBSzmkGHLOetfSIQh+JNgUILCda8VHHjV6mn4lV/GCJmNKzJeluOmY4nyOW5VFijry+HC+4FKLQ0ZS+MmX5pt2I3V4eMHbzXAllknjWPZJHizuJfueddvvW6lIoCgijeDNdlbcznnMdPlBKztYhhW13bBnrOzbKakPTk6wLHl83b3BEKqGbY8A8KLwD/fAlveL/j+rO3CXkQw4CMiIqJCG9q2Kr7cesY8y3crX9Dki1hYHcOWM4iRX95VJlCCQMkKHjNkBSVIu3LSsFklK/B6swyc4tQGw5ZzPFGpKuZBoHGTMUUywUaxXZAbwIpnDe+XmmnSJFN3PRbQ66x7HK8gIFC6P5YzPCfJqh5cXPDt7vnY9sGJtV0M7dm10tFZtqLAUc/bXQLCCKBaJ+sCPmu7sBcRDPiIiIio0AK9PTCiXQRmrvsXH284mZXl09juC5qUly9gstXuYd7dT6asNwZ/sj/7V97jcizet/vN9b48Tdf/Mq4RFgh4mq4X5n9zrTDT41H7gW/7Ffx4dw7JWqfwrGGTsUaSIcxvggl53SwFgyo7GG6YadFW3VglgMvOZEpWU8a5mWQ403LspRtuQV0rZUr/jW9ZPicZWuOkJCqgK295L5m2nPU8t9U5QVdR6FrpjCxbUeDI513FyYG9nTDgIyIiolsyTLJ8W07jZGwSfjsYhXsal7f/FzTpYifBgGzVOxWuu92D3wE1uxrG+9iiO2VEB+u+HPaZZR4ISKZKJpQwBoCm29WzQGq8IViW7cLO3HcrYxtlVsF8J5cA8OvTwPntholJ8grerO6eegtkNtbKrW5m6Ix7Gct5K4GRs4OuotC1kuxLWwQCeztgwEdERES3keWrhg/++Bcfrz+B3g3L3VyXz5Gs/VW+Ti/bflG71S+HMsYrv/FEkh2zFAzKJhNNZKZaMbkEDAHdjk8L8Xw8bmY0szOfcjlran1j5vP6JWDP1wXfX8dJtg/8nR10ZWWwM05vxr4ta9CkfXe4O2LpD3Kceq4X2DPgIyIiotvL8m09jROxSVh1MEot01CifpW3x5dDn1KGTabktzTpicw2uHeBdWONanYHKjS92V3V2CU1u2uqMbjzN2Q+rSFdK0+sKbnj2bRu0Fdph4uHE9C4SjsGe66onmuNmWTAR0RERLcsyMcwlm/WHyfw8QZDlk/rjCyfM3+Vd+SXQzd3wzg+ayeXaDOm6C3Ibas6lMTxbOQ4WtdpY1pnV4CIiIiKt+FtIxDg7Y5/Y5Lw+6Fo51VEAq+xh5DxyDLsrjJK7TH2oGOnrW94v2Fv70yAsRurMcCymGXLWh/RngG2jKU0JXVy9cXmiYoZZviIiIjotrN8j7WNUGvyfbj+X/RsEO6cLF9J6m5XFLJsLtbtjchVMcNHREREt00CvgAvQ5Zv9WEnZvlKkqKQZXN0ZpOICo0ZPiIiIrptQb4eGN62Kj7acBKz1v2LYB8PXEpKRViAN1pEhDhn9s6SgFk2IioAAz4iIiKyicfaReCLzafxb2wSBn95c/24ckHemNy3Hno0yJGJIttwockliMj22KWTiIiIbGLH6StIydDlOh4dn4JR3+3F6kMyjT8RETkSAz4iIiK6bZk6PaasOGLxnHE6ETkv5YiIyHEY8BEREdFt23XmKqLiU/I8L2GenJdyRETkOBzDR0RERLctNjHvYM/UhKX70aFmKBpVDELDCsGoWdYfHm78/ZmIyF4Y8BEREdFtk9k4rXHh6g0s3HkeC7PmdPFy16Je+UA0qhCEhhWD0bBCEGqE+d/yrJ7SZXTnmavYc1mD0meuonWNMIfMECqPK9lLCXw5MykRFSUM+IiIiOi2SYAjs3HKBC2WRulJ6BMa4IVXe9fDoah4HPzPsCWmZuCf83FqA86psj4ebqhfPhANKwZlZwKrlfErcDF3mRRGxgkaupa6YcGJ3Q6ZIdT8cQ04Mym50o8K/EGjeGPAR0RERLdNvvxJgCOzccrXQNOgz/i1cOq99VUA1LdJeXVdp9Pj3NVkHPgvTgV/By7G4/DFeFxPy8Tuc9fUZuTv5a6CQBUAVgxWGcEqpX2h0Wiygy55bH0eM4R+9siddgm+nPW4VLI480cF/qBR/DHgIyIiIpuQL38S4OT8chiex5dDydhFlPFT271NKmRnEs5cTsIBCQAlCyhBYGQ8klIzVFdN2YwCvd1VFrB++SAs3n3BYmZRjklIKHXqWi/cplkJqevrK444/HHJ+dkuR3YbduaPCvxBwzUw4CMiIiKbkS9/EuDc6pdxKVcjLEBt991ZUR3LyNTh1KXrhkzgRUMgeCQqAQkpGfjr5BW15cc4Q2ifj7bA39tdfWHP1BsyjHJZpzfsM417OZZ9Hdnnbx4z3CYjU28x2Mv5uMv3XcQ9TSow6HO5bJf9uw0blztxxo8KznzsnPVgd9ISEPD9+eef6NSpk8Vzu3btQvPmzdXlAwcO4JlnnsHff/+N0NBQjBkzBhMmTDArv2TJErz66qs4e/YsatasienTp6NXr17Z5/V6PSZPnoy5c+ciLi4Obdu2xWeffabKGl29elXd94oVK6DVajFgwAB8+OGH8Pf3zy5jTV2IiIhckXwZa129tM3uz91Ni9rhAWp7oFkldSw9U4d/YxJVV9Dl+yOx7VT+QZ84Gp0IZ3h+8X5M+uUgaoYFoFbZANTJei6yhQV4ZXdLLa7ZLkc+tqtku+T75o30TCSmZCAxJV39eGG8bLqXNm7Ncift3tkAH0+33AWsfCssFbuRlmnVY8/ecALtaoaqtizjdL09LNTjFrE7aQkK+Nq0aYOoqCizYxK0rV+/Hs2aNVPXExIS0K1bN3Tp0gVz5szBwYMH8dhjjyE4OBhPPPGEKrNt2zY89NBDmDZtGvr06YPvv/8e/fr1w969e9GgQQNVZsaMGfjoo48wf/58REREqMfp3r07jhw5Am9vwwxkDz/8sKrPunXrkJ6ejuHDh6vHkPuzti5ERER062QpB+nKKVuV0n5WBXzP3l0DdcoFqoDETaNRe23WZa0WZsfcZZ913c30srGsVoN9F+LUF/2C66pBSrpOZSdlMxXs65EdBGbvwwMQ6O1RzLJd9n9sazNOXeqWVe+PXn9zLKkEWDcvy3F99mXkOG48ps+6ncjQ6TF5+eE8H1tM/PkgYhNTcT01E0mpxsDNckAnXZTl+dhKVIJ1y6LYwwd/nFCbUYC3e3bwJz8CGPZeCAv0Qqi/d9beS7X9/H7sYHdS29HojS25GJEgq0KFCiprJgGZkCzcyy+/jOjoaHh6eqpjEydOxLJly3Ds2DF1feDAgbh+/TpWrlyZfV+tWrVCkyZNVGAmL0X58uUxfvx4/O9//1Pn4+PjUbZsWXzzzTcYNGgQjh49inr16qnMnTHYXL16tcoS/vfff+r21tTFGhI4BgUFqToEBgaq571q1Sr1WB4e1v1HQFQYbGNkb2xjZA/yxbnd9A35zhAq4wi3vni3zcfwWfO4m17ohItxN3A8OtGwxSSo/ZnL15HXd/7yQd4qAyjBnzEYlOUqvNzdCvxCbHyGzsh2Ffax5buXTNITfyMdCTfSs/cSIN28bDh+9nIy9p6/OZGPK5DmKBMSBXh7qEApMGtv2DzU8/91f2SB9yNBtvz4UZDCfO2XsbNTVx4tsFzNMD/cSNepYDctQ2f1/csPIRL4hQZ6q70xEJR9GT8vvPTLQVy5nmbxtvb6my7q/1/mjA1cKsOX0/Lly3HlyhWVWTPavn07OnTokB1gCcnMSZfNa9euoVSpUqrMuHHjzO5LykggJs6cOaOCNMnMGcmL2rJlS3VbCfhkL5k6Y7AnpLx07dy5cyf69+9vVV0sSU1NVZuRvKnGN9y4Ga8T2QPbGNkb2xjZy8s9a2PMj/vznCFUzusyM6DLdPzjavSZqBjkiYpBpdG59s2urqnpmTh1+Tr+jUnC8ZgknFD7REQnpCIyPkVtG49fyi4vX2yrlvZFrTB/1Ajzw7c7Cpqo5jA61ixtl7FdrxeU7Vp6EJHXriMpNVMFb8YgToK3hBvmexsmupyuQfkA1Azzh78Ebl7u8Pd2Q4CXSRCnjt287Ovplm+WyzBBzBXEJKTm86OCFx5qZvsxoo0rBOCLzacLfOwVz7TJyqjqVfbyUlIaLiWmqgDwcpJxbzh2KSkVlxLTEHcjHemZ+ux2XljG7qTbTsSgVTXbdR8v6v9f3ur/ncUy4Js3b54KoCpWNAzmFhKoSRdMU5KZM56TIEv2xmOmZeS4sZzp7fIqExYWZnbe3d0dISEhZmUKqosl0tV0ypQpuY6vXbsWvr6+2delKymRPbGNkb2xjZE9DK+lwc9ntYhLu/nFN8hTj/uq6pB5bg9WnSuajys/DzeUrQyAMkByBhCVLJsme4tMBm5kQk1eIxsOW/OFOBUd31kLLzeZeMbYRRHQGfdZx8z2Jpezyxm7O2ZdNpTPP7iQL/RTfztu9WvoptHD1x3wcQN83AFfd332ZXXdTY/EdGBjVMHjw0bUykS1QEOIYlpL07jKeDH7kCZH2Ry3O5mgwZyjBT92x+A41PTJykJKcsokQZWUtRVWr3ANvkrQWqiZoWNqz7LJWLP691u4Z/s+tgQZ4VkbfLO2rK/YkghMSAcS0oDEdA3is/ZyXY5Lm7+SWnAAO/yb3ajgB4T76BHuq0e4D9S+lKf5+30rpJ2fStCo+gR6ANUD9Soj68z/L5OTk4tfwCfdHCXrlR/pQlmnTp3s69Jtcs2aNVi8eDFczaRJk8wykJLhq1SpkhoPaOzSKW96165d2RWK7IJtjOyNbYzsSaZgm6DTY8epS9iwfQ/ubt0UraqH2r3Ll/FxZd1AyWbIeKVmVUrZ9HElexKTmKqygbKtPxaL3edksfr8Rd9wXne3hhUCUbtsAIJ8DN0TjXtZTiPIx9iF0XDZy11b4OQ1ku3q+P7mAjNOLzzcwS5ZzWVWPPbogbZ/bGlfdx6OwZurjqnsr+l4yZd71kH3+uaJCld4bFn24pGvdhdYLkOvwbkk4FyS+Wvu5+mG6qF+qht0jTA/1Aj1V5lX6SotY3QLsuZwDKbleM7hgV54pZd9X++C/r809v4rVgGfjJUbNmxYvmWqVatmdv3rr79G6dKlcc8995gdDw8PR0xMjNkx43U5l18Z0/PGY+XK3ex3LtdlnJ+xTGxsrNl9ZGRkqJk7C3oc08ewxMvLS205yZts+sUo53UiW2MbI3tjGyN7kVbVtmYY4k/o1d5R7UwepV0t+34RrFTaE5VKB6BzPaBJ5RA8NHdHgbd5vkst1CsfqDIT2RPUmExSI8fUdY2hy6jhsnGyGsmS3JzgRuIx2f9zPg5PLyx4spqXetWz6Wyt8hq/fk99NXYwry60k/vWh7fXzSE1rvDYok+TiujZqIJTZmN1xmPL2oYSVBY0PvbrYc1VxvtEbKLqEi17GRsr40IPXExQmynpQmsIAv3VuFgJAmX23IqlfLIDQRmfKt20cz6uBPty3NGTxZj+f3mrn2dODfhkuQLZCvPrlgR8Q4YMyfWEW7durSZKkWjYeE6i4tq1a2d3oZQyMrPn2LFjs28nZeS4kG6YEpBJGWOAJ5G0jM0bNWpU9n3Icg179uxB06ZN1bENGzZAp9OpsX7W1oWIiIjoVskXbmu+EI++u4bNv5iH1fe26rGljrYmX7TlC3fO2UHDHTAzqTMf2x7LnRTlx5bHk9c0/wC7npp1Vzbg5msvS7acu2IYG2sMAk/EJOH05SQkSyD4n2EtT1PeHloVBNYM9ccfR2OdvvagrRWrMXwSWMnEKo8//niuc4MHD1bj30aMGIEXX3wRhw4dUmvjffDBB9llnnvuOdx11114//330bt3b/z444/YvXs3vvjiC3VefsWSYPDNN99U6+4Zl2WQmTdl+QZRt25d9OjRAyNHjlQze0pQN3r0aDWhi5Szti5ERERE9v5CbI8vpc58bCGBlXzhdka2y/jY20/GYu2WnejWvqXKRhWnL//Fxa0G2LJkS40wmdU2wDA41iwQTMbJ2ERDMBgrAWEiTl+6rpZNOXQxQW3WTBYjbc9ZwbfLB3wyWYusyWc6ps90Nk2Z3EQWO5fMW5kyZfDaa6+ZrXsnt5W18l555RW89NJLKqiTGTqNa/AJWRxdlm6Q20kmr127dmrZBeMafGLhwoUqyOvcuXP2wuuydl9h6kJERER0O5jtcl62q2VECK4c1as9gz37sWVw76ECQUN3zh43v/ojQwLBq8kqC7h830WsOmSYhDE/UpfipFgFfMaFzfPSqFEjbNmyJd8yDzzwgNryIlm+qVOnqi0vMiOnLepCREREVNyzXc54bCo57B3cu7tpUT3UX20ygZA1AZ+09eKkWAV8RERERFS0sl3FqWsbkS3GxtpjfKo9GRfWICIiIiIiKrHcssanipx5akeMT7UXBnxEREREREQm41Mlk2dKrjt6SQZbYZdOIiIiIiIiFx2fyoCPiIiIiIjIRcensksnERERERGRi2LAR0RERERE5KIY8BEREREREbkoBnxEREREREQuigEfERERERGRi2LAR0RERERE5KIY8BEREREREbkoBnxEREREREQuigEfERERERGRi2LAR0RERERE5KLcnV0Bypter1f7hIQEtU9PT0dycrK67uHh4eTakStiGyN7YxsjR2A7I3tjGyNntDFjTGCMEazFgK8IS0xMVPtKlSo5uypERERERFREYoSgoCCry2v0hQ0RyWF0Oh0iIyMREBAAjUajonoJ/i5cuIDAwEBnV49cENsY2RvbGDkC2xnZG9sYOaONSdgmwV758uWh1Vo/Mo8ZviJM3siKFSvmOi5vOj9cyJ7Yxsje2MbIEdjOyN7YxsjRbawwmT0jTtpCRERERETkohjwERERERERuSgGfMWIl5cXJk+erPZE9sA2RvbGNkaOwHZG9sY2RsWpjXHSFiIiIiIiIhfFDB8REREREZGLYsBHRERERETkohjwERERERERuSgGfERERERERC6KAV8x8sknn6Bq1arw9vZGy5YtsWvXLmdXiVzE66+/Do1GY7bVqVPH2dWiYmzz5s3o27cvypcvr9rTsmXLzM7LfGGvvfYaypUrBx8fH3Tp0gUnTpxwWn3J9drYsGHDcn2u9ejRw2n1peJn2rRpaN68OQICAhAWFoZ+/frh+PHjZmVSUlLwzDPPoHTp0vD398eAAQMQExPjtDqT67Wxjh075vose+qppwr1OAz4iolFixZh3LhxanrWvXv3onHjxujevTtiY2OdXTVyEfXr10dUVFT2tnXrVmdXiYqx69evq88p+aHKkhkzZuCjjz7CnDlzsHPnTvj5+anPNPnyRGSLNiYkwDP9XPvhhx8cWkcq3jZt2qSCuR07dmDdunVIT09Ht27dVNszev7557FixQosWbJElY+MjMR9993n1HqTa7UxMXLkSLPPMvk/tDC4LEMxIRk9+QVg9uzZ6rpOp0OlSpUwZswYTJw40dnVIxfI8Mmv4/v27XN2VcgFya+Rv/zyi/rlUsh/O5KVGT9+PP73v/+pY/Hx8Shbtiy++eYbDBo0yMk1puLexowZvri4uFyZP6JbdenSJZWFkS/pHTp0UJ9boaGh+P7773H//ferMseOHUPdunWxfft2tGrVytlVpmLexowZviZNmmDWrFm4VczwFQNpaWnYs2eP6vJkpNVq1XX5QCGyBelOJ1/Cq1Wrhocffhjnz593dpXIRZ05cwbR0dFmn2lBQUHqhy1+ppEt/fnnn+rLU+3atTFq1ChcuXLF2VWiYkwCPBESEqL28t1MMjKmn2UyHKJy5cr8LCObtDGjhQsXokyZMmjQoAEmTZqE5OTkQt2v+61Vhxzp8uXLyMzMVL9+m5Lr8ksS0e2SL9qSWZEvRdJVYMqUKWjfvj0OHTqk+pUT2ZIEe8LSZ5rxHNHtku6c0rUuIiICp06dwksvvYSePXuqL+Jubm7Orh4VM9KzauzYsWjbtq360i3k88rT0xPBwcFmZflZRrZqY2Lw4MGoUqWK+lH+wIEDePHFF9U4v59//tnq+2bAR0TqS5BRo0aNVAAoHy6LFy/GiBEjnFo3IqJbYdo1uGHDhuqzrXr16irr17lzZ6fWjYofGWclP4JyfDs5uo098cQTZp9lMtmZfIbJD1nymWYNduksBiSFK79G5pz1Sa6Hh4c7rV7kuuTXylq1auHkyZPOrgq5IOPnFj/TyJGku7r8f8rPNSqs0aNHY+XKldi4cSMqVqyYfVw+r2TYjYwVNcXPMrJVG7NEfpQXhfksY8BXDEh3gaZNm2L9+vVmaV+53rp1a6fWjVxTUlKS+uVIfkUisjXpYidfhkw/0xISEtRsnfxMI3v577//1Bg+fq6RtWSCKfkiLhMCbdiwQX12mZLvZh4eHmafZdLVTsbA87OMbNHGLDFOsFeYzzJ26SwmZEmGoUOHolmzZmjRooWaqUembB0+fLizq0YuQGZKlPWspBunTCkty39IVvmhhx5ydtWoGP9oYPrro0zUIv9JyUB0mdBAxim8+eabqFmzpvoP7tVXX1XjE0xnWSS61TYmm4xFljXR5McF+QFrwoQJqFGjhlr+g8jaLnYyA+evv/6qxrMbx+XJJFOyfqjsZdiDfEeTNhcYGKhmT5dgjzN0ki3amHx2yflevXqptR5lDJ8sBSIzeEo3davJsgxUPHz88cf6ypUr6z09PfUtWrTQ79ixw9lVIhcxcOBAfbly5VTbqlChgrp+8uRJZ1eLirGNGzfKkj+5tqFDh6rzOp1O/+qrr+rLli2r9/Ly0nfu3Fl//PhxZ1ebXKSNJScn67t166YPDQ3Ve3h46KtUqaIfOXKkPjo62tnVpmLEUvuS7euvv84uc+PGDf3TTz+tL1WqlN7X11ffv39/fVRUlFPrTa7Txs6fP6/v0KGDPiQkRP1fWaNGDf0LL7ygj4+PL9TjcB0+IiIiIiIiF8UxfERERERERC6KAR8REREREZGLYsBHRERERETkohjwERERERERuSgGfERERERERC6KAR8REREREZGLYsBHRERERETkohjwERERERERuSgGfERERHk4e/YsNBoN9u3bh6Li2LFjaNWqFby9vdGkSZPbui95bsuWLbNZ3YiIqOhhwEdEREXWsGHDVFDyzjvvmB2XIEWOl0STJ0+Gn58fjh8/jvXr1+dZLjo6GmPGjEG1atXg5eWFSpUqoW/fvvne5nb8+eef6j2Ji4uzy/0TEdGtYcBHRERFmmSypk+fjmvXrsFVpKWl3fJtT506hXbt2qFKlSooXbp0npnJpk2bYsOGDXj33Xdx8OBBrF69Gp06dcIzzzyDokyv1yMjI8PZ1SAichkM+IiIqEjr0qULwsPDMW3atDzLvP7667m6N86aNQtVq1Y1yxb269cPb7/9NsqWLYvg4GBMnTpVBRcvvPACQkJCULFiRXz99dcWu1G2adNGBZ8NGjTApk2bzM4fOnQIPXv2hL+/v7rvRx99FJcvX84+37FjR4wePRpjx45FmTJl0L17d4vPQ6fTqTpJPSQrJ89JAjUjyaDt2bNHlZHL8rwtefrpp9X5Xbt2YcCAAahVqxbq16+PcePGYceOHVZn6KQrqxyTAFKcO3dOZQlLlSqlsoxyn6tWrVLnJZgUck5uI6+38TnJexcREQEfHx80btwYP/30U67H/f3331WQKs9769at2L9/v7rPgIAABAYGqnO7d++2WHciIsobAz4iIirS3NzcVJD28ccf47///rut+5KMV2RkJDZv3oyZM2eq7pF9+vRRQcrOnTvx1FNP4ckn/9/e/b3i3cdxHP/cwn9gB3No8qOsaCmtKEVKKWprixSt7pyQtjDlQByJA8K2RG07WA5QfhyQciQHymqFQls5EeJg+ZGk++71rq++1+Vi1+W2lu/9fJTa9ev747OjV+/3+/P9+8p5FAhfv37tvn796vLy8iz0HBwc2GcKSIWFhS47O9sCiQLa7u6ue/78ecgxPn786BITE93i4qJ7//59xOvr7e11PT09rru723379s2CYVlZmdvc3LTPd3Z2LGTpWvTvN2/eXDnG4eGhXYMqeQpl4RR0b0vHPDs7s/VT1VCVV4VctYuOjY3Zd9RqqmvTvYjC3qdPn+yeV1dXXWNjo6uqqroSmltaWqx1d3193T1+/NhVVlZa8F1eXraQq88TEhJufe0A8H8V/6cvAACAXykvL7dqlwLa8PDwrY+jKl5fX5+Li4tzaWlprqury52cnLjW1lb7/O3btxY6VGF68eLF5e9UnVOlTN69e2eBStfR1NTk+vv7LewplHpGRkYsBG1sbFh1TVJTU+18N1HQa25uvjy3AtXCwoJVKwcGBqzSGR8fbyFL/45ka2vL2iLT09PdXdve3rZ1yMrKsteaD/SvrTx48OAyVCocal3m5+ctKHu/0fp++PDBFRQUXP5eVcuioqKQcyloe/eh9QMAxI7ABwC4FxR+VEmLVNWKlqpjCnsetV+qRdNfTdRc3N7eXsjvvLAiClxPnjyxSpSo9VChTCEs0rydF/jUkniTnz9/WvXx6dOnIe/rtc4RLYW936W+vt7V1dW5ubk5a7VV+FM17joKnwrU/iDnzTAqJPtpTf3Ufvrq1Sv3+fNnO9ezZ89cSkrKHd8RAAQfLZ0AgHshPz/fWhxVhQunEBcedM7Pz698L7wlULNjkd7T3Fm0jo6OrMVT827+P7Vh6po9kdorfwdVwnQPmjuMhReE/esYvoYKYN+/f7cZRbV0KqSp1famtZGZmZmQtVlbWwuZ44u0PppPVAtoaWmpteJmZma6iYmJmO4JAEDgAwDcI2q3nJqacktLSyHvJyUl2WMI/GHlLp+d59/oRJu8aKYsIyPDXufk5Fgw0QYxjx49CvmLJeRpY5KHDx/ajJ+fXivsREutlQrGagE9Pj6+8vl1j03QGorm725aQ7WqatZxfHzcZgmHhobsfc0nysXFxeV3dd3ahEXtmeFro+P8iqqjmvlTRbGioiLihjoAgJsR+AAA94Zmx7SZh+bw/LQL5v7+vs3IqY1SYUe7Pt4VHU/VJVXNtHGJHhFRW1trn+m1Nkp5+fKlbTCi88/OzrqampqQ8BMNzaypdXV0dNQ2P9FGJQpdDQ0NMV+vzp2bm2ubqajaqBZUrZu/PdXPC2GqrOn7qsppAxk/7TKqe/vx44dbWVmxVlYv+OoxEaosTk9P2/+FqnvaYVMtuApt2rRGa6PfqSqo19c5PT21uUnt4KmdQRV6tbbeuQAA0SPwAQDuFW3uEd5yqSAwODhoQUfb/utxBP9l1i9SZVF/OrY2HJmcnLTHK4hXlVPAKi4utlCqYKSNS/zzgtHOyGl2TZUzHUebw+hcsW5Yoo1RFKz0WAMdS3OKmqPTQ9e16Uwkam398uWLhVrN5Sl4dnZ2hnxH96iAq/UuKSmxCpzWXZKTk117e7uFVM1GKrBJR0eHa2trs906vd8pTOoxDdfRLKV2Qa2urrZzaMdTPfZCxwcAxOavf37ndDcAAAAA4I+hwgcAAAAAAUXgAwAAAICAIvABAAAAQEAR+AAAAAAgoAh8AAAAABBQBD4AAAAACCgCHwAAAAAEFIEPAAAAAAKKwAcAAAAAAUXgAwAAAICAIvABAAAAgAumfwHVUEu/QdCSKgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimal number of clusters: 17\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 0: Best model is Ridge with CV MAE -0.24\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 1: Best model is LinearRegression with CV MAE -1.51\n",
+      "Cluster 2 has too few weighted samples after thresholding.\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 3: Best model is GradientBoostingRegressor with CV MAE -0.61\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 4: Best model is GradientBoostingRegressor with CV MAE -0.48\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 5: Best model is GradientBoostingRegressor with CV MAE -1.57\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 6: Best model is Ridge with CV MAE -0.27\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 7: Best model is GradientBoostingRegressor with CV MAE -0.95\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 8: Best model is GradientBoostingRegressor with CV MAE -0.70\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
+      "1 fits failed out of a total of 10.\n",
+      "The score on these train-test partitions for these parameters will be set to nan.\n",
+      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
+      "\n",
+      "Below are more details about the failures:\n",
+      "--------------------------------------------------------------------------------\n",
+      "1 fits failed with the following error:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
+      "    estimator.fit(X_train, y_train, **fit_params)\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\ensemble\\_gb.py\", line 734, in fit\n",
+      "    self.init_.fit(\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\dummy.py\", line 578, in fit\n",
+      "    self.constant_ = np.average(y, axis=0, weights=sample_weight)\n",
+      "                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
+      "    raise ZeroDivisionError(\n",
+      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
+      "\n",
+      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n",
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
+      "1 fits failed out of a total of 10.\n",
+      "The score on these train-test partitions for these parameters will be set to nan.\n",
+      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
+      "\n",
+      "Below are more details about the failures:\n",
+      "--------------------------------------------------------------------------------\n",
+      "1 fits failed with the following error:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
+      "    estimator.fit(X_train, y_train, **fit_params)\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 622, in fit\n",
+      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
+      "                                        ^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 184, in _preprocess_data\n",
+      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
+      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\utils\\_array_api.py\", line 716, in _average\n",
+      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
+      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
+      "    raise ZeroDivisionError(\n",
+      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
+      "\n",
+      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "No valid model found for cluster 9.\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
+      "5 fits failed out of a total of 50.\n",
+      "The score on these train-test partitions for these parameters will be set to nan.\n",
+      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
+      "\n",
+      "Below are more details about the failures:\n",
+      "--------------------------------------------------------------------------------\n",
+      "5 fits failed with the following error:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
+      "    estimator.fit(X_train, y_train, **fit_params)\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_ridge.py\", line 1249, in fit\n",
+      "    return super().fit(X, y, sample_weight=sample_weight)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_ridge.py\", line 956, in fit\n",
+      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
+      "                                        ^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 184, in _preprocess_data\n",
+      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
+      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\utils\\_array_api.py\", line 716, in _average\n",
+      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
+      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
+      "    raise ZeroDivisionError(\n",
+      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
+      "\n",
+      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan nan nan nan nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 10: Best model is RandomForestRegressor with CV MAE -0.61\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 11: Best model is RandomForestRegressor with CV MAE -0.45\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 12: Best model is GradientBoostingRegressor with CV MAE -1.95\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 13: Best model is RandomForestRegressor with CV MAE -0.42\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 14: Best model is Ridge with CV MAE -0.30\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 15: Best model is GradientBoostingRegressor with CV MAE -1.78\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 16: Best model is Ridge with CV MAE -0.25\n",
+      "FeatureStacker - Transformer 'gmm' output shape: (860, 18)\n",
+      "FeatureStacker - Combined features shape: (860, 28)\n",
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FeatureStacker - Transformer 'gmm' output shape: (3437, 18)\n",
+      "FeatureStacker - Combined features shape: (3437, 28)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3gAAAHWCAYAAAAl5yv5AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAnxhJREFUeJzs3Qd4U9X7B/Bv0r1LgdKy9957C7KHCqIyBEQRFMWfCIrgAFH/IrjAiaIgKCqCiopMQURlg+yNbDpYbWlLZ+7/eU+akrRpGyBtRr+f57ne5N6T3JP0EPPmPUOnaZoGIiIiIiIicnl6R1eAiIiIiIiI7IMBHhERERERkZtggEdEREREROQmGOARERERERG5CQZ4REREREREboIBHhERERERkZtggEdEREREROQmGOARERERERG5CQZ4REREREREboIBHhGRm6lcuTJGjBjh6GqQA3z55ZfQ6XQ4deoUiotOnTqpzV2uXRz/hkRkXwzwiKhY+fjjj9WXp1atWuVZRs6PHTs21/GEhARMmzYNjRo1QmBgIPz8/FC/fn08//zzuHDhAlyNvE7zLSAgAHXr1sXrr7+O5ORki7ISMMprtuann35Cr169UKpUKXh7e6Ns2bJ44IEHsH79+nyvL9d45ZVXsGHDBru+LvlibP66vLy8VN3atm2LF154AWfOnLnl5y6sOrsLTdPw1VdfoWPHjggNDYW/vz8aNGiAV199FUlJSbf8vAcPHlTvuysHPZmZmZg/f74KCMPCwuDj46N+jHn44YexY8eOIqvHihUr1HtJRO7L09EVICIqSosWLVJfqrZt24bjx4+jevXqNj3uv//+Q9euXVVwcP/992P06NEqmNm7dy+++OILFeQcPXoUrqZbt24YPny4up2YmIi//voLL7/8Mvbs2YMlS5YU+GX+kUceURmHJk2aYPz48YiIiEBUVJR6P7p06YJ//vlHBVZ5BUsSMIvCyMAMHjwYvXv3hsFgwNWrV7F9+3bMmjULs2fPVn+zQYMG3fRzFnadb9ewYcPU65LgwREBzJAhQ/D999+jQ4cOKoiQAE/alLxn0p5+//13lClT5pYCPHkOec/l36+5NWvWwNldv34d9957L1atWqWCX/mhQYI8CVjl/VqwYIH6bClfvnyRBHgfffQRgzwiN8YAj4iKjZMnT2LTpk348ccf8dhjj6lgb+rUqQU+LiMjQ305i4mJUZmb9u3bW5z/v//7P8yYMQOuqGbNmhg6dGj2/ccffxxpaWnqPUpJSYGvr2+ej33nnXdUcDdu3Di8++67Kltm8uKLL6pMjqen4/4307RpU4vXJk6fPo3u3bvjoYceQp06dVQ21hlIdksyqLfLw8NDbY4wc+ZMFaw8++yzeOutt7KPy48hktHt16+fygSvXLnSrteVH1qc3XPPPaeCu/fee0/9ezEnn0Fy3JXJjz3yeSG9GojICWhERMXEa6+9ppUoUUJLTU3VxowZo9WoUcNqOflofPLJJ7Pvf/fdd+rY//3f/93ytU+dOqWuWbNmTc3X11cLCwvT7rvvPu3kyZMW5ebPn6+u9ffff2vPPPOMVqpUKc3f31/r16+fFhsba1HWYDCo11SuXDnNz89P69Spk7Z//36tUqVK2kMPPVRgnXK+TpOxY8dqHh4eWnp6evYxeb6AgIDs+8nJyeo11K5dW8vIyLjp90Net1w/5zZ16tTsMuvWrdPat2+vXn9ISIh29913awcPHrT5ud966y2r5zdt2qTODxkyxOL41atXtaefflorX7685u3trVWrVk178803tczMTJvrfOjQIW3AgAGqnfn4+GjNmjXTfv75Z6t/4w0bNqg2Ubp0aS00NFSdu+OOO7R69eppe/bs0Tp27Kj+rlKPJUuWqPPymJYtW6o2JG1p7dq1Vp/bvF1Je+jTp4/2119/aS1atFD1qlKlirZgwYJc701B70FepD3Ia5Y6mbcbcw8//LCq2+bNm3PVbfXq1VqjRo1U3erUqaP98MMPuV5Tzu2PP/7Ifs9kM5Hjcn7x4sXaK6+8opUtW1YLDAxUf5e4uDgtJSVFvUZ536VNjxgxQh0zN2/ePK1z586qjLwPUqePP/4412vKeW1rzp49q3l6emrdunXLt1x+f8Oc7cz8/TP/t56WlqZec/Xq1dV7Kf9G27Vrp61Zs0adl7LW3ksT+Tu/9957Wt26ddXjw8PDtdGjR2tXrlzJdV35u61atUq1cSkrjxNyLbmm/JuV91faxOTJk2167URkH8zgEVGxIRk7ycTJL/7Sfe+TTz5R3fZatGiR7+N++eWX7O5vt0quI9lD6T4n3bCka5ZcX7qcSfcz6cpm7qmnnkKJEiXUr/tSVroWyrjAxYsXZ5eZMmWKGi8n3RBl27Vrl8pOSQbOVvKr+6VLl7KzSNKlUrqLSVe7/LJvf//9N65cuaKyEbeSMSpdurR6/WPGjEH//v3V30U0bNhQ7aUrn4zrq1q1qupKJl3cPvjgA7Rr1069zpzd9G5GmzZtUK1aNaxdu9ai6+Udd9yB8+fPq+xuxYoV1d9r8uTJqsupvP8F1fnAgQOqfuXKlcOkSZNURk4yWpK5+uGHH9RjzD3xxBPqOeXvaD4+TbqT9u3bV7UV6Q4s15Tb0n7l/ZYsq/x9JEt233334ezZswgKCsr3NUt3ZCk7cuRIlb2cN2+eyqY1a9YM9erVs/k9yK89SL2ffvrpPNuNdAWWMWjLly9H69ats48fO3YMAwcOVK9L6iZl5HVLxku6EEuXxv/97394//33VddGybwK0z4v06dPVxkl+VvI65f2I+Mx9Xq9qqu0qy1btqgsdJUqVdTfwUTec3lf7r77bvV6fv31V/X3ku6+Tz75JG6GZCylF8DtfH7YSl6TvO5HH30ULVu2VOOGZXyf/JuR91L+rjJeWNq+ZNhzkvPyfsi4QHnPpdfDhx9+iH///Vd9Nsj7Z3LkyBH1OSqPGTVqFGrVqqX+DUjblX8TMu5SugrLey+PJaIiZKdAkYjIqe3YsUP9Um3KeEj2S7IU8kt+QZmtJk2aqF+jb4dkOHKSTIZca+HChbl+ve/atauqo4lk8ySrJhkIIdk8ySzIr+jm5V544QX1eFszeNY2yRbmzGjkzODNnj1blf3pp5+0W3Xx4sU8MxONGzdW2YPLly9nH5Osll6v14YPH35bGTxxzz33qDLx8fHqvmRC5fUdPXrUotykSZPU+37mzJkC69ylSxetQYMGFu+d/G3atm1rkS02/Y0lO5kz+ynZIDn3zTffZB87fPiwOiavfcuWLdnHJeslx+X5CsrgybGNGzdmH5P2I1mXCRMmZB+z9T2wZtasWQW2B8kCSZl77703V93MM3byN4mMjFT/7kwkg2metcv5nlnL4NWvX19ltEwGDx6s6XQ6rVevXhaPb9OmjapHQf9ee/TooVWtWjXfa1sj/3alPv/++69W2Bk8yYLKZ0J+5LPN2tc/yfDK8UWLFlkclyxdzuOmv5ucMydZPDku/06IyHE4iyYRFQuS/ZDJHTp37qzuy3gxyRp89913anKI/Miv4AVlSApiPjYlPT0dly9fVhO8yEyD8ut6TjJuyXxMm0xaIfWUMWSmDJdk6iTTZ14u5/iegtxzzz3q13zZfv75Z5WtkcyJZIiM3yvzfk/E7b4v1ki2aPfu3SrDJBNRmEhWQLIQMknE7TLNCHrt2jW1lwlA5D2WrKlkNE2bTKwj7/vGjRvzfT7JZsqsoTLWTJ7T9Hj5O/fo0UNlqSQzZk6yHtayn1I38wlgJDMi7UQyVuazv5puywRABZHZUeX1mUjmUJ7X/LG38x6Y3sf82oPpnKntmMisq+bZzeDgYJXtk6xRdHQ0bpU8h3nGSd4v08RA5uS4ZEEly2bt32t8fLx6HyS7Ke+X3L8ZhflvJSdpJ5JFk/Z2s+TvHxISov6Nmf/9JcsrbfKPP/6wKC9ZT2nbOa8v5LNEsp1E5BjsoklEbk++nEogJ8GddDky/2InE4WsW7dOdW3Mi3zhtOVLdH6ki6F0nZLuZ/JF3zx4svaFUbrHmZMv3UK6lglToFejRg2LcvLF3VTWFtJdVL7Am0iXtJIlS6qJMqQr3V133ZXne2L+xd6eTK9NApCcJMhZvXr1bU9KIjOGmn/pli/EMiOqvH/WxMbG5vt80g1N/qYyA6lseT2HdN80/4Kc19/EPGgX8sW7QoUKuY6Zt4n85GxPQtqJ+WNv5z0wvY/5tYe8gkD5oSPn65XJf4R0T5aZWW9Fztdser+svY8SjMi/Q2n7QroUSvfozZs351oyRMqZnssWhflvJSfpFik/2sj7J0u49OzZU3UNNXUjzo/8/eW1hYeH2/T3t9Z+5Uezzz//XHURla6xMpOudGWW7sHSNZaIigYDPCJye5JZkayQBHmyWcvu5Rfg1a5dW2UT5Ff+nF8ObSWZNgnuJMMmY8DkC6J8qZVMjbVfuvMa15ZfVs1e5EuZkIxNXgGevCdi3759aoyZq9m/f7/6Imv68i1/A8lcTJw40Wp5U8CRF9PfUALjnFkNk5xLcuQ142Bef/vbaRO2PPZ23gPTeDgJEPNqD3LOlE0sCrf6Pp44cUL9G5A2LrPDyr95GbcrmWOZ7fJmM1Pm/1YaN24Me8rZ+0DGK0r9JYMmy0dIsCV1njNnjgq68iOvS/5NyOehNTkDf2vtV47J54Zk+3777TfVG0DGDd95552qPo6a4ZWouGGAR0RuT76wyBcXWfspJ1kOQNZsky9AeX3hliDn22+/xddff626MN6KpUuXqgkkJGNoPsFJXFzcLT1fpUqVsn91l4lITC5evGhTRic/pq5qpiyXNbJUhGSA5H2RiS9u5YtbzqxNztcmkzjkdPjwYbVo+e1k7yQrI1+CzZdQkElX5PWaZzNvps6mv4F0CSzoOZyVre9BXu1Buud98803aokMa+1h4cKFai+TcFjLfpq/t6Y1JU2T6eT1vhcGmVAlNTVVTa5kngXM2UXRVjJZkLwf8vlxqxOtyL+1nJ8V0kVbfrjKSbo1yyQpssnfU4I+mXzFFODl9V7K31+6fstEQbez3IFk6iRAlk0C5DfeeEO1CXn/XPXfBpGrYb6ciNyadI2UIE6+VEo3oZybzEwpXadMM2VaI+UaNGig1ruT4CAnebx8gcmPfMHLmWmRWf0KGv+XF/miJMGEPIf58+Y30+HNfMEV+a0RJ7N+Pv/88zh06JDaW8siyRdaWVA+v+cQOb+4RkZGqkyHzOZpfk6ybpIFkBlDb6f7p4ztk4yMrE1mImPn5G8r3T9zkjqYgt686iw/IMiMqJ9++qnVL90SeDs7W98Da+R9keylBOXW/i1INkdmZ5TspvkMmkJmdZQfWczHrEkwKG3A1D3TFNDf6g8iN8MUnObsRi0Z+FshGUAZbyltV/69WsucyQ8/586dy/M5JPjKOQbys88+y/X5IWM+zcnYOckcS8Bqktd7KX9/eb7XXnst1/Xlb2/Ley9jUXMyZS3N60BEhYsZPCJyaxK4SQAmY8uskS+b0vVIsnwyfsQaCaQkSJSgSn4Nly9C8iu3HJcJDSRrIb+wSwCYFwkwZVpy6ZopXdTki7T8Wm4a83OzpM7yhVrG9clzS9Aj3UhlSnbJcNlKMiUSiAkZayTTxktgJV8KC8o2SIAkr1++nMqv8xIIyxdymRhj2bJlKriTafbzIlkCeS+kC5d0/5PMg4wbkk2WAJDMh3Rnlan9TcskyPsn2QhbyOQ18trkC7R8OZWlKmS5AslgyN/CfFySvBZpK/JempYPkHF+0q1Osq8yFkze1/zqLBliyWTJjwHyhV6yejExMepvLV/e9+zZA2dm63uQFxlzJW1wxowZ6jUPGDBAvV+yhIL8HaQbp7StnOR9lL+x/H1kIiRZwkHeN/OASoIECbzkuSXYkun3pdtfXuPFbod015YfACRzL0sASBZs7ty56lrWgndbyL8RyRrL0gOmH5zkM+PMmTNqchPJTJtPrJOTZN9kGQl5T6UbrbQlCcRz/j2kbcoPDfK3k7YpSyTI305+yDKRc0LqIgG3vK9ybZlERl6vfKbIJEfyPshnnPQSkDrOnj1b/RsvaAygBKJ9+vRRmXgZt/fxxx+rcaXyb4OIiogDZ/AkIip0d911l1oUOikpKc8ystCxl5eXdunSpXwXAJdFoKdMmaKmwpfFt+V5ZSp2WcQ3Kioq33rIY2WhZ1m4XBZdlinXZfr7nNOcm6ZI3759u8XjTVO/m08TL4sST5s2TU0pf6sLnZtvMhW+LB0hCxvHxMTku0yCuaVLl2rdu3dXiyrLgs5Sn4EDB6pFuQsii47LQsmy5EPOqeB///13tWCyvLbg4GD1t7yZhc5Nm9RJ6taqVSv1tzp9+rTVx127dk2dl0WipT7yt5IlDt5++22L6fbzq/OJEyfUMg4RERGqTcki9H379lXvUUF/Y/OFznMyLSydU862mt9C59aulXOKf1vfg7xIm5Q6yN9N/mbyb0Rej7TTxMTEPF+XLPnQsGFDtXRD7dq1sxd2Nzd37ly1TIG0U1sWOs/5HHm97/L3yzm1/y+//KLqI/WvXLmyNmPGDLX4ec731pZlEkxkSYzPP/9c69Chg1p2RdqHvH75XDBfQsHa31De1+eff179PeSzRz4/jh8/nuvf+uuvv661bNlSCw0NVf9u5L38v//7P4u/ndTjqaeeUou4y7IROb8KfvbZZ6p9y+ODgoLU593EiRO1Cxcu5Pq75bRu3Tq1BIksLi/tR/ayPEXOpTeIqHDp5D9FFUwSERERmcgYO8l+yoytRERkHxyDR0RERERE5CYY4BEREREREbkJBnhERERERERugmPwiIiIiIiI3AQzeERERERERG6CAR4REREREZGb4ELnTkwW571w4QKCgoLUwrxERERERFQ8aZqGa9euoWzZstDr887TMcBzYhLcVahQwdHVICIiIiIiJ3H27FmUL18+z/MM8JyYZO5Mf8Tg4GB1Oz09HWvWrEH37t3h5eXl4BqSK2NbInthWyJ7YVsie2FbIndsRwkJCSr5Y4oR8sIAz4mZumVKcGce4Pn7+6v7ztDQyHWxLZG9sC2RvbAtkb2wLZE7t6OChm5xkhUiIiIiIiI3wQCPiIiIiIjITTDAIyIiIiIichMcg0dEREREREU21X9GRgYyMzPhCmPwPD09kZKSUiT19fDwUNe73eXRGOAREREREVGhS0tLQ1RUFJKTk+EqwWhERISa0b6o1qSWSV0iIyPh7e19y8/BAI+IiIiIiAqVwWDAyZMnVZZKFuqWAKaogqbbqXNiYiICAwPzXVjcXsGkBMAXL15U71ONGjVu+ZoM8IiIiIiIqFBJ8CIBk6zjJlkqV2AwGFS9fX19Cz3AE35+fmo5htOnT2df91ZwkhUiIiIiIioSRREoFff3h+8wERERERGRm2AXTSqYIRM4vQlIjAECywCV2gJ6D0fXioiIiIiIcmCAR/k7+Au0Vc9Dl3Ah+5AWXBa6njOAunc7tGpEREREVPxkGjRsO3kFsddSEB7ki5ZVwuChd+4JW4oSu2hS/sHd98OhmQV3Qu7LcTlPRERERFRUVu2PQvsZ6zF47hY8/d1utZf7crywbd68Wc0C2qdPH4vjp06dUjOC7t692+L4Dz/8gE6dOiEkJETNxNmwYUO8+uqruHLlSqHWkwEeWWfIxPVfn1NTtuZsJHJfjst51X2TiIiIiKiQSRA35utdiIpPsTgeHZ+ijhd2kPfFF1/gqaeewsaNG3HhgmUCJKcXX3wRAwcORIsWLbBy5Urs378f77zzDvbs2YOvvvqqUOvJLppkVeapf+B3PRrII9stWXA5L+U8qnYs6uoRERERkYtTCYP0TJu7ZU795QA0a88D41fWV345iHbVS9nUXdPPy+Om1uGT9fAWL16MHTt2IDo6Gl9++SVeeOEFq2W3bduGN954A7NmzcLTTz+dfbxy5cro1q0b4uLiUJgY4JFVJ/47gZq2lmOAR0REREQ3SYK7ulNW2+W5JMiLTkhBg1fW2FT+4Ks94O9teyj0/fffo3bt2qhVqxaGDh2KcePGYfLkyVaDxEWLFqkumU888YTV5woNDUVhYhdNsipWC7VrOSIiIiIiV/XFF1+owE707NkT8fHx+PPPP62WPXbsGKpWraoWLXcEZvDIKo/K7XDh7zBE4IrqjpmTpgHRCFPliIiIiIhulnSTlEyaLWTWzBHztxdY7suHW6hZNW25tq2OHDmiul3+9NNP6r6np6caXydBn0yiYq3rqSMxwCOrWlYrjRe9HsUb6TNh0Ixj7kykzUo2OhNeaBnhyFoSERERkauS7o22dpPsUKM0IkN81YQq1sIn+aoaEeKrytl7yYR58+YhIyMDZcuWtQjifHx88OGHH+YqX7NmTfz9999IT093SBaPXTTJKvmH0anfI3gifZzK1Jm7hBAkaH4ojxh4zO8JXD3tsHoSERERUfH4bjr1rrrqds7wzXRfznvYObiTwE5mvZQZMGUZBNMms2FKwPftt9/mesyQIUPUpCwff/yx1efkJCvkMD3rRwJDHsf9v7RDhcQ9CEccYhGKA571UCr9Ar7yno7yV04AX3QHhv0IlKnn6CoTERERkRt/N/1kaFNM+/WgxVIJkrmT4E59d7Wz1atX4+rVqxg5cqRaz87cgAEDVDdNGZNnrlWrVpg4cSImTJiA8+fPo3///ioYPH78OObMmYP27dtbzK5pbwzwKF/yD6Vb3QhsO9kMsddSEB7kixaVS+C934/i3j+mYaH3m6ideBba/F7QDfkeqNja0VUmIiIiIrf/bnol+7upjLmzd+bORLJ3Xbp0yRXcmQK8mTNnIiEhIde5GTNmoFmzZvjoo49UUGcwGFCtWjXcd999eOihh1CYGOBRgeQfTJtqJS2OPdejtuoz/cDql/GF99tokXIU2sJ7oLt/AVDL8lcMIiIiIqLC/G5aWL777jsEBwdbPdeyZcvsCVWsTazywAMPqK2ocQwe3bInO1fH031bYljaZKzLbAJdRgq074YAu3P3RSYiIiIiosLHAK+QSVpWVq339fVV/XFlilV3MrJ9FUzp3xyPZzyDHzI7QKdlAsseBzZ94OiqEREREREVOwzwCtHixYsxfvx4TJ06Fbt27UKjRo3Qo0cPxMbGwp0MaVURMx9ohuczH8dnGX2MB9e8BKydYlxTgYiIiIiIigQDvEL07rvvYtSoUXj44YdRt25dNcDS399fraXhbvo3KY8PBjfDW9pQvJE+2Hjwn9nAz2OBzAxHV4+IiIiIqFjgJCuFJC0tDTt37sTkyZOzj+n1enTt2hWbN2+2+pjU1FS1mZhm5JFFEmUz3TbfO5OutUvh4yGNMfZbHa6mB2GG1+fQ7/4ahqRLyOw/F/Dyc3QVyYwztyVyLWxLZC9sS2QvbEvOR/4WMhGJzCYpmyvQzCZQKao6y3XkevJ+eXh4WJyztT3rNGtTvtBtu3DhAsqVK4dNmzahTZs22cdlTYw///wTW7duzfWYV155BdOmTct1/JtvvlGZP1dxNF6HuYf16Ihd+Mj7ffggHZcCamFr1XHI8AxwdPWIiIiIqIh5enoiIiICFSpUgLe3t6Or49RJorNnzyI6Olotsm4uOTlZLaIeHx+f58yeghk8JyLZPhmzZ57Bk38E3bt3z/4jSuS+du1adOvWDV5eXnBGvQF0PBOHkQu9MCx1Eub5votSSUfQO+ZDZAxaDARFOLqK5CJtiVwD2xLZC9sS2QvbkvNJSUlRgUtgYKCafNAVaJqGa9euISgoCDpd4ayzZ+198vPzQ8eOHXO9T9bW27OGAV4hKVWqlEqrxsTEWByX+/LrhTU+Pj5qy0k+mHJ+OFk75kxaVSuNb0e1xrB5Otx//SUs8p2JsNgD8FrYBxj2E1CymqOrSC7Slsh1sC2RvbAtkb2wLTmPzMxMFSTJkCXZXIEhq1umqd5FQa4j18vr+79Nz1FIdSv2JPUsq9evW7fOopHIffMum+6sQfkQLB7dBhcDauKelCk4r4sA4k4D83oAUXscXT0iIiIiIrfDAK8QSXfLuXPnYsGCBTh06BDGjBmDpKQkNatmcVErIgjfP9YaGcGVcM/1qTiqqwIkXQTm9wFO/uXo6hERERGRqzFkGr9H7ltq3Mt9ysYArxANHDgQb7/9NqZMmYLGjRtj9+7dWLVqFcqUKYPipGrpQHz/WBv4h0ViwPUXsVNXH0i7Bnx9L3DwF0dXj4iIiIhchXx3nFUfWNAX+GGkcS/3C/E75cMPP6y6TZq2kiVLomfPnti7d292GTm+bNkyi8f98ccf6N27tyovEybKsmkTJkzA+fPnUZgY4BWysWPH4vTp02r5A5k5s1WrViiOKoT5qyAvvHRpDLn+LNbrWgGZacCSh4CdXzq6ekRERETk7CSI+344kHDB8nhClPF4IQZ5PXv2RFRUlNpkyJXMCtq3b988y3/66adqeTSZe+OHH37AwYMH1ZrYMgPmO++8g8LESVaoyESE+GLxY20w9POteDT6KbzlG4gB2jrg16eBpEtAhwny84ejq0lERERERUFWa0tPtq2sdMNcOVEeZO2JJIcGrHoeqNoJ0FuuH2eVl/9Nfe+UiRBNEyXKftKkSejQoQMuXryI0qVLW5Q9d+4c/ve//6ntvffeyz5euXJlNTtmXFwcChMDPCpSpQJ98N3o1nho3jZMOPcILvuEYLTuR2D9a8Ygr8cbMn2Qo6tJRERERIVNgrs3ytrpyTRjZu/NCrYVf+EC4H1r6zMnJibi66+/RvXq1VX3y5yWLFmi1rOT9a+tCQ0NRWFigEdFLtTfG18/2gojv9yBN07dh0veQXhBvwDY+gmQfAm452PjLy+nNwGJMUBgGaBSW9t+jSEiIiIisrPly5erNfyETJoYGRmpjllbPuHYsWNqDWsp4wgM8Mghgny9sOCRlhj91Q58dqwHrngFYabnHOj3LQEuHjHOtHkt6sYDgssCPWcAde92ZLWJiIiIyF6km6Rk0mwhP/wvuq/gcg8uNSYGbLn2TejcuTM++eQTdfvq1av4+OOP0atXL2zbtg2VKlXKtUB6US2Mbg37wpHD+Hl7YO7w5uhaJxxL09vi0fQJyNR7A9F7LYO7Iho8S0RERERFSIIg6SZpy1btTuMP/jLWzvqTAcHljOVseb6bDMACAgJUl0zZWrRogc8//1xl8mRJtJxq1qypJlORCVkcgQEeOZSvlwc+GdoMfRtGYkNGA1zN9LU6dDZ7QO2qSVzrhIiIiKi4kaE60ptLyRmcZd3v+WaRDemRDJ10z7x+/Xquc/fddx+8vb0xc+ZMq4/lJCvk9rw89Jg9qAnqpe1FqVMJBQyePW9M0VfpUIQ1JCIiIiKHk6E6Dyw0zpZpvlSCGsrzZqEO5UlNTUV0dHR2F80PP/xQTbZy11135SpboUIFNXumLJeWkJCA4cOHqxk0ZXbNhQsXqrF8hblUAgM8cgoeeh0eaxoAnLKhsEy8QkRERETFjwRxtfsU+WR8q1atyp40JSgoCLVr11azZXbq1Mlq+SeeeEJ11Xz77bfRv39/lemTIE/Wzhs/fnyh1pUBHjkNTf6B2iAzIBycT5OIiIiomJJgrgh7c82fPx8LFizIt4xMrJKTLHQuW1HjGDxyGtsya+OCFgaDlvdamBe0kqocERERERHlxgCPnEZsUjqmpQ9Xt/MK8pZltFPliIiIiIgoNwZ45DTCg3yx2tASY9LHIRphFueSNB81m+1wzzWonGHLQD0iIiIiouKHY/DIabSsEobIEF+siW+JtanN0VJ/GOGIQyxCsctQHV96zURbj4No+PfjQJ0NQEBJR1eZiIiIiMipMINHTjWT5tS76qrbGvTYYqiLXwxt1T4N3ngi/WnEeJaFLu6McdHzjDRHV5mIiIiIboK1yUjIvu8PAzxyKj3rR+KToU0REeJrcbyEvxfiEIQHk8Yh3TMAOP03sHKiceYVIiIiInJqXl5eap+cnOzoqjg10/tjer9uBbtoklMGed3qRmDbySuIvZaixuZJ98131x7BR38AY1OfxByPt6DbOR8oUw9oOcrRVSYiIiKifHh4eCA0NBSxsbHqvr+/P3QywYITMxgMSEtLQ0pKCvR6faFn7iS4k/dH3id5v24VAzxy2u6abapZjrEb360W9p9PwOqjjfGxzzA8mbEQWPk8UKoGUNX6IpNERERE5BwiIiLU3hTkOTtN09QC5X5+fkUWjEpwZ3qfbhUDPHKpoO/9QU1w14d/460rPdAw7AI6JP8OfP8QMGo9ULKao6tIRERERHmQICkyMhLh4eFIT3f+Za/S09OxceNGdOzY8ba6TNpKrnE7mTsTBnjkUkL8vfDZ8Gbo/9EmPHplKNaXika5xP3At4OAR38HfEMcXUUiIiIiyocEMfYIZAqbh4cHMjIy4OvrWyQBnr1wkhVyObUjgvHW/Q2RCm/0uzQG133LAJeOAktHAoZMR1ePiIiIiMhhGOCRS+rbsCweu6MqLqIEhiaNg8HTFzi+Fvh9qqOrRkRERETkMAzwyGVN7FEbHWqUws70SnhVP9Z4cNMHwO5vHF01IiIiIiKHYIBHLj/pSvkSfvgyoSmWBT9oPPHr08CZrY6uHhERERFRkWOARy6tRIA3Ph3WDL5eejwT2wtHwzoBmWnA4qFA/DlHV4+IiIiIqEgxwCOXV69sCGYMaAgNevS7MBwJIbWApFjg28FAWpKjq0dEREREVGQY4JFbuKdxOYxsXwXJ8MW9V59Chm9JIHovsGwMYDA4unpEREREREWCAR65jcm9aqN11TAcTwvDM7pnoem9gIM/AxtnOrpqRERERERFggEeuQ1PDz0+GtIUZUN88evVSviyxP+MJzZMNwZ6RERERERujgEeuZWSgT74dFhzeHvqMe18M+yKHGw88dPjQNReR1ePiIiIiKhQMcAjt9OgfAim92+gbt9/sjcuRXQA0pONk64kxjq6ekREREREhYYBHrmlAc3KY0TbysiEB+6KegRpoVWBhHPAdw8CGamOrh4RERERUaFggEdu68U+ddCychiiUn0wKn0CNJ9g4Nw2YPkzgKY5unpERERERHbHAI/clpdMuvJgU0QE++LPyyUwu8SL0HR6YPciYPNHjq4eEREREZHdMcAjt1Y6yAdzhjWDt4ces05VwF9VnjGeWPsycGyto6tHRERERGRXDPDI7TWuEIrX+9VXtx861BQXqt4HaAZg6SPAxaOOrh4RERERkd0wwKNi4YEWFTC0dUVomg59/rsXKZEtgdQE4NuBQPIVR1ePiIiIiKh4BXj/93//h7Zt28Lf3x+hoaFWy5w5cwZ9+vRRZcLDw/Hcc88hIyPDosyGDRvQtGlT+Pj4oHr16vjyyy9zPc9HH32EypUrw9fXF61atcK2bdsszqekpODJJ59EyZIlERgYiAEDBiAmJuam60JFa0rfemhWqQSupgDDro2FIbg8cOU/YOnDQCb/NkRERETk+lwmwEtLS8P999+PMWPGWD2fmZmpAiopt2nTJixYsEAFb1OmTMkuc/LkSVWmc+fO2L17N8aNG4dHH30Uq1evzi6zePFijB8/HlOnTsWuXbvQqFEj9OjRA7GxN9ZPe+aZZ/Drr79iyZIl+PPPP3HhwgXce++9N1UXKnqy+PknDzZFeJAPtl/yxBshU6F5BQD/bQBWv+Do6hERERERFZ8Ab9q0aSqwatDAuIB1TmvWrMHBgwfx9ddfo3HjxujVqxdee+01lY2TQEvMmTMHVapUwTvvvIM6depg7NixuO+++/Dee+9lP8+7776LUaNG4eGHH0bdunXVYyQLN2/ePHU+Pj4eX3zxhSp35513olmzZpg/f74K5LZs2WJzXcgxwoN98cnQZvDy0OHzYwFYVfMV44ltnwI75gEn/wL2LTXuDZmOri4RERER0U3xhJvYvHmzCv7KlCmTfUwyb5LxO3DgAJo0aaLKdO3a1eJxUkYyeUKCr507d2Ly5MnZ5/V6vXqMPFbI+fT0dIvnqV27NipWrKjKtG7d2qa6WJOamqo2k4SEBLWX68lmum2+p5vXsGwgpvSpg5d/OYgndpXD782eRrX9s6EtfwY6s3JaUFlkdn8DWu2+cEdsS2QvbEtkL2xLZC9sS+SO7cjWerhNgBcdHW0RUAnTfTmXXxkJpK5fv46rV6+q7pXWyhw+fDj7Oby9vXONA5QyBV3HvC7WTJ8+XWUqc5KMoGQRza1dyyn+b0cwgDbhemyO1WP2bmC2JyyCO+XaBXj8MALbqzyFqNAWcFdsS2QvbEtkL2xLZC9sS+RO7Sg5Odn5A7xJkyZhxowZ+ZY5dOiQypAVB5I5lPF/JhJ4VqhQAd27d0dwcHB25C6NrFu3bvDy8nJgbV1flwwDhn2+BZMufWX1vAR8GnRocflHZAx6CdB7wJ2wLZG9sC2RvbAtkb2wLZE7tiNT7z6nDvAmTJiAESNG5FumatWqNj1XRERErtkuTTNbyjnTPudsl3Jfgic/Pz94eHiozVoZ8+eQrpxxcXEWWbycZQqqizUys6dsOUmDytmorB2jmyNv3xedMxC2NO9lEnTQgITz8LqwHajSAe6IbYnshW2J7IVtieyFbYncqR3ZWgeHTrJSunRplZ3Lb5PukLZo06YN9u3bZzHbpUTcErzJZCmmMuvWrbN4nJSR40KuJZOmmJcxGAzqvqmMnJc317zMkSNH1LIIpjK21IWcQ5h21baCiZZBPxERERGRM3KZMXgSQF25ckXtZZycLHMgZC07WYtOujFK8DRs2DDMnDlTjXV76aWX1Hp1pqzY448/jg8//BATJ07EI488gvXr1+P777/Hb7/9ln0d6SL50EMPoXnz5mjZsiVmzZqFpKQkNaumCAkJwciRI1W5sLAwFbQ99dRTKqiTCVaELXUh55AZEA4PO5YjIiIiInIklwnwZA05WU/OxDQT5R9//IFOnTqprpXLly9XM1VKsBUQEKACtVdffTX7MbJEggRzstzC7NmzUb58eXz++edqhkuTgQMH4uLFi+p6EpjJMgerVq2ymDRFllWQ2TVlgXOZ9VIe//HHH2eft6Uu5By2ZdZGJS0MEbgCfa5ZVoziNX8czKwNY36WiIiIiMh5uUyAJwuFy5afSpUqYcWKFfmWkWDw33//zbeMrI8nW158fX3Vmnay3U5dyPFik9LxZfpwfOI1CwYNFkGepgE6HRCEZHge/RWoMdKRVSUiIiIicp+FzokKQ3iQL1YbWmJM+jhEI8ziXBTCsCGzoQr6mu2cZFz8nIiIiIjIiblMBo+oMLSsEobIEF+siW+JtanN0VJ/GOGIQyxCsc1gXJ7jC68P0dmwBfhuCPDwSiCivqOrTURERERkFTN4VKx56HWYepdxZlMNemwx1MUvhrZqb4Bebb9WmwZUbAukJgCL7gPizji62kREREREVjHAo2KvZ/1IfDK0KSJCfC2Oh/gZ1xr5cd9lrKj/DlC6DnAtCvh6AJCc99p5RERERESOwi6aRFlBXre6Edh28gpir6WosXnSffPNlYcw96+TGPfzaUQO/gJN1twPXDoKfDMQGP4z4O3v6KoTEREREWVjBo/IrLtmm2olcU/jcmov9yf3qoOe9SKQlmnAwz+ex9neXwG+IcC5bcAPI4HMDEdXm4iIiIgoGwM8onzo9Tq8N7AxGlUIRVxyOob+moD4fl8Bnr7AkRXAb+ON6ykQERERETkBBnhEBfDz9sDnw5ujfAk/nL6cjEf+8ELaPZ8BOj2wawGw4U1HV5GIiIiISGGAR2SD0kE++PLhFgj29cTO01fxzL4KMPR623jyzzeBHfMdXUUiIiIiIgZ4RLaqHh6EOcOawctDh9/2RuGtK+2AjhONJ6Wr5uHfHF1FIiIiIirmGOAR3YS21UrhzXsbqtufbDiBbwOGAk2GAZoBWPoIcGaLo6tIRERERMUYAzyimzSgWXk83aWGuv3SzwewsdaLQM2eQEaKcfmE2MOOriIRERERFVMM8IhuwbiuNXBvk3LINGh44tu9ONLhfaB8CyAlzrgQesIFR1eRiIiIiIohBnhEt0Cn02H6gAZoVSUMiakZePjr/Yi9awFQsgaQcM4Y5F2Pc3Q1iYiIiKiYYYBHdIt8PD3w2bDmqFo6ABfiU/DI9/8h+YHvgcAyQOxB4LshQHqKo6tJRERERMUIAzyi2xDi74UvR7REyQBv7D+fgKdWXkbmkKWATzBw+h/gp9GAIdPR1SQiIiKiYoIBHtFtqljSH3Mfag4fTz3WHY7Fq9v10AZ+DXh4Awd/BlY+D2iao6tJRERERMUAAzwiO2hasQRmDWwMnQ5YsPk05l2oCPSfYzy5fS7w97uOriIRERERFQMM8IjspFeDSEzuVVvdfv23g1itawf0fNN4ct2rwL+LHFtBIiIiInJ7DPCI7GhUh6p4sFVF1SPz6e/+xZ5yg4F2TxtP/vIUcGyto6tIRERERG6MAR6RnZdPmHZ3PXSqVRop6QaMXLADZ5tOBBoOArRM4PvhwLmdjq4mEREREbkpBnhEdubpoceHQ5qiTmQwLiWm4pEFOxHf/T2g2p1AejLwzf3A5ROOriYRERERuSEGeESFINDHE/NGNEeZYB8ci03EE9/tRdq9XwKRjYHky8BX/YFrMY6uJhERERG5GQZ4RIUkMsQP80a0QIC3B/45fhkvrjgFbcj3QIkqQNxpYNF9QEqCcZ28k38B+5Ya91w3j4iIiIhukeetPpCIClavbIjqrjlywXYs2XkOFcP88dSwH4HPuwHRe4H5PYHkq8C1CzceFFwW6DkDqHu3I6tORERERC6IGTyiQta5djim3VNf3X5n7VH8fMYHeHAJ4OEDxBywDO5EQpRxMpaDvzimwkRERETkshjgERWBYa0rYXTHqur2c0v2YltKBcAnMI/SmnG3ahK7axIRERHRTWGAR1REJvWsjV71I5CWacBnX39tnGwlTxqQcB44vakIa0hEREREro4BHlER0et1eG9gYzSuEAr/1Eu2PSiRM20SERERke0Y4BEVIV8vD3z+UHNoQWVse0CgjeWIiIiIiBjgERW9UoE+ePrh4YjSwmDIGm6Xk6YBad6hQKW2RV09IiIiInJhDPCIHKBKeAje8XhE3c4Z5Elwp9MB3mlxMKx+EchMd0wliYiIiMjlMMAjcoBtJ69gaXJTjEkfh2iEWZyLQhhWZTZXt/VbPwG+7AMk5FhKgYiIiIjICi50TuQAsddS1H61oSXWpjZHS/1hhCMOsQjFNkNtGKBHt8wd+Nh/LrzObgU+7QgM+AKoeoejq05ERERETowZPCIHCA/yzb4twdwWQ138Ymir9nJfrDU0x/4+PwNl6gNJF4Gv+gF/vQsYDA6sORERERE5MwZ4RA7QskoYIkN8ocunTOkgHzRs1BQYuRZoNATQDMC6acDiB4HrcUVYWyIiIiJyFQzwiBzAQ6/D1Lvqqtt5BXnXrqdj49GLgLc/0O9j4K7ZgIc3cGQF8FknIGpvkdaZiIiIiJyfSwR4p06dwsiRI1GlShX4+fmhWrVqmDp1KtLS0izK7d27Fx06dICvry8qVKiAmTNn5nquJUuWoHbt2qpMgwYNsGLFCovzmqZhypQpiIyMVNfq2rUrjh07ZlHmypUrePDBBxEcHIzQ0FBVt8TExJuuCxVvPetH4pOhTRERcqO7pigT7INqpQOQkmHAIwu2Y86fJ6Am2mw2AnhkNRBSEbh6EviiG/DvIkdVn4iIiIickEsEeIcPH4bBYMCnn36KAwcO4L333sOcOXPwwgsvZJdJSEhA9+7dUalSJezcuRNvvfUWXnnlFXz22WfZZTZt2oTBgwergOzff/9Fv3791LZ///7sMhKIvf/+++r5t27dioCAAPTo0QMpKcZJMYQEd1KPtWvXYvny5di4cSNGjx59U3UhMgV5fz9/J74d1RqzBzVW+02TumDl0x0xuGVFtWTCmysP45nFu5GSngmUawo89idQvRuQkQL8/ATwy/+A9Bvtk4iIiIiKMc1FzZw5U6tSpUr2/Y8//lgrUaKElpqamn3s+eef12rVqpV9/4EHHtD69Olj8TytWrXSHnvsMXXbYDBoERER2ltvvZV9Pi4uTvPx8dG+/fZbdf/gwYOSTNG2b9+eXWblypWaTqfTzp8/b3NdbBEfH6+uJXuTtLQ0bdmyZWpP7k3a48JNJ7Vqk3/TKj2/XLvrg7+0C3HJxpOZmZq2YYamTQ3RtKnBmjang6ZdOXlTz8+2RPbCtkT2wrZE9sK2RO7YjqzFBta47DIJ8fHxCAu7sX7Y5s2b0bFjR3h7e2cfk8zbjBkzcPXqVZQoUUKVGT9+vMXzSJlly5ap2ydPnkR0dLTqlmkSEhKCVq1aqccOGjRI7aVbZvPmxnXKhJTX6/Uq49e/f3+b6mJNamqq2swzgSI9PV1tptvme3Jvg5qXQ5WSfnjquz3Yey4ed3/wNz4a3BhNKoYCbZ+BLqIxPJY9Bl3UHmif3oHMez6BJtk9G7Atkb2wLZG9sC2RvbAtkTu2I1vr4ZIB3vHjx/HBBx/g7bffzj4mgZmM0TNXpkyZ7HMSVMnedMy8jBw3lTN/XF5lwsPDLc57enqqYNO8TEF1sWb69OmYNm1aruNr1qyBv7+/xTHpHkrFx1O1gLlHPBCVmIbBn2/FA1UNaB2uRubBr+pLaHHyQ5RI/g+eiwfjSMQ9OBzRH9DZ1gObbYnshW2J7IVtieyFbYncqR0lJyc7f4A3adIkldXKz6FDh9SkKCbnz59Hz549cf/992PUqFFwJ5MnT7bIMEoGTyZokfF8MqGLKXKXRtatWzd4eXk5sLZU1O5NzcDEH/djzcFYfHvCA97hFTGpR014euiBjIHI/P1leOych1rRP6OGXzwy+30K+JfM8/nYlshe2JbIXtiWyF7Ylsgd25Gpd59TB3gTJkzAiBEj8i1TtWrV7NsXLlxA586d0bZt21wTlkRERCAmJsbimOm+nMuvjPl50zGZRdO8TOPGjbPLxMbGWjxHRkaGmlmzoOuYX8MaHx8fteUkDSpno7J2jNxbqJcX5gxtjvfXH8Os349hweYzOHExGR8OaYJQ/0DgrveAiq2BX5+G/uQG6L/oAjywACh/ozuxNWxLZC9sS2QvbEtkL2xL5E7tyNY6OHQWzdKlS6vsXH6baRybZO46deqEZs2aYf78+WrMm7k2bdqo2SzN+6ZKxF2rVq3sLpFSZt26dRaPkzJyXEi3SgnAzMtIpCxj60xlZB8XF6dmxzRZv369muVTxurZWheiW6HX6zCua03MGdoU/t4e+Pv4Jdzz0T84GnPNWKDRQGDUOiCsGpBwDpjXE9g2V2ZTcnTViYiIiKgIuMQyCabgrmLFimrc3cWLF9VYNtOYNzFkyBAVDMoSCLKEweLFizF79myLLo9PP/00Vq1ahXfeeUctvSBLF+zYsQNjx45V53U6HcaNG4fXX38dv/zyC/bt24fhw4ejbNmyajkFUadOHdVFVLqHbtu2Df/88496vEzAIuVsrQvR7S6v8MOYtihfwg+nLyej/0f/YO3BrKxxmXrA6A1AnbsAQzqw4lngx9FAWpKjq01EREREhcwlAjzJfsnEKpJZK1++vOo+adrMZ7uUyUhkJkzJ8kn3T1mw3Hx9Ouna+c0336junY0aNcLSpUvVDJr169fPLjNx4kQ89dRT6nEtWrRQC5hLUCgLlpssWrRIZRe7dOmC3r17o3379hZdRm2pC9HtqhMZjF/GtkfrqmFISsvE6K924MP1x2TpE8A3GHjgK6D764DOA9j3PTC3C3DpuPHBhkzoTv+Nclc2q73cJyIiIiLXp5O1EhxdCbJOuodKsChLQphPsrJixQoVWDpDX2ByvPRMA1799SC+2nJa3e/TMBJv3dcQ/t5ZQ2xP/QMsfRhIjAG8g4DmI4D9PwAJF248SXBZoOcMoO7dDnoV5Mr4uUT2wrZE9sK2RO7YjqzFBi6bwSOivHl56PFav/p4o38DeOp1+G1vFO77ZDPOx103FqjcDnhsI1CxLZB2Ddj0gWVwJxKigO+HAwd/cchrICIiIiL7YIBH5CaGtKqIb0a1RskAbxyMSlCLom87ecV4MigCGPYT4B2Yx6OzEvmrJrG7JhEREZELY4BH5EZaVgnDz2PboW5kMC4npeHBz7fg221njCfPbQfSEvN5tAYknAdObyqq6hIRERGRnTHAI3Iz5Uv4Y+mYNujTIBLpmRom/7gPU37ejwzphmkLGatHRERERC6JAR6RG5IJVmQB9Ge711T3F24+jTc2ZnXXLEhgmcKtHBEREREVGgZ4RG5K1nUce2cNzB3eHAHeHvjyfDnEoiQ06PIehedfEqjUtqirSkRERER2wgCPyM11q1sGPz3ZDhVKBuLltGFqnTxDjsVRZLEUCfsMyXHA4eWOqioRERER3SYGeETFQM0yQfhxTFv8oWuNMenjEI0wi/NRCMP2zJrQIxPakhHA7m8cVlciIiIiunVZKyETkbs7GpOItEwDVqMl1qY2R0v9YYQjDrEIxTZDbVVmuvY5BnpuAJaNAdKSgJajHF1tIiIiIroJDPCIionYaynZtw3QY4uhbq4ykzIeRfOa5VHtv6+BFc8ag7z244q4pkRERER0q9hFk6iYCA/yLbCMBj1i204DOkwwHvh9KrD+deMgPSIiIiJyegzwiIrRIuiRIb55zKFpFBHsi5ZVSwJdpgBdphoPbnwLWP0CgzwiIiIiF8AAj6iY8NDrMPUuY7fMvIK8ED9PpGUYjHc6jAd6vWW8veVj4Nf/AYbMIqotEREREd0KBnhExUjP+pH4ZGhTRIRYdtcsGeANH089jsQk4pEvtyM5LcN4otVo4J6PAJ0e2LUQ+HE0kJnumMoTERERUYE4yQpRMQzyutWNwObjsVjz11Z079AKbaqHY/fZq3ho3nZs/u+yCvLmjWgBf29PoMlQwDsA+OFRYP9SID0ZuG8+4FXwmD4iIiIiKlrM4BEV0+6araqEoVkpTe3lfrNKYVjwSEsE+nhiy39X8PB8s0xevf7AoG8ADx/gyArg24HGGTaJiIiIyKkwwCOibM0qlcDCkS0R5OOJrSevYMT87UhKzQryavYAhi4FvAKA/zYAX90LpMQ7uspEREREZIYBHhFZaFrxRpC3TQV525BoCvKqdASGLwN8QoCzW4AFdwFJlx1dZSIiIiLKwgCPiHJpUrEEvnq0FYJ8PbH91FWMmGcW5FVoCYxYDviXAqL2AF/2Bq5FO7rKRERERMQAj4jy0rhCKL4eaQzydpyWCVi24VpK1gyakQ2Bh1cCQZHAxcPAvJ5A3BlHV5mIiIio2GOAR0R5alQhFIsebYVgX0/szBnkla5pDPJCKwFXTxqDvEvHHV1lIiIiomKNAR4R5atheQnyWiPEzwu7zsRh+LxtSDAFeWFVgEdWAaVqAgnngfm9gOj9jq4yERERUbHFAI+ICtSgfIjK5EmQ968EeV+YBXnBZYERK4CIBkBSLPBlH+DcTkdXmYiIiKhYYoBHRDapX84Y5IX6e2H32TgM+2Ib4q9nBXmBpYGHfgXKtwBS4oCFdwOn/nZ0lYmIiIiKHQZ4RHRLQd6es5LJ23ojyPMrAQz7CajcAUhLBL4eABz73dFVBgyZwMm/gH1LjXu5T0REROSmGOAR0U2pVzYE3zzaGiUkyDsXj2ES5CVnBXk+QcCDS4AaPYCMFODbQcDBXxxXWbn2rPrAgr7ADyONe7nvyDoRERERFSIGeER00+qWDcY3o1ojLMAbe8/FY6h5kOflBwz8GqjbDzCkA0tGAHu+K/psmgRx3w8HEi5YHk+IMh5nkEdERERuiAEeEd2SOpES5LVSQd6+8/F48IstiEtOM5709AYGfAE0fhDQMoGfHgN+ebrosmkSOK56HoBm5WTWsVWT2F2TiIiI3A4DPCK6ZbUjgvHtqNYoGeCN/ecTMGTuVlxNygryPDyBuz8EWo423t/1pX2zaZnpQPIV4Opp49IMZ7YAx9YC+38Efn8l97UsaMZlHU5vuvnrEhERETkxT0dXgIhcW62IIHw7ujWGzN2Cg1EJePDzrWoilhIB3oBeD/SYDuz+xjjxSl7ZtF+fBpIvA+nJQOq1G5s8JjUx67bpeNb9zNTbr7xct2JroGR1oFQNoGQN49p+nj6397ySGZTgMTEGCCwDVGoL6D1uv75EREREBWCAR0S3rWaZIJXJGzx3qwryhmQFedJ9E2c25xHcmbl+BVg+7tYu7ulrnNzFO9C4ly0zDTi3veDHXjlh3Mzp9EBoJWPAJwu4mwd/geGATpf/c0o2UrqHmmcQZa3AnjOAunff2mskIiIishEDPCKyixplgvDd6FYY9NlWHJIgb+4W40QsksWyRURDY0ClgjQJ1oLNgrasvXdQjvuBgIeX9QyajO+TLqBWx+HpgIDSQM/pwJX/gEtHgUvHgMvHjcHo1ZPG7dgay4dJnUwBnynok31YNcDL98bELjmvaeqK+sBCBnlERERUqBjgEZHdVA+XIE8yeVtwOPqaCvIWdw9DiC0P7vEGUKWDfSoi3SElY6aCLV2OgCsrA9fnndzBlqYB16KBy8duBHxqfwyIOwOkJgAXdhk3CzogpDyQGJvPxC4648QutfuwuyYREREVGgZ4RGRX1cMDjUHeZ8Ygb9AqfywPLAuPxHyyadKFUcap2ZMEbw8shLbqeejMuktqwWWh6/mm9UyadL8MjjRuVTpanktPMWb1zLN9puAvJR6IP1tAhcwmdrFXIEtERESUAwM8IrK7aqWzgry5W3AoNhmvhw3HFMxQwZzOLMjT1H0AEnAVQlZrlaEFXkuZjQppexCOOMQiFGdTGuFlQwP0vNknky6Y4XWMW86sX9IlYPtc4E95jQWwtcsqERER0S3gMglEVCiqqiCvDSKCfTH/SkNM9nwOsQizKBODMPzbZnahjEtbtT8KY77ehfMJ6dhiqItfDG3V/kJCujou5+1Csn6BpYHKNmblZFZNIiIiouIe4N19992oWLEifH19ERkZiWHDhuHCBct1rvbu3YsOHTqoMhUqVMDMmTNzPc+SJUtQu3ZtVaZBgwZYsWKFxXlN0zBlyhR1DT8/P3Tt2hXHjh2zKHPlyhU8+OCDCA4ORmhoKEaOHInExMSbrguRu6tSKkBl8kL9vfBdYmO0SZmNQWkv4X9pY9W+Xcps3PtHKfsFW1kyDRqm/Xowv2XO1XkpZzfSxVS6mprG+OUi3T/L2b8rKhEREZErdtHs3LkzXnjhBRV4nT9/Hs8++yzuu+8+bNpkXKg4ISEB3bt3VwHZnDlzsG/fPjzyyCMqABs92rjQspQdPHgwpk+fjr59++Kbb75Bv379sGvXLtSvX1+VkUDs/fffx4IFC1ClShW8/PLL6NGjBw4ePKiCNSHBXVRUFNauXYv09HQ8/PDD6hryfLbWhai4qBDmDy9ZD08mt4ReZdFyenbJHvx7Nk5FXwZNg8RdEnzJDy6ZWffVbYPxtkHt5ZyxfM5zl5NSERWfkmedJKyT89tOXkGbaiWLYGKXLIXUFZWIiIjI5QK8Z555Jvt2pUqVMGnSJBWcSYDl5eWFRYsWIS0tDfPmzYO3tzfq1auH3bt34913380OqmbPno2ePXviueeeU/dfe+01FaR9+OGHKhCTL4mzZs3CSy+9hHvuuUeVWbhwIcqUKYNly5Zh0KBBOHToEFatWoXt27ejefPmqswHH3yA3r174+2330bZsmVtqgtRcSFB1MXE/BclT0zNxKd//oeiNmPVIXSrG4H65UJQv2wwSgb62GVil1zr4Ok8gPvnc4kEIiIiKnQuE+Dl7CIpQVTbtm1VcCc2b96Mjh07qoDKRDJvM2bMwNWrV1GiRAlVZvz48RbPJWUkeBMnT55EdHS0yryZhISEoFWrVuqxEuDJXjJxpuBOSHm9Xo+tW7eif//+NtXFmtTUVLWZSCZQSBArm+m2+Z7oVhVVW4qKS7Kp3B01SqF6eAD0Ol3WBuj1WfusYx56nRryZn7bw6Ks8fbJS8mY+/epAq+5+2y82kwign1UoFe3bDDqyRYZhPAgH+gKWtzcXI1eyKzSDcd2rEXqpVNosu81eBjSkBEQCc1N/93yc4nshW2J7IVtidyxHdlaD5cK8J5//nmVbUtOTkbr1q2xfPny7HMSmEmXSnOSeTOdk6BK9qZj5mXkuKmc+ePyKhMeHm5x3tPTE2FhYRZlCqqLNdJ1dNq0abmOr1mzBv7+/hbHJPNIZA+F3Zb+i5fgqOBuiQ28YlDDTmPi6mpAqLcH4tLknrXgTEOgJ3BnWQPOJenUdjEFiE5IRXTCRfx++GJ2ySAvDeUDNFQIgHEfqKGEt3FuFWv2XNbhx1N6xKXJa66GD72aoq/HFmxdOguXqg+EO+PnEtkL2xLZC9sSuVM7khjI6QM86WYpWa38SJdImRRFSNdKmdDk9OnTKhAaPny4CvJu6td1JzZ58mSLDKNk8GSCFhnPJxO6mCJ3aWTdunXLzl4S3YqiaksyNm7pOxsRk5Ca1yp4iAjxwdiBHVVWzl68Ksfgqe/2qNu5lznX4c37GqFHvRs/5iSmZuBQ1DUciErAwQsJOHDhGo5fTMS1dB0Oxcl24zlC/bxQt2wQ6kVmZfrKBqFiCX+sPRSL+Zv3WFzvt8xWKsCrEL8NVyvOQI/6EXA3/Fwie2FbInthWyJ3bEem3n1OHeBNmDABI0aMyLdM1apVs2+XKlVKbTVr1kSdOnVU8LNlyxa0adMGERERiImxXF/KdF/OmfbWypifNx2TyVzMyzRu3Di7TGxsrMVzZGRkqG6jBV3H/BrW+Pj4qC0naVA5G5W1Y0S3orDbkjzzK3fXU0sT5Jx6xBTOTb2rHnx9bnRptoe+jcvD09NDzZZpPuFKRIgvpt5VFz3r3/g3Lkp4eaFtDT+0rXEjQ389LROHohNw4Hw89p9PwP4L8Tgacw1x19Ox6cQVtZkEeHsgPdOQK4j9w9AYyZoPKuovYsqKlejVaJRdA1lnws8lshe2JbIXtiVyp3Zkax1uK8CTiURk3Fq1atVUN8WbVbp0abXdCoPBoPamMWsS5L344ovZk64Iibhr1aqV3SVSyqxbtw7jxo3Lfh4pI8eFdKuUAEzKmAI6iZRlbN2YMWOynyMuLg47d+5Es2bN1LH169er+shYPVvrQlScSDD1ydCmNgdb9ryuTKIiE73EXktBeJAvWlYJsznA8vP2QNOKJdRmkpqRiaPRiSrY2y+B34UEHIpKQFJaptXnSIEP1hsao6/HVrS+vhHbTg6w38ydRERERPYI8KT/51NPPaWWEhBHjx5VmTY5Vq5cOdX10p4kwJJZK9u3b68CpBMnTqjlCySwNAVnQ4YMUd02pQunjNXbv3+/mjXzvffey36ep59+GnfccQfeeecd9OnTB9999x127NiBzz77TJ2Xrp4S/L3++uuoUaNG9jIJMjOmzNgpJHMoM3GOGjVKzbwpQdzYsWPVBCxSzta6EBU3txts3Sp5fnsGVD6eHmhQPkRtJpK5+/yv/zBj1RGrj1mhumluRW/9FvybcN1udSEiIiKyy0LnMlZsz5492LBhQ/bacKbZJBcvXgx7kwlGfvzxR3Tp0kVlwSRwatiwIf7888/sLo0y26VMRiIZRcmsSfdPWbDcfFkCmXVT1qqTgK5Ro0ZYunSpmkHTtAaemDhxogpU5XEtWrRQC5jLsgjmr1Nm8JRxgVIfWR5BAk9TkGhrXYiKI1OwdU/jcmrvLl0VvTz0aFwh7+y8dNO8rnmrbppV0o8Xad2IiIioeLmlDJ4ERRLIyUyW5hOcyHpvkl2ztwYNGqhukAWRoO+vv/7Kt8z999+vtrzI63n11VfVlheZMdO0qPnt1IWI3IdkIyNDfBEdn5JrHN51+GK9oQn6eGxF/bg/AHRyUC2JiIjI3d1SBu/ixYu5lgoQSUlJbjOjJRHRzZBspIwnFLo8umkK/aFlgGaf5SCIiIiI7BLgySLfv/32W/Z9U1D3+eefZ4+JIyIqrpPJyOQx5jz1OvR7YATg6QdcPQVEGZdvICIiInKKLppvvPEGevXqhYMHD6olAmQCEbm9adMmNS6OiKi4Mp9M5uSlRLy0bD8yDBpqVYgEanYHDv4MHFwGlDXO1EtERETk8AyeTCoik6xIcCfj42RCEemyuXnz5uylA4iIivtkMkNaVcqewXPl/iigrnE2Xhz4id00iYiIyDkCPFkW4JFHHlHdMufOnYtt27ap7N3XX3+tgj0iIrqhV9Yafyv2RwM1e7CbJhERETlXgCcLd//www+FUxsiIjfTo14EZJjynrNxOJekM3bTFNJNk4iIiMgZumjKot+yVAIREeWvdJAPWlYOU7dXSRYvu5smZ9MkIiIiJ5lkpUaNGmqduH/++UeNuQsICLA4/7///c9e9SMicnm9G0Ri68krWLk/Go+ONHXTPAlE7wUiGzm6ekRERFTcA7wvvvgCoaGh2Llzp9rMydg8BnhERDf0rB+Bqb8cwM7TVxF93QMRNboBh34xZvEY4BEREZGjA7yTJ0/asw5ERG6tTLAvmlcqgR2nr2LV/iiMqNcvK8D7CegyRX4Zc3QViYiIqDiPwTOnaZraiIgob70amM2mWUO6afre6KZJRERE5OgAb+HChWpZBD8/P7U1bNgQX331lb3qRUTkdt00xfZTVxCb5glIN00h3TSJiIiIHBngvfvuuxgzZgx69+6N77//Xm09e/bE448/jvfee89edSMichvlQv3QuEKomjhz9YEYoF7/G8slsBcEEREROXIM3gcffIBPPvkEw4cPzz529913o169enjllVfwzDPP2Kt+RERuo3eDCOw+G4eV+6IwbHhWN80r/wHR+4DIho6uHhERERXXDF5UVBTatm2b67gck3NERJRbr/rGcXhb/ruMy+leN7ppctFzIiIicmSAV716ddUtM6fFixerNfKIiCi3CmH+qF8uGAYNWHMwxmzR85/YTZOIiIgc10Vz2rRpGDhwIDZu3Ih27dqpY7Lo+bp166wGfkREdCOLt/98Albsi8LgoT3ZTZOIiIgcn8EbMGAAtm7dilKlSmHZsmVqk9vbtm1D//5ZEwcQEVEuvbJm09x04jKuZngD1bsaT7CbJhERETkqgyeaNWuGr7/+2h51ICIqNqqWDkTtiCAcjr6GtYdi8IDMpnl4uXG5hDtf5qLnREREVPQZvBUrVmD16tW5jsuxlStX3l6NiIjcXO+sRc9lNk3UNM2meQKI2e/oqhEREVFxDPAmTZqEzMzMXMc1TVPniIgo/+USxN/HLyHe4HujmyYXPSciIiJHBHjHjh1D3bp1cx2vXbs2jh8/frt1IiJya9XDg1AjPBDpmRrWHeKi50REROTgAC8kJAT//fdfruMS3AUEBNijXkREbq2XqZvm/mhjN00PH+DycXbTJCIioqIP8O655x6MGzcOJ06csAjuJkyYgLvvvvv2akREVIy6af559CIS4Xdj0XN20yQiIqKiDvBmzpypMnXSJbNKlSpqk9slS5bE22+/fTv1ISIqFmqVCULVUgFIyzBg/eHYG4ues5smERERFfUyCdJFc9OmTVi7di327NkDPz8/NGrUCB06dLiduhARFRs6nQ69GkTgoz9OqNk0776/p1k3zQNARH1HV5GIiIjcPYO3efNmLF++PPvLSffu3REeHq6ydrL4+ejRo5GamlpYdSUiciu96hvH4f1xJBbJOrNumlz0nIiIiIoiwHv11Vdx4MCB7Pv79u3DqFGj0K1bN7U8wq+//orp06ffal2IiIqVemWDUTHMHynpBmw4cvFGN00Zh8dumkRERFTYAd7u3bvRpUuX7PvfffcdWrZsiblz52L8+PF4//338f33399KPYiIim03TbFCFj2vZeqmeczYTZOIiIioMAO8q1evokyZMtn3//zzT/Tq1Sv7fosWLXD27NmbrQMRUbHVO6ubpky0kqL3v7HoObtpEhERUWEHeBLcnTx5Ut1OS0vDrl270Lp16+zz165dg5eX163Ug4ioWGpYPgTlQv2QnJaplkxAPXbTJCIioiIK8Hr37q3G2v3111+YPHky/P39LWbO3Lt3L6pVq3Yb1SEiKobdNOsbu2nKbJqoadZNM/ago6tHRERE7hzgvfbaa/D09MQdd9yhxt3J5u3tnX1+3rx5amZNIiKyXa8Gxm6avx+KRapnwI1umlz0nIiIiApzHbxSpUph48aNiI+PR2BgIDw8PCzOL1myRB0nIiLbNakQiohgX0QnpODvY5fQRbppHvnNOA6v8wuS5nN0FYmIiMgdM3jmC53nDO5EWFiYRUaPiIgKptfr0DOrm+aKfdE3umleOspumkRERFT4AR4REdmXaRze2oPRSPMMBKpnLUnDbppERER0ExjgERE5geaVw1Aq0AcJKRnYdOLSjUXPpZsmZ9MkIiIidw3wUlNT0bhxYzXznCy8bk5m8ZRZPX19fVGhQgXMnDkz1+NlnGDt2rVVmQYNGmDFihUW5zVNw5QpUxAZGQk/Pz907doVx44dsyhz5coVPPjggwgODkZoaChGjhyJxMTEm64LEZGJh+qmaVxndKV001SLnntnddM85OjqERERkYtwuQBv4sSJKFu2bK7jCQkJagbPSpUqYefOnXjrrbfwyiuv4LPPPssus2nTJgwePFgFZP/++y/69euntv3792eXkUDs/fffx5w5c7B161YEBASgR48eSElJyS4jwd2BAwewdu1aLF++XE08M3r06JuqCxFRXouerz4YjXSvIKBaVjdNLnpOREREhTGLpqOtXLkSa9aswQ8//KBum1u0aJFafF2WapCJXurVq6cyfO+++2528DV79mz07NkTzz33XPayDxKkffjhhyqgk+zdrFmz8NJLL+Gee+5RZRYuXKgWeF+2bBkGDRqEQ4cOYdWqVdi+fTuaN2+uynzwwQdqjcC3335bBZ+21CWv7KRs5oGiSE9PV5vptvme6FaxLTmfJuWDUMLfC1eT0/HPsVi0r30XPI+uhHbgJ2S0N35uOSO2JbIXtiWyF7Ylcsd2ZGs9XCbAi4mJwahRo1SgJQus57R582Z07NjRYhZPybzNmDEDV69eRYkSJVSZ8ePHWzxOyshzipMnTyI6Olp1yzSfMbRVq1bqsRLgyV66ZZqCOyHl9Xq9yvj179/fprpYM336dEybNi3XcQlqc75mCUyJ7IFtybnUDtRjc7Ien63cjqRKevTUecLj0lH89cNnuOZXHs6MbYnshW2J7IVtidypHSUnJ7tPgCeZtREjRuDxxx9XgdWpU6dylZHArEqVKhbHJPNmOidBlexNx8zLyHFTOfPH5VUmPDzc4rws/i5LRJiXKagu1kyePNkiAJUMnozfk+6eMt7PFLlLI+vWrRu8vLzyfd+I8sO25JyCjl/C5gW7cCTRF1369IDu+k/AsdW4o9QVGO7IuweAI7Etkb2wLZG9sC2RO7YjU+8+pw7wJk2apLJa+ZEukZLBunbtmgqA3JmPj4/acpIGlbNRWTtGdCvYlpxLh5plEOLnhctJadh9/hpa179XBXgeh3+FR9eX4czYlshe2JbIXtiWyJ3aka11cGiAN2HCBJWZy0/VqlWxfv161e0xZ/Aj2TyZ8GTBggWIiIhQ3TjNme7LOdPeWhnz86ZjMoumeRmZudNUJjY21uI5MjIy1MyaBV3H/BpERNZ4eejRvW4ZLNl5Div3RaF1j15Zs2keMc6mGV7H0VUkIiIiJ+bQWTRLly6tlizIb5NxbDKr5Z49e9REJbKZljZYvHgx/u///k/dbtOmjZrN0nzwoaRUa9Wqld0lUsqsW7fOog5SRo4L6VYpAZh5GUmFytg6UxnZx8XFqdkxTSQANRgMaqyerXUhIspL7wbGH5hW7o+GwTsYqHan8QQXPSciIiJ3WCahYsWKqF+/fvZWs2ZNdbxatWooX9446cCQIUNUMChLIMgSBhL8yayZ5mPann76aTUD5jvvvIPDhw+rpQt27NiBsWPHqvOytt64cePw+uuv45dffsG+ffswfPhwNTOmLKcg6tSpo2bilAlftm3bhn/++Uc9XiZgMS3fYEtdiIjy0rZ6SQT5eiL2Wip2nbkK1OtvPMHlEoiIiMgdAjxbyGyXMlZPZsJs1qyZ6v4pC5abL0vQtm1bfPPNN2o9ukaNGmHp0qVqBk0JGs3X2XvqqafU41q0aKEWMJegUBYsN5FlECS72KVLF7U8Qvv27S3WuLOlLkREefHx9EC3OsaJmVaoRc+zumlePMxFz4mIiMj1Z9HMqXLlympmzZwaNmyIv/76K9/H3n///WrLi2TxXn31VbXlRWbMlEAxP7bUhYgoL70aROLHf89j5f4ovNSnDvTSTfPoKmM3TY7DIyIiInfP4BERuZMONUohwNsDUfEp2HMuDqhr7CbObppERESUHwZ4REROyNfLA12yumnKZCuqm6beK6ub5mFHV4+IiIicFAM8IiIn1buBcVmVFfuioPmG3JhNk1k8IiIiygMDPCIiJ3VHzXD4eXng3NXr2H8+AaiX1U2TyyUQERFRHhjgERE5KT9vD3SuXVrdXrE/CqjVO6ub5iF20yQiIiKrGOARETmxXvWzFj1nN00iIiKyAQM8IiIn1rl2OHw89Th1ORmHoq6xmyYRERHliwEeEZETC/TxxB01jd00V+bspnnxiKOrR0RERE6GAR4RkZPr3cDYTfO37G6anY0nmMUjIiKiHBjgERE5uTvrhMPbQ4//LibhWGwiFz0nIiKiPDHAIyJycsG+XuhQo1T2mniondVNM/YgcPGoo6tHREREToQBHhGRC+iV1U1z5b5owK/EjW6azOIRERGRGQZ4REQuoFudMvDU63Ak5hpOXDTrpnngJ0dXjYiIiJwIAzwiIhcQ4u+FdtWN3TRX7Y9mN00iIiKyigEeEZGL6N0g4sY4POmmWbWT8QS7aRIREVEWBnhERC6iW90IeOh1OHAhAacvJ3HRcyIiIsqFAR4RkYsIC/BGm6ol1e2V0k1TLXruCcQeAC4dc3T1iIiIyAkwwCMiciG9srpprpRumv5hQFUuek5EREQ3MMAjInIh3etGQK8D9pyLx7mryWbdNDmbJhERETHAIyJyKaWDfNCyStiN2TTZTZOIiIjMMMAjInIxvbMWPV+R3U0zazZNdtMkIiIq9hjgERG5mB71IqDTAbvOxCEq/vqNRc8dsVyCIRO603+j3JXNai/3iYiIyHEY4BERuZgywb5oXqmE2aLnfYzdNGP2A7u/A/YtBU7+VfjB1sFfgFn14fl1PzQ//Ynay311nIiIiByCAR4RkQvqWd/YTXPlvmhjN83SdYwnlj0G/DASWNC3cIMted7vhwMJFyyPJ0QZjzPIIyIicggGeERELqhnfeNyCdtPX0H8zh+AmH25C9kj2NI0IP06kBgLXD4BXPgXOPEH8OvTctLaA4y7VZPYXZOIiMgBPB1xUSIiuj3lQv3QuEIo9p69As81k/MoJcGWDljxLBAUAaQlAanXcmwJeRwzO27IuMnaaUDCeeD0JqBKBzu8WiIiIrIVAzwiIhfVu0EEfM9vQkBqTD6lNCAxBvii2+1f0DsI8AkyPue1qILLy3WJiIioSDHAIyJyUb3qR2L/qjjbCvuFGbN4EqBZbMF53M9x3DsQ0Gf16pcJXGSMX0ECy9zeCyQiIqKbxgCPiMhFVQjzR0CpckCCDYUfWGi/7pKV2gLBZY1j/KyOw8tybhtQuT3Umg5ERERUJDjJChGRC6vYpAsuaGEw5FlCBwSXMwZl9qL3AHrOuPH8Oa9nsu5VYPFQICXeftcmIiKifDHAIyJyYT0blMe09OEqkablFWz1fNMYlNlT3buNWcFg43IN2SSzJ8f7zgI8vIHDy4HPOgMxB+x7fSIiIrKKXTSJiFxYlVIBOFOmK8bEAO8Ffwv/lBjLYEuCOwnGCoM8b+0+yPhvI3b/tRqNO/SAZ9WON4LJyIbA9w8BV04An3cF7poNNHygcOpCRERECgM8IiIX17t+BN6Jaomx4T0xr3OGcfZKmeBEumXaO3OXk94DWqX2OH8gAY0qtbe8XrlmwOg/gR8fBU6sB34cBZzbDnT/P8DTu3DrRUREVEyxiyYRkYvr1cDYTfKvE1cRH9EaaHCfcUKVwg7uAGQaNGw9eQU7L+nUXu5bCCgJPLgU6Pic8f62z4Av+wDx5wu9bkRERMURM3hERC6uenggapYJxNGYRHz65wnUighCeJAvWlYJg4e+8GawXLU/CtN+PYio+BQAHlh4bAciQ3wx9a666FnfbGyeBJp3vgSUaw78NNo4u+anHYH75gFV7yi0+hERERVHzOAREbmBGuGyADnw8YYTePq73Rg8dwvaz1ivgrDCIM875utdWcHdDdHxKeq41evW6mnsslmmAZB8CfiqH/D3e4CWz1ILRERE5J4BXuXKlaHT6Sy2N99806LM3r170aFDB/j6+qJChQqYOXNmrudZsmQJateurco0aNAAK1assDivaRqmTJmCyMhI+Pn5oWvXrjh27JhFmStXruDBBx9EcHAwQkNDMXLkSCQmJt50XYiI7EGCqd/25Q6o8g22boN0w5TMnbWwzHRMzufqrinCqgCPrgUaDQE0A/D7K1xKgYiIqLh20Xz11VcxatSo7PtBQcZfrEVCQgK6d++uArI5c+Zg3759eOSRR1QANnr0aFVm06ZNGDx4MKZPn46+ffvim2++Qb9+/bBr1y7Ur19flZFA7P3338eCBQtQpUoVvPzyy+jRowcOHjyogjUhwV1UVBTWrl2L9PR0PPzww+oa8ny21oWIyJ7BljWm8GrCkj3YdvKKum8waMjUNGQabty+cUyDIWuvzuc6Zrwdl5yWK3OX87pyXq7ZplrJ3AW8/IB+HwMVWgArn89aSuEQMPAroEw9e701RERExZJLBXgS0EVERFg9t2jRIqSlpWHevHnw9vZGvXr1sHv3brz77rvZQdXs2bPRs2dPPPeccbD/a6+9poK0Dz/8UAVikr2bNWsWXnrpJdxzzz2qzMKFC1GmTBksW7YMgwYNwqFDh7Bq1Sps374dzZs3V2U++OAD9O7dG2+//TbKli1rU12IiOxBgqj8gi2RlJqJef+cQlGLvZZPvXQ6oPkjQGQjYPFwLqVARERUHAM86ZIpQVnFihUxZMgQPPPMM/D0NL6EzZs3o2PHjiqgMpHM24wZM3D16lWUKFFClRk/frzFc0oZCd7EyZMnER0drTJvJiEhIWjVqpV6rAR4spdMnCm4E1Jer9dj69at6N+/v011sSY1NVVtJpIJFJIllM1023xPdKvYltxDVFySTeU61yqFWmWCoNfp4KFH1l6XvTfehsUxU1kPnQ56vQ6eWcdOXEzEe+tOFHjNkv6eBbev8IbAyHXwWPYY9Cc3qKUUMs9shaHrq8aF0qlY4ecS2QvbErljO7K1Hi4T4P3vf/9D06ZNERYWprpaTp48WXWTlKyYkMBMulSak8yb6ZwEVbI3HTMvI8dN5cwfl1eZ8PBwi/MSZEq9zMsUVBdrpOvotGnTch1fs2YN/P39LY5J5pHIHtiWXNt/8TJLZsHLIdTziEGNdONn1K2SrpeZACpqQKi3B+LS5Ki1WTo1+HkAFw9uwYpDNj55yAjULhOMWjG/wGPH54g/tAHbK49FinfYbdWZXBM/l8he2JbIndpRcnKy8wd4kyZNUlmt/EiXSJkUxTzz1rBhQ5Ude+yxx1RQ5OPjA3cgQav565QMnkzQIuP5ZEIXU+Qujaxbt27w8vJyYG3J1bEtuQcZF7f0nY2ISUi1OumJhF8RIT4YO7CjXZdM8Kocg6e+26Nu576uDtczge2Gynipd214SRrQJn2RcWw1PH55AmFJx9H95OvI7D8XWuUOdqs3OTd+LpG9sC2RO7YjU+8+pw7wJkyYgBEjRuRbpmrVqlaPS7fJjIwMnDp1CrVq1VJj82JiYizKmO6bxu3lVcb8vOmYzKJpXqZx48bZZWJjYy2eQ+ohM2sWdB3za1gjgaq1YFUaVM5GZe0Y0a1gW3Jt8pd75e56arZMXY5gyxTOTb2rHnx97NvdsW/j8vD09DBbB89I1sFrVSUMP++5gG+2ncN/l5Lx8YPNEBZg4/Xr9gUi6gGLh0EXsw+e3wwAukwF2j1tHLdX3BgygdObgMQYILAMUKltkSxg72j8XCJ7YVsid2pHttbBocsklC5dWmXn8tvMx7GZk0lLZNybqbtkmzZtsHHjRou+qRJxS/Bn6hIpZdatW2fxPFJGjgvpVikBmHkZiZRlbJ2pjOzj4uKwc+fO7DLr16+HwWBQQaetdSEishdZVPyToU0REWKc6ddE7stxi0XH7Xzdv5+/E18/0hzDa2SqvdyfNagJ5g5rjgBvD2z57wru+ehvHIm+ZvsT51pKYarlUgoS9Jz8C9i31LiX++7o4C/ArPrAgr7ADyONe7kvx4mIiFx5DJ5MWiJBVufOndVMmnJfJlgZOnRodsAkk67I+DVZk+7555/H/v371ayZ7733XvbzPP3007jjjjvwzjvvoE+fPvjuu++wY8cOfPbZZ+q8rK03btw4vP7666hRo0b2MgkyM6YspyDq1KmjZuKU5Rpk5k0J4saOHasmYJFyttaFiMjewVa3uhFqVk2ZvTI8yBctq4TZtVumNfL8krG7fEhTe9P1utYtg5+ebIdHF+zAmSvJuPfjf/DewMboXi/vXgw2LaXQ4lFg8wdAwoUbZYPLAj1nAHXvhttk0ySI+3547g6wCVHG4w8sLPzXS0RELsklAjzptijB2CuvvKJmmZTASwI88/FqMtulTEby5JNPolmzZihVqpRasNx8WYK2bduqtepkGYQXXnhBBXEyg6ZpDTwxceJEJCUlqcdJpq59+/ZqWQTTGnhClkGQoK5Lly4qizhgwAC1dt7N1IWIyN4kuLK67pyD1CwThJ+fbIcnFu3C5v8uY/RXO/Fs95p4snN19YNagawtpbB6cu5yRRH0SMC16vmiCSwlkJRr5bmUvA5YNQmo3adYdNckIqKbo9Nk8TdyStI9VILF+Ph4i0lWVqxYodbdc4a+wOS62JaoqNpSeqYBry8/iAWbT6v7fRtG4q37GsHP+yaCk2uxxu6JmTeWkrGkMwZc4/bZP+jJK5tmGuWYX2BpMABpicYt9RqQKvuE/O9fPQWc3VJwvR5aDlRxrwlo+LlE9sK2RO7YjqzFBi6bwSMiItcls2hOu6c+akUEY8rP+7F8bxROXU7CZ8Oao2yon21PculIPsGd0ICE88A3DwDB5QCdLPbnYdzrsvZ6fY775ud1ZvfNysjxP/4vn2wagJ8eA3Z/C6SbBWmmgE32hUW6ihIREeXAAI+IiIrEkFYVUa10AMYs2oX95xNw94f/4NNhzdCsUgn7BTPHf0eRS08Gjq7Iv4wEjD5BNzbvwKzbWXtv07lA4FoMsOWjgq8r4wCJiIhyYIBHRERFplXVkmpc3qiFO3A4+hoGf7YF/9e/Pu5vXsE+wUzT4UBoRWPXSJmBU8s07mVcm7pvftvKuZzn484A52/MmpynJsOAKneYBWymAC5r8/S1fZkHuf7Bn4xjC/Na3VC6o8okL0RERDkwwCMioiJVIcwfP4xpi/Hf78bqAzF4buleFexN7lUbnnktii7BjAQ1BQU9fWfZdwyeLMMgyxMUpOFA+42Hk/rL5C1q3F/O1Q2z9HyTE6wQEZHzrYNHRETFU4CPJz55sBme7lJD3f/i75N4ZMEOxF+/sX6o1aBHyZkJ0xVe0GMKLHNd0+zaMubP3tk0mbRFJm8JtrKGYbv/cYkEIiLKEwM8IiJyCL1eh2e61cTHDzaFn5cHNh69iP4f/YMTFxNvLuiRAKywlkhwVGAp5PWM22+cLXPAF0CDB4zHT/wBcAJsIiLKA7toEhGRQ/VuEIlKJf0xeuFO/HcpCf0++gcfDG6CTrXCrQc9sv5bUS04brqmBJBW18F7s3CzafK6TF0/q3YGDv8GRO8Fjq0FanYvvOsSEZHLYoBHREQOV69sCH4e2w6Pf7UTO05fxSNfbscLvetgZPsquRdFNw96ioojAsucAkoCLUYCm94HNs4EanSzfeIWIiIqNthFk4iInEKpQB8sGtUKA5tXgEEDXv/tEJ5dshcp6ZlwCqbAssF9xr0jJjlpM9Y4I+e57cB/G4r++kRE5PQY4BERkdPw8fTAmwMa4JW76sJDr8MPu85h8NwtiE1IcXTVnENQGaDZCOPtjW87ujZEROSEGOAREZFTkS6ZI9pVwYKHWyLEzwv/nolTi6LvPRenzmcaNGw+cRk/7z6v9nK/WGn7P8DDGzj9t7HLKBERkRmOwSMiIqfUvkYpLHuyHR5dsB0nLibh/jmbMbR1JazYF4Wo+BsZvcgQX0y9qy561reypIA7CikHNH4Q2Dkf+HMmMHyZo2tEREROhBk8IiJyWlVKBeCnJ9uhc63SSM0wqPXyzIM7ER2fgjFf78Kq/bIIeuFxROYwz2u2fwbQewL//QGc21Ho9SAiItfBDB4RETm1YF8vfDqsOZq8ugZJabknXJGQR+aSnPbrQXSrG6HG7tmbBI/y/EWZOcz/mpWAhoOA3V8DG98ChiwulDoQEZHrYQaPiIic3s7TV60Gd+ZBngRCU37eh2+2nlEZr/WHY7D1v8s4cCEeZy4n43JiKlIzMm8p0JIMYVFmDm26ZofxgE4PHF0FRO2xex2IiMg1MYNHREROL/aabbNoLtp6FoBsefPy0CHQxxMBPp5qrzZfs9tZ54J8PeHn7YG3Vh1RAWROpmMvLduPsABvNTmMdKE0aBo0Ddm31WYAMtVxuZ//ufRMA95enfc1s7OVz98Jj/oDgH1LjDNqDvzKpveIiIjcGwM8IiJyeuFBvjaVa1+9lArKElMykJSWofaJqcYtOSsDmJ6p4Wpyutrs4VJiGh74dAuKiilbue3kFbTp8KwxwDv0CxB7CAivU2T1ICIi58QAj4iInF7LKmFq/Jl0UbSW2ZKsVkSILxY80jLPMXiSNTMFfUmpGbiWatybB4E5jx+PTcT+CwkF1q9UoLcaK6jTQV1fr9OpjJ6HHuq2ccu6rc7nKGd2LibhOvaeS7Atq1mtNlDnbmOAJ1m8+76w6f0kIiL3xQCPiIicngRDMrmIjD+T8M08yDOFc3I+vwlW5JwEYbLZSmaulIXWC/LB4KZoU62kzc9rj2tmZzU7PmcM8A78CHSaDJSqbpd6EBGRa+IkK0RE5BJktspPhjZVmTpzcl+OF8ZslqbMYV5hoxyX81LOYdeMbAjU7AloBuDvd+1WDyIick3M4BERkcuQIE6WQpDxZ9JFUbJYEugUxtII9soc2vOayLqf65odJxpn09zzHXDHRKBEZbvVh4iIXAszeERE5FIksJHukPc0Lqf2hRXcOTJzmNc1jefK5L5m+WZAtTsBLRP4e5bd60NERK6DGTwiIiInyxxau+bpy8l4d+1R/HPsMhJS0nOPJZSxeCfWA7sXGW+HlCu0uhERkfNigEdERHQTmUNHXdNg0PDrngs4FpuIrzafxpOdc0ymUqktUKk9cPpv4J/ZQO+ZRVpXIiJyDuyiSURE5AJkCYUnOldTt+f9fRLXs9b1s3DHc8b9rgXAtZgiriERETkDBnhEREQu4q6GZVEhzA+Xk9KwePuZ3AWq3AGUbwFkpACbP3BEFYmIyMEY4BEREbkITw89Hr/DmMX7bON/SMswWBaQldZlRk2xfR6QdNkBtSQiIkdigEdERORCBjQtj/AgH1yIT8Gy3edzF6jRDYhsBKQnAVs+dkQViYjIgRjgERERuRBfLw+M6lBV3Z6z4QQyDZqVLF7WWLxtnwHX4xxQSyIichQGeERERC5mSKuKCPHzwn+XkrByf1TuArX6AOF1gdQEYOunjqgiERE5CAM8IiIiFxPg44mH21VWtz/64wQ0LUcWT68HOj5rvC3dNFOvOaCWRETkCAzwiIiIXNCItpXh7+2BQ1EJ2HDkYu4CdfsBJWsAKXHA9s8dUUUiInIABnhEREQuKNTfG0NbV1K3P/zjuJUsngfQYYLx9qYPgbQkB9SSiIiKGgM8IiIiF/Vo+yrw9tBj5+mr2HbySu4CDe4HQisByZeAnQscUUUiIipiDPCIiIhcVHiwL+5vXl7d/mjDidwFPDyBDuONt/+ZDaSnFHENiYioqDHAIyIicmGy8LmHXoeNRy9i37n43AUaDQGCywOJ0cDurx1RRSIiKkIuFeD99ttvaNWqFfz8/FCiRAn069fP4vyZM2fQp08f+Pv7Izw8HM899xwyMjIsymzYsAFNmzaFj48Pqlevji+//DLXdT766CNUrlwZvr6+6nrbtm2zOJ+SkoInn3wSJUuWRGBgIAYMGICYmJibrgsREdHtqhDmj3salVW3P95wPHcBT2+g/Tjj7b9nARlpRVxDIiIqSi4T4P3www8YNmwYHn74YezZswf//PMPhgwZkn0+MzNTBVRpaWnYtGkTFixYoIK3KVOmZJc5efKkKtO5c2fs3r0b48aNw6OPPorVq1dnl1m8eDHGjx+PqVOnYteuXWjUqBF69OiB2NjY7DLPPPMMfv31VyxZsgR//vknLly4gHvvvfem6kJERGQvYzpVU/tVB6JxPNbKkghNhgKBZYD4s8De74q+gkREVHQ0F5Cenq6VK1dO+/zzz/Mss2LFCk2v12vR0dHZxz755BMtODhYS01NVfcnTpyo1atXz+JxAwcO1Hr06JF9v2XLltqTTz6ZfT8zM1MrW7asNn36dHU/Li5O8/Ly0pYsWZJd5tChQzJ1mbZ582ab62KL+Ph49byyN0lLS9OWLVum9kS3g22J7IVtyTmMXrhdq/T8cm384t3WC/zzgaZNDda0WY00LSNdc0ZsS2QvbEvkju3IWmxgjSdcgGTSzp8/D71ejyZNmiA6OhqNGzfGW2+9hfr166symzdvRoMGDVCmTJnsx0nmbcyYMThw4IB6nJTp2rWrxXNLGcnkCcm47dy5E5MnT84+L9eUx8hjhZxPT0+3eJ7atWujYsWKqkzr1q1tqos1qampajNJSEhQe7mebKbb5nuiW8W2RPbCtuQcRrevjNUHYrBs93mM7VQF5Uv4WRZoNBSef78L3dWTyNizGFqDB+Bs2JbIXtiWyB3bka31cIkA77///lP7V155Be+++64aH/fOO++gU6dOOHr0KMLCwlTQZx5QCdN9OWfaWysjgdT169dx9epV1b3SWpnDhw9nP4e3tzdCQ0NzlSnoOuZ1sWb69OmYNm1aruNr1qxRY/nMrV27Ns/nIboZbEtkL2xLjlcrRI8j8XpMWfQn7qtqyHW+RsidqJu8BNdXv4b1Z/wBnXOO1GBbInthWyJ3akfJycnOH+BNmjQJM2bMyLfMoUOHYDAY/yf14osvqglNxPz581G+fHk1Du6xxx6DO5DMoYz/M5HAs0KFCujevTuCg4OzI3dpZN26dYOXl5cDa0uujm2J7IVtyXmUrHMFQ+ftwNbLnpjxUAeUDvKxLJDaAdqHaxGUEoU+VTOh1ekLZ8K2RPbCtkTu2I5MvfucOsCbMGECRowYkW+ZqlWrIioqSt2uW7du9nGZBVPOyWyVIiIiItdsl6aZLeWcaZ9ztku5L8GTzMzp4eGhNmtlzJ9DunLGxcVZZPFylimoLtbIa5ItJ2lQORuVtWNEt4JtieyFbcnx2tUIR9OKodh1Jg4Ltp7F5F51LAt4hQGtxwAbpsPzn/eA+vfKWAQ4G7Ylshe2JXKndmRrHRz6qV66dGk1fi2/TbpDNmvWTAU+R44csYioT506hUqVKqn7bdq0wb59+yxmu5SIW4I3U2AoZdatW2dRBykjx4XpWuZlJHso901l5Ly8ueZlpF4SaJrK2FIXIiIie9PpdHiyc3V1++vNpxGfbGW8RqvHAO8gIGY/cHRl0VeSiIgKlfP9bGeFBEaPP/64WrpAxqNJQCUTloj7779f7aUbowRPspSCLKMgSx+89NJLar06U1ZMnkPG802cOFGNqfv444/x/fffq2UPTKSL5Ny5c9XSBtI9VK6TlJSklmcQISEhGDlypCr3xx9/qElX5JwEdTLBiq11ISIiKgx31g5H7YggJKVlYsHmU7kL+JUAWo4y3t74lkynXeR1JCKiYh7gCZkxc9CgQSpoatGiBU6fPo3169erBc+FdK1cvny52kuwNXToUAwfPhyvvvpq9nNUqVJFLZYu2TRZ304mavn888/VDJcmAwcOxNtvv63WrJOZOmW9vFWrVllMmvLee++hb9++ajxgx44dVbfLH3/8Mfu8LXUhIiIqrCzeE1lZvHn/nERSakbuQm2eBLz8gQv/Ascte7YQEZFrc4lZNIV0i5TAS7a8SHfNFStW5Ps8MvPmv//+m2+ZsWPHqi0vvr6++Oijj9R2O3UhIiIqDH0aROLdNUdw6nIyvt12Bo92qGpZIKAU0PwRYPOHwMaZQPUuEhk6qrpERFQcM3hERERkGw+9DmM6VVO35/71H1IzMnMXavsU4OEDnN0KnPqr6CtJRESFggEeERGRG+rfpDwiQ3wRk5CKH3edz10gKAJo9pDx9p8zi7x+RERUOBjgERERuSFvTz1GZXXNnPPnCWRk5l74HO2eBvRexgzemS1FX0kiIrI7BnhERERualDLCggL8Mbpy8n4bZ9xTVkLIeWBxkNuzKhJREQujwEeERGRm/L39sQj7Sqr2x//cQIGg5UlEdo/A+g8gOO/A+d3Fn0liYjIrhjgERERubFhbSoj0McTR2KuYf3h2NwFwqoADR8w3t6Y90zVRORkDJnAyb+AfUuNe7lPxACPiIjIvYX4eWFYm0rq9od/HIdmbWHzDhNkBT3gyAogel/RV5KIbs7BX4BZ9YEFfYEfRhr3cl+Ok30YMqE7/TfKXdms9q4UQDPAIyIicnOPtKsCH089dp+Nw+YTl3MXKFUDqNffeJtZPCLnzqZJEPf9cCDhguXxhCjj8cIO8opD5vCgMYD2/Lofmp/+RO1dKYB2mYXOiYiI6NaUDvLBoBYVsGDzaXy04TjaVi+Vu1DHZ4EDPwIHlwG7vwE8vIHAMkCltoDewxHVJnIN8qV/1fOWAVdwWaDnDKDu3fa9lgRTci1YycSrYzpg1SSgdp/C+XdblK/VUQ5mBdA532NTAP3AQqd/rQzwiIiIioHRd1TDoq1n8M/xy/j3zFU0qVjCskCZekC5ZsaJVpaNcd8vb0TOFAwYDEB6snFLS8ray/2krL358STg4pHcmTsLGpBwHlj1AlCuCeATBPgEG/e+ss/aPL2L/rW6AoODA2g7YYBHRERUDJQL9UP/JuWwZOc5fLzhBOYOb577y5u1WTTd6csbFcOxU8FA1Y6F82U8PQVY8Ww+wQCAH0cDu74CMq5bD+DkeGHYNif/856+eQd/FvezbnsFAMufcfnAp0Cn/7EtgD69CajSAc6KAR4REVEx8Xinali66xzWHozBkehrqBURlONXa7j3lzcqWtKu5ItwYkzRdffN6kLomXAB6ieM05/cfBZaJiJKvgJcuwBcizZ+4Ze93JcfPK5lbUkXC34uCeCOr7HtuhJEefsDXn5mt/0B74CsvT9wPR44/GvBz1WpHeDpA6QkAKnXgNSsfVpiVr1SjJstr8EmWYHPP+8DtXsDoRWNr8NZ21LqNeDyceDSceDysazbx4wZUltIPZwYAzwiIqJiolrpQPSuH6kWPf9kw3HMGtTEeEK+OLnBr9YuEYAUF44Yq2VLF8LqXW8EaObBmnkQJ/vMNPvVq+kIYxYxO2izErxJMKTT2dZmZbIPqbvVbJrO+D4/9Kv1tiyPNwV8OYO/lPgc9xNu3L56Cog/W3D91r1i3ERgBFCiEhBaybgvUfnG7eBytv9bu9W2lJkBxJ2+EbypQO6E8XZiNG6LfF44MQZ4RERExciYTtVUgPfLngsY360WKpb0t/3X6F+eMmYGwmsDpesY9/JFzZYvps7Sra44TRbhKIU9Vsti3FqisetjyjVg+bj8u0taq1N+/EsBwZFAkNmm7pcFgiKAuDPA4gcLfp4G99nvhxH5NyFtVL0WXY7Xk/XvsOebef/bkeN+ocbtZshsmbIUQ0FKVAGSLxsDQwmiZDu71Uo9PIGQClYCwMrG2/4ljZ8rBbalBUDFtpZZuMuSlTsOXDkJGNLzrmtAaaBkDaBUdaCkbDWAsKrAV/2NQX9+AbT8GOTEGOAREREVI/XLhaBTrdLYcOQi5mw8gTf6N7D91+irJ42bORmnU7q2ZdAne/kCbGvgZ49udTejOEwW4ahsZYGTVMA4lktuqnFpiTcmEFHBmvntJOvnZPzaLcm6vmTMVLAmgZoEbBFZtyOMwZsEcfIeSRfH/MjERPK4hCIOBqRtShu1+gPFm4XTduU12PJan9oJ6PTA9avGrJ9k0K6eztqfMt6WTKBkSK19nph4BwIhFYGr/xUQtD+Uf9Du6QeUrGYM4GQ5GFMgJ8fyCnJ73UYA7SQY4BERERUzT3aurgK8pTvO4ekuNVDGli9vgeHGLzaXjgKxB4HYw8CVE8Zf6s9tM27mfEOyAr6sTQWBdYy/mpsHfkUZbEmXrZS4AibGcMPxhoWVrcxMv9G9Ubrwyv7stgK6+wJIvgQsGQa7kEBAujlqBtvGk939AdBkmH2yzrebTbsd8neTNlpUXYxv9rX6hxm3ck2tZ2Cl3eQVAMo5CegvHrShYln1kDF/puCtVFYAJ7dVV1C98wfQdsYAj4iIqJhpUTkMLSuHYdupK/j8r//wYp+6BX956/127i82GWnGrlAXDxkDPgn8Lkrg959xPM/ZLcbNnF/YjaCvVE3gz5kFB1s1exozOebjgyzGDJm2nGOKzMrKZlPmJ2u84eKhxu6o0mUrrIqx+5g9Jo0o6nF/txpAZ6Qav2jHn7cM4Mz3ibE31+XRXFg145dyCc7MNzU+zdoWeGPMmgrq/I3ZGdOX95vpQmiP4M4ZggFpN0U5JtZer1X+ZiHljBvaWW97cWeBf78C/plV8PP1+wRoPASFEUBn/LcRu/9ajcYdesCzsLuN2xEDPCIiomLoic7VsG3+FbU23hOdqqPErXx5k7W0ytQ1bjmnj5cxMRL0qeAva5Nf6K9fMU5FLputwdbrpVHkjqwwbuak+54K+Cob9xIsmAJAyVg627g/W7pL/vo/Y1Y2ZybO1tkV9V7G1xCc9YVdMmn7fyj4cXfNtm9wYmsXwsIYO1XU2TRHKorXKl1jZVycTIhjS4AnY/kKg94DWqX2OH8gAY0qtXepvycDPCIiomLojpqlUa9sMA5cSMD8TacwvltN+3158/IFIhoYN3MyhkqCCcnyScB3Yj0Qvdf25/XwMVujy2wNr+x9UO41vHKWi9oLfN2v4GvVvx/QMozZSJmsQbKCaobFC8Dpv3OXl0khzAM+8wAwoBRw6Ff7dEWVbqZp5lnLxNyZTdN0+PJeF9RdUsZKrX8t77XSTMGb2pvfln054+s27wInQeWZzUUfaDmyu6Tp+u40w6wzvFZHBu0ujgEeERFRMaTT6dRYvCcW7cKX/5zE6I5VEejjWbhf3qRbXdnGxk3IL/S2dKsb+A1Qo2vBk17YQrpZ2fKl8d5PbwQDpnXRZEIIU8Bnfjsp1jhzoGznd+R+Sul2qKbdzyeT9vOTxsfKJCL5BW3SVdXeKrYxdkfNGcDJGKqb7c7o6HFpLj52ipwoaHdhDPCIiIiKqR71IlC1dAD+u5iERVtO47E7qhVtBWz9hb5WT/t9ibuVL40S5ASUNG7l1TyflkzrhJkCPtmrADBr7TBbxv5JMPfP7JvPZlpkKQMtj0nA+e/XBT9X5xftG9Q7MtBy8bFTlAOD9lvCAI+IiKiY8tDr1Pi7Z5fswdy/TuKhtpXh6+Xh/r/Q2/tLowRT1rqkmiaM2PYZsOalgp+nWlfjrIMWgVvOLdg4yYiMfyyIdJeUbrDFbVyaC4+domI+xtFOGOAREREVY/c0Lov31h7F+bjrWLLzHIa1rlQ8fqEvqi+N0q00MqtLakHaj7NvJs3RXdyK07g0KlxsSzflJheGICIiInfi5aHHY3dUVbc//fME0jMNRV8JCbbG7UfG0GXYUWmM2mPcvsLvfmX60tjgPuO+sAIdU1dUU1BlNZNWrvAyaRJAy+Ld5qQ+7rigOxExg0dERFTcPdC8At5fdwznrl7Hr3su4N6m5Yu+Eu7crc7RmTR2cSMqVpjBIyIiKuZk3N3I9sYs3scbTsBguMXFq8l5M2lFla0kIodjBo+IiIgwtHVFfLzhOI7HJuKD9cdRuZQ/woN80bJKmJqMheyAmTQiKgIM8IiIiAhBvl5oX70UVu6Pxnu/H80+Hhnii6l31UXP+jkyT3RrOFkEERUydtEkIiIirNofhVX7o3Mdj45PwZivd6nzRETk/BjgERERFXOZBg3Tfj1odaU00zE5L+WIiMi5McAjIiIq5radvIKo+JQ8z0tYJ+elHBEROTeOwSMiIirmYq/lHdyZe2bxv2hfozQaVQhFkwqhqBURpNbRIyIi58EAj4iIqJiT2TJtEZ2QiqU7z6lN+HjqUa9ssAr4GmdtFcP8odPd/Kyb0v1z68kr2HlJh5Inr6BN9fBCn71TrilZSQlwOWMoEbkLBnhERETFnAQ2MlumTKhibZSdhDzhwT547e762HchHrvPxmHP2TgkpGRg15k4tZmE+nuhUfnQrKAvRN0uGeiT7/VlAhcZ42fsJuqBhcd2FPrsnZbXNOKMoeRKPxbwBwrKCwM8IiKiYk6+FEpgI7NlytdD8yDP9HVx2t310L1+hNqEpmk4eSkJe85JsGcM+g5eSEBccjr+PHpRbSYVwvxUoGfK8tUrGwI/b4/sQEuuq+Uxe+cnQ5vaPeByxDXJfTnixwL+QEH5YYBHRERE6kuhBDY5vzRG5PGlUbphVi0dqLb+TcqrY2kZBhyKSlBBnynLd+JiEs5eua625XujsgPKWmWC0KB8iFqaIa/ZOyW4lPp0qxtht8yEZD1eyWfG0MK4ZnHlqAxTUXb35Q8U5IwY4BEREZEiXwolsLnVL+XennrVNVO24W2Mx+Kvp2P/eWOGz7RdvJaKg1EJasuPafbOvu//hUBfT2QYNBgMGjI1DZkGqNsZBgNk9Qb5Ui+bQdNylNMsz2VqVoO7nNf8/WA0evBLsstlmIqyu29By4sU1g8URX1Na3Vg11Dn5hIB3oYNG9C5c2er57Zt24YWLVqo23v37sWTTz6J7du3o3Tp0njqqacwceJEi/JLlizByy+/jFOnTqFGjRqYMWMGevfunX1eupxMnToVc+fORVxcHNq1a4dPPvlElTW5cuWKeu5ff/0Ver0eAwYMwOzZsxEYGJhdxpa6EBERORv5otamWkm7PV+InxfaVS+lNtP/Z6MTUlR2b8nOc1h3KLbA5zgUfQ1F7bGvdyE8yAe1I4NRJzIIdSJkH4yqpQNua+ZQR2a1iuq6jsow2eu60kavp2fiWkoGEq6nq7GmCSnp2ffVPiUdx2Ku2bS8SPs312d3Sc5m41ufs9j1tEybrvnh+uPoULMUygT7onSgj/rxxR7YNdQ1uESA17ZtW0RFGbt1mEiQtm7dOjRv3lzdT0hIQPfu3dG1a1fMmTMH+/btwyOPPILQ0FCMHj1aldm0aRMGDx6M6dOno2/fvvjmm2/Qr18/7Nq1C/Xr11dlZs6ciffffx8LFixAlSpV1HV69OiBgwcPwtfXOMvYgw8+qOqzdu1apKen4+GHH1bXkOeztS5ERETFkXTtjAzxU1uIn7dNAd7/ulRXAZZer4OnXqf2HjqdClBMmz7rvjqffQ7qtqdeD73eGLzuPhOHMYt22VTX2GupiL12ERvNxhN6e+hRPTwQtSODUDcyGLVV4BdU4EQyzpPVKtzr2pph6lqnjPp7aJrxuARVpjJZNyG5VtNtdV+VzSqX43GStZ36y4E8rysm/bAP565eR2JqRq5gzWJ/PV09n71EJdi2DIk9vff7UbWZhAV4qx8swoN9USbIRwV+MnGSBPuytyUQLG5dQzMdMLOvveg0078MFyJBVbly5VRWTAIwIVm2F198EdHR0fD29lbHJk2ahGXLluHw4cPq/sCBA5GUlITly5dnP1fr1q3RuHFjFYjJW1G2bFlMmDABzz77rDofHx+PMmXK4Msvv8SgQYNw6NAh1K1bV2XmTMHlqlWrVBbw3Llz6vG21MUWEiiGhISoOgQHB2e/9hUrVqjreXl52e09peKHbYnshW2JbucLVPsZ6/OdvVPGAP79/J127eJmyzVXj+uI4xcT1ZjCw1HXjPvoayo4sKZ0kI/K8NWJCFJ7CQCrlQ7Mzvbl9eXY9KqKOqt1s9fNyDSoTJZ0uc21Jadl35aJd7afugp3IE0uyNcLwX6eCPLJ2st9Xy8E+XqqgPDHXecLfB4JpGViofzY+nX8wIV4vLr8UIHlqocH4HqaQWVs0zNt/6pvCgRVAGgWCJYK8MHLP+/H5aQ0q48rjH+rjrTKSTOV1mIDl83g5fTLL7/g8uXLKnNmsnnzZnTs2DE7oBKSeZMumFevXkWJEiVUmfHjx1s8l5SRwEucPHlSBWWSeTORN7FVq1bqsRLgyV4ycabgTkh56aq5detW9O/f36a6WJOamqo28z+i6cuTbKbb5nuiW8W2RPbCtkS348VetfDUd3vynL1TzhsyM2DILNpr+nkCDSID1Wb+Jfxc3HUciU5U3UYl4JPbZ64mq3GFF3Nk+7w8dCrIq10mAOsOXyogq3UAnWqUtOuXYzWhjA1ZrQtxyUjMCt5MQZxkseKuG7NZ8SnpSEq14x/AgRqXD0GtiCAE+0qw5qn2gSpou3Ffgji5HeDtke+ajvL+bjp+CTEJqfn8WOCDwc3L2e3v2qhcED7b+F+B11z+ZFt1TRmLGnc9XWWjpY3GZO3lvjzHxcRUxGbtJRC8kpSmNmnbN8PUNXTz8Vi0qhIGV7b6QIz6fMgrU/nBoEboUa+MQ+pm6/9nXTLA++KLL1TAVL68cdYuIYGZdKk0J5k30zkJqmRvOmZeRo6bypk/Lq8y4eHhFuc9PT0RFhZmUaagulgjXUenTZuW6/iaNWvg7+9vcUy6hxLZA9sS2QvbEt2qh2vq8OMpPeLSbnwJDvHWcG9lAzJP78SK0853zWqyhQB9QgCJfaKSgfPJOlxI0hn3ycbj8kW5oC/Lxi/Hqej05hr4ekBNGmPI6oaYvc/qkmixzzpvum06bnqMJG60AgZ7yZf/V5fb3rvIx0ODvwfg7wn4eWrGfdZ9f08NienAn9E5xptZMbJmJqoGG79Cm9fQPJ6Sm9l3dTnK5XjM8QQd5hwq+Lrtg6+ghtdlQOLVpKxNxrZlbQV3GLbUO0KHeQl6K7UydibtVSYZq1etvMlnLbxryrfJSrLJw0Oztqx2k5wBxKcBCek6415tOsSnQ7XrS6kFB6mjFmxHpUANkf5ApL/sNUT4Sdfm23vNUr8TCTokpAPBXkC1YE1lWO3NoAHTdnlkBXeWFzB1In7px91IP5VZKNcvSHJysvMHeNJtUbJa+ZEukbVr186+L90gV69eje+//x7uZvLkyRYZRsngVahQQY3nM++iKV+iunXrxq5QdFvYlshe2JbodslUZxMNGracuIj1m3fizjbN0Lpa6ULt6mW65o7TV1U2Q7qjNa9Uwm7XNM/2Ldt9AasPFhw6RF93TNe2+mVlLGEQQvwkg+Vl3PvJ3pjZksXr5bjc9ixgghnJanV6Z2OBGabnHuxo92zlMhuuO3agfa8r7ajpgRi8vuIwohNSLbrzvdirdqFkehxxTRmLNnTejgLLXc/U4XC8bJYBeMUS/qhZJtC4hQeiRplAVC7pb9OERZJRm57jtUYE++Cl3rf/WpNSM1SbkYmfZL/91BXEpV3I5xE6xKUBpeu2dkim0tS7z6kDPBnrNmLEiHzLVK1a1eL+/PnzUbJkSdx9990WxyMiIhATE2NxzHRfzuVXxvy86Vhk5I3+tXJfxumZysTGWn5IZ2RkqJk1C7qO+TWs8fHxUVtO8oUp55cma8eIbgXbEtkL2xLdDmk57WqEI/6YpvZF0ZbkCu1rFl5Xq6rh3qgaHoLQAF+bArxnutZQ4/dMk8aYJpORCWJME8fc2N84lvO+6bEyocyT3xQ8ocyLferabeZUeU9fubue6sqWVxfYqXfVg6/PjWEsrnxd0bdxefRqWK5IZ0ct6mvKBCMSQOY3drVMsA/eH9wUJy4m4ojqvnwNR2KuqS6fp68kq22t2aRKMmGRzEorXWbVViYINcsEoVyon2q/prFw1rpLSjAmx/MaQ6ppGuKS01W30ZiEFLWXIC46/rrFMZlU51ZcTs5wyP/vbL2mQwM8WT5ANlvJH0sCvOHDh+d6gW3atFETm8gvyaZz8otyrVq1srtEShmZeXPcuHHZj5MyclxIt0oJwKSMKaCTSFnG1o0ZMyb7OWT5hJ07d6JZs2bq2Pr162EwGNRYPVvrQkRERMWDfPEu6MuxTFAx9s4adv2CHhHsa9N1pX72JF+45Yt3zkkqIgp5kgpHXbcwlhdxtmvKteQ9zC+AlgBb2lLO9nQpMTU74DsaY+yyLEtMJKVlWu3CLGMfa0YEoUZ4IFbtj853DOnkH2UM6XU1tjAm3jyQS0FqhnRWLligj6dqI/JvRbKNG49eKvAxElA7M5cagyeBlEyE8uijj+Y6N2TIEDV+beTIkXj++eexf/9+tTbde++9l13m6aefxh133IF33nkHffr0wXfffYcdO3bgs88+U+dlIK0Ef6+//rpa9860TILMjCnLKYg6deqgZ8+eGDVqlJp5U4K4sWPHqglYpJytdSEiIqLiwZYvx3Le3tkXR11XSDAli20X9Zp/puvKZB9r/tqK7h1audT09s7sVgPoUoE+KFXdJ3stTCGTv5xXXZiNWT4J/OS2ZP8k8Pv3TJzaCnI1OT3fWUVLBnirmUAleJN6yo8exmDOT3XZlXMyqc7NzrJr7x9FinWAJ5OryJp45mPyzGe7lMlIZHFxyayVKlUKU6ZMsVh3Th4ra9W99NJLeOGFF1QQJzNomtbAE7IYuSylII+TTF379u3VMgimNfDEokWLVFDXpUuX7IXOZe28m6kLERERFR/MahUdua6Mj7p8SFN7BnfOF7hLF8wKYf5q61r3Rjfp9EwDTl1KUkHfr2rsquWQJ2saVwhBk4olVBBnDOb81G1Z3sHH08NlfhRBcV8Hr7jgOnhUmNiWyF7YlsheikNbkgxBUWe1HHldRykObcndbT5xGYPnbimw3LejWtv9h4RVXAePiIiIiJw9q+WI6xIV9tjVwugu2dPFu/oWPDcpERERERFRETJ1lxQ5w6qi6C7pkdXVt1kp1+vqywCPiIiIiIicjmkMqWTqzMn9vJZIIHbRJCIiIiIiJ+WoGVldGQM8IiIiIiJyWhxDenPYRZOIiIiIiMhNMMAjIiIiIiJyEwzwiIiIiIiI3AQDPCIiIiIiIjfBAI+IiIiIiMhNMMAjIiIiIiJyEwzwiIiIiIiI3AQDPCIiIiIiIjfBAI+IiIiIiMhNMMAjIiIiIiJyE56OrgDlTdM0tU9ISMg+lp6ejuTkZHXMy8vLgbUjV8e2RPbCtkT2wrZE9sK2RO7YjkwxgSlGyAsDPCd27do1ta9QoYKjq0JERERERE4SI4SEhOR5XqcVFAKSwxgMBly4cAFBQUHQ6XTZkbsEfGfPnkVwcLCjq0gujG2J7IVtieyFbYnshW2J3LEdSdgmwV3ZsmWh1+c90o4ZPCcmf7jy5ctbPSeNzBkaGrk+tiWyF7Ylshe2JbIXtiVyt3aUX+bOhJOsEBERERERuQkGeERERERERG6CAZ6L8fHxwdSpU9We6HawLZG9sC2RvbAtkb2wLVFxbkecZIWIiIiIiMhNMINHRERERETkJhjgERERERERuQkGeERERERERG6CAR4REREREZGbYIDnYj766CNUrlwZvr6+aNWqFbZt2+boKpGLeeWVV6DT6Sy22rVrO7pa5AI2btyIu+66C2XLllXtZtmyZRbnZc6uKVOmIDIyEn5+fujatSuOHTvmsPqSa7ajESNG5PqM6tmzp8PqS85r+vTpaNGiBYKCghAeHo5+/frhyJEjFmVSUlLw5JNPomTJkggMDMSAAQMQExPjsDqT67alTp065fpsevzxx+GMGOC5kMWLF2P8+PFqutZdu3ahUaNG6NGjB2JjYx1dNXIx9erVQ1RUVPb2999/O7pK5AKSkpLU54780GTNzJkz8f7772POnDnYunUrAgIC1GeUfMEisrUdCQnozD+jvv322yKtI7mGP//8UwVvW7Zswdq1a5Geno7u3burNmbyzDPP4Ndff8WSJUtU+QsXLuDee+91aL3JNduSGDVqlMVnk/x/zxlxmQQXIhk7+XXhww8/VPcNBgMqVKiAp556CpMmTXJ09ciFMnjyi/nu3bsdXRVyYfLL5U8//aR+5RTyvxLJyEyYMAHPPvusOhYfH48yZcrgyy+/xKBBgxxcY3KFdmTK4MXFxeXK7BEV5OLFiyr7Il/WO3bsqD6DSpcujW+++Qb33XefKnP48GHUqVMHmzdvRuvWrR1dZXKRtmTK4DVu3BizZs2Cs2MGz0WkpaVh586dqsuTiV6vV/flQ4roZki3OfkyXrVqVTz44IM4c+aMo6tELu7kyZOIjo62+IwKCQlRP0zxM4pu1oYNG9SXq1q1amHMmDG4fPmyo6tELkACOhEWFqb28r1JMjHmn0syJKFixYr8XKKbaksmixYtQqlSpVC/fn1MnjwZycnJcEaejq4A2ebSpUvIzMxUv4abk/vyaxSRreQLt2RU5IuTdC+YNm0aOnTogP3796u+50S3QoI7Ye0zynSOyBbSPVO60FWpUgUnTpzACy+8gF69eqkv5B4eHo6uHjkp6dU0btw4tGvXTn35FvLZ4+3tjdDQUIuy/Fyim21LYsiQIahUqZL6gXzv3r14/vnn1Ti9H3/8Ec6GAR5RMSNflEwaNmyoAj75wPr+++8xcuRIh9aNiMi8O2+DBg3U51S1atVUVq9Lly4OrRs5Lxk/JT9Uckw5FVZbGj16tMVnk0woJp9J8kOUfEY5E3bRdBGSDpZfLnPO/CT3IyIiHFYvcn3yy2bNmjVx/PhxR1eFXJjpc4ifUWRv0pVc/h/IzyjKy9ixY7F8+XL88ccfKF++fPZx+eyRIS4yptMcP5foZtuSNfIDuXDGzyYGeC5Cuhg0a9YM69ats0ghy/02bdo4tG7k2hITE9WvT/JLFNGtku508oXJ/DMqISFBzabJzyi6HefOnVNj8PgZRTnJ5E7yhVwm6lm/fr36HDIn35u8vLwsPpekS52MO+fnEt1MW7LGNFmdM342sYumC5ElEh566CE0b94cLVu2VLP4yPStDz/8sKOrRi5EZjiUNaikW6ZMFy3Lbkh2ePDgwY6uGrnAjwHmv1TKxCryPzgZhC6TFsiYhddffx01atRQ/3N8+eWX1VgF8xkSifJrR7LJuGBZq0x+MJAfnyZOnIjq1aurJTeIcnalkxkyf/75ZzWG3DSuTiZ4krU4ZS9DD+T7k7St4OBgNfO4BHecQZNupi3JZ5Gc7927t1pTUcbgyRIcMsOmdCN3OrJMArmODz74QKtYsaLm7e2ttWzZUtuyZYujq0QuZuDAgVpkZKRqQ+XKlVP3jx8/7uhqkQv4448/ZFmdXNtDDz2kzhsMBu3ll1/WypQpo/n4+GhdunTRjhw54uhqkwu1o+TkZK179+5a6dKlNS8vL61SpUraqFGjtOjoaEdXm5yQtXYk2/z587PLXL9+XXviiSe0EiVKaP7+/lr//v21qKgoh9abXK8tnTlzRuvYsaMWFham/v9WvXp17bnnntPi4+M1Z8R18IiIiIiIiNwEx+ARERERERG5CQZ4REREREREboIBHhERERERkZtggEdEREREROQmGOARERERERG5CQZ4REREREREboIBHhERERERkZtggEdEREREROQmGOARERHl4dSpU9DpdNi9ezecxeHDh9G6dWv4+vqicePGt/Vc8tqWLVtmt7oREZHjMcAjIiKnNWLECBWEvPnmmxbHJSiR48XR1KlTERAQgCNHjmDdunV5louOjsZTTz2FqlWrwsfHBxUqVMBdd92V72Nux4YNG9TfJC4urlCen4iIbMMAj4iInJpkqmbMmIGrV6/CXaSlpd3yY0+cOIH27dujUqVKKFmyZJ6Zx2bNmmH9+vV46623sG/fPqxatQqdO3fGk08+CWemaRoyMjIcXQ0iIpfFAI+IiJxa165dERERgenTp+dZ5pVXXsnVXXHWrFmoXLmyRTawX79+eOONN1CmTBmEhobi1VdfVcHEc889h7CwMJQvXx7z58+32i2ybdu2KtisX78+/vzzT4vz+/fvR69evRAYGKiee9iwYbh06VL2+U6dOmHs2LEYN24cSpUqhR49elh9HQaDQdVJ6iFZN3lNEpiZSIZs586dqozcltdtzRNPPKHOb9u2DQMGDEDNmjVRr149jB8/Hlu2bLE5AyddU+WYBIzi9OnTKgtYokQJlUWU51yxYoU6L8GjkHPyGHm/Ta9J/nZVqlSBn58fGjVqhKVLl+a67sqVK1VQKq/777//xp49e9RzBgUFITg4WJ3bsWOH1boTEdENDPCIiMipeXh4qKDsgw8+wLlz527ruSSjdeHCBWzcuBHvvvuu6u7Yt29fFZRs3boVjz/+OB577LFc15EAcMKECfj333/Rpk0bFeRcvnxZnZOA6M4770STJk1UACIBWUxMDB544AGL51iwYAG8vb3xzz//YM6cOVbrN3v2bLzzzjt4++23sXfvXhUI3n333Th27Jg6HxUVpYIqqYvcfvbZZ3M9x5UrV1QdJFMnQVhOEtjeKnnO1NRU9f5JVlAyqxLUSvfPH374QZWRrqNSN3ktQoK7hQsXqtd84MABPPPMMxg6dGiuIHnSpEmqK+6hQ4fQsGFDPPjggyrQ3b59uwpq5byXl9ct152IqLjwdHQFiIiICtK/f3+VzZKA7Isvvrjl55Es3fvvvw+9Xo9atWph5syZSE5OxgsvvKDOT548WQUZkkEaNGhQ9uMk+yaZMPHJJ5+oAErqMXHiRHz44YcquJMg1GTevHkq6Dl69KjKnokaNWqo6+VHArvnn38++9oSQP3xxx8qG/nRRx+pTKanp6cKquS2NcePH1fdHGvXrg17O3PmjHofGjRooO7L+D7z91aEh4dnB5ESDMr78vvvv6vA2PQYeX8//fRT3HHHHdmPl6xkt27dLK4lgbXpdcj7R0REBWOAR0RELkGCHcmUWcta2UqyXxLcmUh3SulyaZ4tlHFtsbGxFo8zBSdCAqzmzZurTJOQroQShEnQZW28nCnAky6G+UlISFDZxXbt2lkcl/tyDVtJcFdY/ve//2HMmDFYs2aN6jorwZ5k2/IiwaYE0OaBm2kMogTF5uQ9NSfdSR999FF89dVX6lr3338/qlWrZudXRETkfthFk4iIXELHjh1Vl0XJsuUkQVvOwCY9PT1XuZxd/GTsl7VjMm7MVomJiarLpoxXM9+kW6XU2cRad8n/b++OcUwLwziMn7sIDa2GUmEJItHpNBI2YAUKYQ0aCxANyaCwAp1SyQLUopJ783yJm3NcXHJnbuLM80sUDOeMb5r553vf9/sK7HTxHegbfMUl+MbX8XoNCVy73S70GFKiSSijdPbR2mC5XCbWZrvdJvrwbq0P/YWUdNZqtVBaWywWo9ls9tJ3kqTvyIAnSXoblE/O5/NovV4nXs9kMuFYgHg4+cyz6+KDSRjKQk9YoVAIz0ulUggiDHTJ5/OJxyuhjkEi2Ww29OjF8Zxw8yxKJQnClHQej8c/fn7vGAPWEPTPPVpDSk/pVZxOp6EXcDQahdfpL8T5fP79Xn5vhqZQbnm9Nlznb9j9pGePHcN6vX5zAI4kKcmAJ0l6G/R+MXyDPro4plQeDofQ40ZZJOGGqYyfheuxe8SuGINGOLKh3W6Hn/GcwSaNRiMMBOH+q9UqarVaibDzDHrOKEWdTCZhWAmDRQhZnU7n5d+Xe5fL5TD8hN1ESkpZt3i5adwldLFzxvvZdWPgSxxTQPlu+/0+2mw2oTT1EnQ5toGdw8ViEf4W7N4xAZOSWkIaQ2ZYGz7Hrh/P7zmdTqHvkQmbTO4k5LK2l3tJku4z4EmS3grDOK5LKPnHfzgchmDDGH6OB/iXXr1bO4c8uDYDQj4+PsJxB7jsuhGoKpVKCKEEIQaNxPv9nu1xo/eMnTGuwzAX7vXqgBEGmRCkOGaAa9FnSB8ch5wzJOYWSlXH43EIsfTVETQHg0HiPXxHAi3rXa1Www4b645cLhf1er0QSultJKCh3+9H3W43TNO8fI7wyLEJ99ALyZTSZrMZ7sFEUo6h4PqSpMd+/PzKbmxJkiRJ0n/jDp4kSZIkpYQBT5IkSZJSwoAnSZIkSSlhwJMkSZKklDDgSZIkSVJKGPAkSZIkKSUMeJIkSZKUEgY8SZIkSUoJA54kSZIkpYQBT5IkSZJSwoAnSZIkSVE6/AJLEQkzJ5ha8AAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimal number of clusters: 17\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 0: Best model is Ridge with CV MAE -0.24\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 1: Best model is LinearRegression with CV MAE -1.51\n",
+      "Cluster 2 has too few weighted samples after thresholding.\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 3: Best model is GradientBoostingRegressor with CV MAE -0.61\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 4: Best model is GradientBoostingRegressor with CV MAE -0.48\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 5: Best model is GradientBoostingRegressor with CV MAE -1.57\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 6: Best model is Ridge with CV MAE -0.27\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 7: Best model is GradientBoostingRegressor with CV MAE -0.95\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "Cluster 8: Best model is GradientBoostingRegressor with CV MAE -0.70\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
+      "1 fits failed out of a total of 10.\n",
+      "The score on these train-test partitions for these parameters will be set to nan.\n",
+      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
+      "\n",
+      "Below are more details about the failures:\n",
+      "--------------------------------------------------------------------------------\n",
+      "1 fits failed with the following error:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
+      "    estimator.fit(X_train, y_train, **fit_params)\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\ensemble\\_gb.py\", line 734, in fit\n",
+      "    self.init_.fit(\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\dummy.py\", line 578, in fit\n",
+      "    self.constant_ = np.average(y, axis=0, weights=sample_weight)\n",
+      "                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
+      "    raise ZeroDivisionError(\n",
+      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
+      "\n",
+      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n",
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
+      "1 fits failed out of a total of 10.\n",
+      "The score on these train-test partitions for these parameters will be set to nan.\n",
+      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
+      "\n",
+      "Below are more details about the failures:\n",
+      "--------------------------------------------------------------------------------\n",
+      "1 fits failed with the following error:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
+      "    estimator.fit(X_train, y_train, **fit_params)\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 622, in fit\n",
+      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
+      "                                        ^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 184, in _preprocess_data\n",
+      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
+      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\utils\\_array_api.py\", line 716, in _average\n",
+      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
+      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
+      "    raise ZeroDivisionError(\n",
+      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
+      "\n",
+      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
+      "No valid model found for cluster 9.\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
+      "5 fits failed out of a total of 50.\n",
+      "The score on these train-test partitions for these parameters will be set to nan.\n",
+      "If these failures are not expected, you can try to debug them by setting error_score='raise'.\n",
+      "\n",
+      "Below are more details about the failures:\n",
+      "--------------------------------------------------------------------------------\n",
+      "5 fits failed with the following error:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py\", line 866, in _fit_and_score\n",
+      "    estimator.fit(X_train, y_train, **fit_params)\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_ridge.py\", line 1249, in fit\n",
+      "    return super().fit(X, y, sample_weight=sample_weight)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_ridge.py\", line 956, in fit\n",
+      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
+      "                                        ^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\linear_model\\_base.py\", line 184, in _preprocess_data\n",
+      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
+      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\utils\\_array_api.py\", line 716, in _average\n",
+      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
+      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\numpy\\lib\\_function_base_impl.py\", line 575, in average\n",
+      "    raise ZeroDivisionError(\n",
+      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
+      "\n",
+      "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan nan nan nan nan]\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
@@ -7752,7 +7740,21 @@
       "\n",
       "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
+      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
       "1 fits failed out of a total of 10.\n",
       "The score on these train-test partitions for these parameters will be set to nan.\n",
@@ -7782,23 +7784,7 @@
       "\n",
       "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [nan]\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
-      "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
-      "No valid model found for cluster 9.\n",
-      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "  warnings.warn(\n",
       "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\model_selection\\_validation.py:528: FitFailedWarning: \n",
       "5 fits failed out of a total of 50.\n",
       "The score on these train-test partitions for these parameters will be set to nan.\n",
@@ -7838,6 +7824,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "No valid model found for cluster 9.\n",
+      "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 1 candidates, totalling 10 fits\n",
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
@@ -7901,11 +7889,7 @@
       "Fitting 10 folds for each of 5 candidates, totalling 50 fits\n",
       "Cluster 16: Best model is Ridge with CV MAE -0.25\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 18)\n",
-      "FeatureStacker - Combined features shape: (860, 28)\n",
-      "\n",
-      "Categorical columns: []\n",
-      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
-      "Target column: SettlementValue\n"
+      "FeatureStacker - Combined features shape: (860, 28)\n"
      ]
     },
     {
@@ -7920,6 +7904,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
+      "Categorical columns: []\n",
+      "Numerical columns: ['InjuryPrognosis', 'GeneralRest', 'SpecialTherapy', 'SpecialEarningsLoss', 'SpecialAssetDamage', 'GeneralFixed', 'SpecialLoanerVehicle', 'SpecialJourneyExpenses', 'SpecialUsageLoss', 'DaysBetweenAccidentAndClaim']\n",
+      "Target column: SettlementValue\n",
       "FeatureStacker - Transformer 'gmm' output shape: (3437, 18)\n",
       "FeatureStacker - Combined features shape: (3437, 28)\n"
      ]
@@ -9011,7 +8999,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -9050,7 +9038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -9062,7 +9050,25 @@
       "FeatureStacker - Transformer 'gmm' output shape: (860, 5)\n",
       "FeatureStacker - Combined features shape: (860, 15)\n",
       "FeatureStacker - Transformer 'gmm' output shape: (860, 3)\n",
-      "FeatureStacker - Combined features shape: (860, 13)\n",
+      "FeatureStacker - Combined features shape: (860, 13)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
+      "  warnings.warn(\n",
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
+      "  warnings.warn(\n",
+      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "Comparison of Pipelines:\n",
       "Original Pipeline\n",
@@ -9079,404 +9085,47 @@
       "----------------------\n",
       "\n",
       "Best Model:\n",
-      "{'MSE': 0.0275207110099833, 'RMSE': np.float64(0.1658936738094111), 'MAE': 0.08297564987420322, 'R^2': 0.9334204941609521, 'Name': 'Best Pipeline', 'MSE_GBP': 63908.31262119313, 'RMSE_GBP': np.float64(252.8009347712012), 'MAE_GBP': 114.89961393543192, 'y_pred': array([6.53037312, 6.7903958 , 6.25955674, 6.78942322, 6.64397061,\n",
-      "       6.95782783, 7.55337544, 6.8014366 , 7.59648526, 6.85314738,\n",
-      "       7.17266722, 6.7834049 , 7.24954106, 6.97981136, 7.53626456,\n",
-      "       7.22868034, 6.26080578, 6.94758911, 7.080856  , 5.48479693,\n",
-      "       8.48450878, 6.82747087, 7.45700384, 7.76337587, 6.63701894,\n",
-      "       6.21565591, 5.48479693, 6.20657593, 7.17377445, 7.13350424,\n",
-      "       6.3727518 , 6.25575004, 7.94588516, 7.10943464, 6.73540666,\n",
-      "       7.32779381, 6.41365536, 7.28648187, 6.79794041, 7.51184271,\n",
-      "       6.25575004, 6.6773061 , 7.31110193, 5.94149561, 5.9380212 ,\n",
-      "       6.99140317, 7.25183096, 7.09866616, 7.42004858, 6.94981762,\n",
-      "       6.70898827, 6.25269535, 6.2972975 , 7.51136191, 6.2516285 ,\n",
-      "       6.25427901, 6.73459166, 6.43153805, 5.59661819, 6.77434872,\n",
-      "       7.13682388, 6.37753307, 6.20562508, 7.31306604, 5.56452041,\n",
-      "       8.52758022, 6.62495107, 6.89504454, 6.79803107, 6.34095642,\n",
-      "       7.67204676, 5.56452041, 6.49088961, 6.8499795 , 6.61388949,\n",
-      "       6.96109524, 7.08060143, 7.39463082, 7.62639809, 7.17536401,\n",
-      "       5.56452041, 6.64302323, 7.36795982, 7.03860144, 7.12799683,\n",
-      "       6.97022152, 6.81033012, 6.22337568, 6.79302025, 6.82265491,\n",
-      "       6.79794041, 6.94588589, 6.99331636, 7.00816603, 6.74178745,\n",
-      "       7.71712544, 6.85717314, 7.70237639, 7.62263502, 6.7778646 ,\n",
-      "       6.20657593, 6.58623536, 6.94394296, 7.30477164, 8.10668874,\n",
-      "       5.48479693, 7.45879729, 7.49909667, 7.13569567, 6.96052095,\n",
-      "       6.41866073, 6.79354516, 6.86975618, 5.56452041, 7.87279532,\n",
-      "       8.34171099, 7.71466098, 6.26667839, 5.55995304, 6.74756263,\n",
-      "       7.32739727, 6.86092651, 5.48479693, 6.43613743, 6.3209317 ,\n",
-      "       7.75358295, 6.97026947, 7.02326224, 5.6208973 , 7.24486218,\n",
-      "       6.99534887, 7.69053906, 6.74325128, 7.23302377, 7.1699616 ,\n",
-      "       6.25575004, 7.72023381, 7.0293588 , 7.08292076, 7.12742987,\n",
-      "       6.70419005, 7.02018082, 7.54335342, 6.48694313, 6.99313795,\n",
-      "       6.80367057, 5.56452041, 6.76241988, 6.28118335, 6.3874251 ,\n",
-      "       6.55878962, 6.24140954, 7.36602885, 7.23943978, 7.23318622,\n",
-      "       5.56452041, 7.83960162, 5.48479693, 7.30900715, 7.03347313,\n",
-      "       6.1458697 , 6.226646  , 7.11079419, 7.5421397 , 7.19578443,\n",
-      "       6.82144747, 6.90516395, 6.50628624, 6.05488905, 7.64240715,\n",
-      "       7.4305141 , 8.07929395, 5.48479693, 5.53980613, 7.39491785,\n",
-      "       7.09298971, 6.73459166, 6.27638882, 7.5208526 , 7.24573268,\n",
-      "       6.69542049, 7.19411036, 7.03862759, 7.61269355, 7.61838521,\n",
-      "       6.2860746 , 7.43048549, 6.32307257, 8.0446285 , 7.80795796,\n",
-      "       6.71539637, 7.1709281 , 5.59717917, 6.32187727, 6.96544442,\n",
-      "       6.25757006, 6.48065437, 6.29629399, 6.54910969, 8.19400279,\n",
-      "       6.79794041, 7.35459679, 7.11469983, 7.61541303, 6.79803107,\n",
-      "       6.63192632, 7.06833194, 7.0969441 , 6.85200157, 6.03184189,\n",
-      "       7.57238541, 7.32224788, 6.53016242, 6.25575004, 6.79794041,\n",
-      "       7.70872341, 6.79784898, 6.8619738 , 6.79794041, 6.69812824,\n",
-      "       7.1061493 , 6.73418926, 6.11097666, 6.40141129, 7.24013122,\n",
-      "       6.80159292, 6.9604321 , 5.48479693, 7.34953058, 6.64246897,\n",
-      "       5.59616578, 7.0865787 , 7.55968704, 6.73459166, 7.28460185,\n",
-      "       6.84742372, 7.03855673, 7.72928948, 6.7464057 , 6.25575004,\n",
-      "       8.07109288, 7.55189367, 7.29241165, 6.73459166, 6.39701766,\n",
-      "       7.28436443, 7.28453479, 6.86948889, 6.74139755, 7.24566205,\n",
-      "       6.79803107, 7.35019877, 6.77201508, 7.22628126, 6.38134143,\n",
-      "       6.6936756 , 7.16181248, 6.53973568, 6.68305075, 6.36517431,\n",
-      "       7.30196988, 6.17265859, 7.50176434, 7.71018329, 7.51755618,\n",
-      "       7.88887035, 6.83757077, 6.84951041, 6.37555864, 6.84969473,\n",
-      "       7.22159932, 6.94467496, 6.52954966, 5.48479693, 5.83048685,\n",
-      "       6.76394473, 7.01948141, 5.48479693, 7.41704127, 7.10077455,\n",
-      "       7.35781253, 6.45004633, 6.77171527, 5.48479693, 7.15286104,\n",
-      "       6.61765963, 6.78288857, 6.35228934, 6.29629399, 7.41366988,\n",
-      "       6.73522515, 5.56372317, 6.81594345, 7.36992292, 7.50251576,\n",
-      "       6.99642821, 6.85859348, 7.88382211, 6.29764284, 5.48479693,\n",
-      "       6.25575004, 6.5166033 , 6.59936298, 7.39522269, 6.26046242,\n",
-      "       7.17646996, 6.90995958, 7.56072172, 7.0819272 , 6.90329433,\n",
-      "       8.15789914, 7.36277008, 6.54210842, 7.51414676, 7.43904775,\n",
-      "       7.31673614, 6.61295859, 6.25702322, 5.56452041, 6.94280885,\n",
-      "       7.03419547, 7.58371275, 7.0839888 , 5.48479693, 6.91813394,\n",
-      "       7.46070189, 7.9599362 , 7.56700368, 7.07147791, 7.20296922,\n",
-      "       6.93199383, 7.45634514, 6.38614207, 6.75416308, 5.48479693,\n",
-      "       7.20185816, 6.70146966, 7.290694  , 8.43604408, 7.22162811,\n",
-      "       7.22347842, 6.25575004, 7.2652357 , 7.26915608, 6.6868446 ,\n",
-      "       6.85552934, 7.55752298, 6.73522515, 7.2066575 , 7.67608488,\n",
-      "       7.40160723, 7.21982365, 7.00594784, 6.85653345, 7.24120281,\n",
-      "       6.31624217, 7.45671999, 7.34113004, 8.38434763, 5.48479693,\n",
-      "       7.30401018, 6.82711587, 7.32365129, 7.2594877 , 6.45283631,\n",
-      "       6.78702513, 7.81975849, 6.79794041, 7.43132259, 7.41947261,\n",
-      "       7.00724384, 7.48042925, 6.28081022, 7.67876395, 6.83852197,\n",
-      "       7.44638135, 6.90115243, 7.33143646, 5.5958401 , 6.25575004,\n",
-      "       7.03619701, 6.73677164, 5.48479693, 7.52925792, 7.43156057,\n",
-      "       6.68650766, 6.21075573, 6.6376701 , 6.7960646 , 6.41536895,\n",
-      "       7.71749802, 7.26481792, 6.85298009, 7.03660112, 7.18371861,\n",
-      "       8.47509379, 6.41218085, 6.43860344, 6.96054558, 6.88384466,\n",
-      "       8.25687033, 7.7469407 , 6.21538503, 6.46243568, 6.78959526,\n",
-      "       6.67129102, 6.26292955, 6.45148271, 6.95943347, 6.30038464,\n",
-      "       6.43394053, 7.39695493, 7.80339892, 7.00121995, 6.53191207,\n",
-      "       7.44746796, 6.25551899, 7.52568086, 5.56292594, 7.18966775,\n",
-      "       6.21586543, 7.32617645, 7.03217651, 6.84969128, 6.81684989,\n",
-      "       6.75523159, 6.80571185, 6.78811845, 7.64167198, 7.20157643,\n",
-      "       5.76897962, 6.29406136, 7.25011619, 7.79693393, 7.77511535,\n",
-      "       6.81504241, 6.60325979, 7.59351722, 6.26915258, 5.48479693,\n",
-      "       6.18440458, 6.20903463, 7.46705251, 7.0078266 , 7.58090836,\n",
-      "       7.07811563, 6.6034196 , 6.65322958, 6.42555717, 6.82610513,\n",
-      "       6.90777446, 7.31427424, 7.24120281, 7.43102526, 7.10808215,\n",
-      "       7.15423957, 5.48479693, 5.60938637, 7.07050144, 6.99147897,\n",
-      "       7.24567592, 6.421465  , 6.56150302, 6.78738305, 7.39139337,\n",
-      "       6.26105167, 6.6285713 , 7.68144895, 7.49541205, 7.00128796,\n",
-      "       7.40080649, 6.25575004, 6.785399  , 7.13214196, 5.56372317,\n",
-      "       6.54935399, 6.74626953, 6.68900852, 6.9438449 , 6.73854684,\n",
-      "       7.00870351, 6.2552583 , 7.28540136, 7.37006582, 6.22244765,\n",
-      "       6.73144785, 7.6956772 , 6.79794041, 6.90419258, 8.85051143,\n",
-      "       8.85051123, 7.10090631, 6.85007737, 5.56372317, 6.80347803,\n",
-      "       6.71020361, 6.55093736, 6.71273333, 6.28081022, 6.36408666,\n",
-      "       6.86368756, 7.36438943, 7.14580997, 6.28217996, 6.78704091,\n",
-      "       7.23917124, 6.71164366, 7.229178  , 6.81563225, 7.41608516,\n",
-      "       6.67165736, 6.79927285, 5.48479693, 6.73235853, 7.88487504,\n",
-      "       6.76692812, 5.61090337, 6.57816318, 7.08575866, 7.06664811,\n",
-      "       7.77671315, 7.06160716, 7.12503511, 7.7677283 , 7.29602897,\n",
-      "       6.74139755, 6.93708075, 7.4421254 , 7.82805035, 7.69223287,\n",
-      "       6.91948985, 7.12136769, 5.72912883, 7.01903114, 7.38209199,\n",
-      "       7.01546325, 6.55142089, 8.01334566, 6.25955674, 8.22414077,\n",
-      "       6.95511619, 6.20657593, 7.51368852, 7.71094317, 6.79794041,\n",
-      "       7.1321837 , 6.81697422, 5.56452041, 7.46306455, 7.03605459,\n",
-      "       6.99070513, 6.77454428, 7.52508781, 6.49102056, 6.73454768,\n",
-      "       6.88998959, 6.80420332, 7.08309799, 7.50644587, 6.14788546,\n",
-      "       7.3971296 , 7.57517557, 8.20354711, 6.79675175, 6.92890852,\n",
-      "       7.02674247, 7.45575926, 7.32835662, 7.14784072, 6.57367109,\n",
-      "       6.8893279 , 6.94073807, 6.61445686, 7.1321273 , 6.43385548,\n",
-      "       6.03351455, 7.22151625, 8.47509379, 6.65762326, 7.63356751,\n",
-      "       5.5630789 , 5.56292594, 6.20657593, 7.83154785, 6.25575004,\n",
-      "       7.35486509, 7.54889329, 6.69785864, 7.22657645, 5.48479693,\n",
-      "       7.13142442, 6.79794041, 6.30656811, 6.33927022, 7.02404207,\n",
-      "       6.79589159, 6.57534756, 7.03877615, 6.21240973, 7.20387596,\n",
-      "       7.20014685, 6.26544543, 7.50224382, 5.56452041, 6.25575004,\n",
-      "       6.88507915, 7.01287808, 7.26098104, 7.97590025, 8.01334729,\n",
-      "       7.25978647, 6.70400385, 7.00996031, 7.75591721, 6.78620237,\n",
-      "       6.3632773 , 7.06027147, 6.43838002, 6.27977163, 5.56452041,\n",
-      "       6.83712267, 7.42541366, 6.77295769, 7.39068049, 6.44682566,\n",
-      "       6.70620534, 7.0019912 , 7.6492286 , 7.1086524 , 6.61695273,\n",
-      "       6.9742848 , 6.87643716, 6.26705234, 7.56987893, 6.68897456,\n",
-      "       5.56452041, 7.0771753 , 6.81466467, 6.33403585, 8.02023524,\n",
-      "       6.95750434, 7.20757073, 7.98861775, 7.13720311, 6.75366997,\n",
-      "       7.11735209, 8.19400279, 6.73459166, 6.55652521, 6.82764505,\n",
-      "       6.02715715, 8.27221562, 6.81415039, 6.93036612, 6.20977434,\n",
-      "       7.75003129, 6.75842911, 7.19733686, 6.81811972, 7.14815085,\n",
-      "       6.35627878, 7.69093091, 6.20910842, 7.42270216, 6.98974485,\n",
-      "       6.7464057 , 5.56548526, 6.9595727 , 5.66366629, 7.41182362,\n",
-      "       7.07698831, 7.84307645, 7.42580387, 6.28637956, 7.53285157,\n",
-      "       6.73460518, 7.67803446, 7.17216488, 6.90151483, 7.05176502,\n",
-      "       6.58538558, 6.8474289 , 6.99992458, 6.50123346, 7.42869767,\n",
-      "       7.83867276, 7.04308179, 6.24837392, 7.24078863, 6.7457723 ,\n",
-      "       6.83483556, 6.65288513, 7.01751228, 6.78887255, 7.59934008,\n",
-      "       7.36617135, 7.15148227, 7.39397342, 7.85524357, 7.38539046,\n",
-      "       6.43615959, 6.96080055, 7.4289146 , 7.80271891, 7.78171986,\n",
-      "       6.78999709, 6.79730693, 6.51970345, 6.55897859, 6.29829616,\n",
-      "       7.51370982, 6.29946514, 6.79794041, 6.99805418, 7.29138349,\n",
-      "       5.56452041, 7.42621841, 7.42880022, 7.444761  , 7.65456855,\n",
-      "       7.0344082 , 6.26154203, 7.09281135, 6.25717766, 7.07165649,\n",
-      "       6.79794041, 7.11385913, 6.62773316, 7.03507696, 7.16796494,\n",
-      "       7.22164861, 5.57114122, 5.48479693, 6.2552583 , 5.56372317,\n",
-      "       7.75186756, 7.51865676, 6.89069736, 7.171675  , 6.20657593,\n",
-      "       6.25575004, 7.46839786, 6.66982997, 6.79153272, 7.25119737,\n",
-      "       5.95320029, 6.63400431, 6.17191784, 7.30314789, 7.33328789,\n",
-      "       6.54594345, 6.56898639, 8.11105513, 6.2559917 , 6.96935831,\n",
-      "       7.72275936, 7.82406028, 6.86162109, 8.37123116, 6.25575004,\n",
-      "       7.62085211, 6.226646  , 7.156368  , 6.36545259, 6.87827089,\n",
-      "       7.03934231, 7.2694283 , 6.72001035, 7.97102821, 6.26154203,\n",
-      "       6.25692669, 5.48479693, 6.20706767, 6.66569269, 8.13132022,\n",
-      "       6.76527515, 6.80779838, 6.25575004, 6.79794041, 7.15393912,\n",
-      "       7.02355188, 7.05540658, 6.78140595, 6.73522515, 6.79794041,\n",
-      "       6.75247992, 6.53114928, 7.34687855, 6.27226967, 5.56452041,\n",
-      "       6.74167198, 6.20903463, 6.50582926, 6.60361325, 7.59520118,\n",
-      "       7.28813634, 7.44702477, 6.85138496, 6.79794041, 6.27013582,\n",
-      "       7.86634119, 5.7742002 , 6.25615626, 6.82799002, 6.37214047,\n",
-      "       6.20897102, 6.25202009, 6.23657182, 5.48578393, 7.22641874,\n",
-      "       6.25702322, 6.25575004, 7.29682519, 6.38371949, 6.44560711,\n",
-      "       6.2552583 , 6.62224339, 7.653948  , 7.13877621, 7.24212842,\n",
-      "       7.08557379, 7.11110905, 6.68079846, 5.56452041, 6.73102643,\n",
-      "       7.34455897, 5.61601356, 5.56292594, 7.20648438, 6.25575004,\n",
-      "       7.23385901, 6.06359645, 7.44668331, 6.74615741, 7.81972988,\n",
-      "       6.27073095, 8.22255833, 7.75935585, 6.26457456, 7.01771416,\n",
-      "       6.58752914, 6.8554845 , 6.65866702, 7.70230225, 7.55996752,\n",
-      "       6.79794041, 5.57769981, 6.54990817, 6.35684532, 6.25575004,\n",
-      "       7.94595952, 6.23798194, 7.19823132, 8.09919086, 6.59276746,\n",
-      "       5.56452041, 7.58781661, 6.79830305, 7.19301328, 6.81360261]), 'y_pred_GBP': array([ 684.65399816,  888.26546002,  521.9870682 ,  887.40100036,\n",
-      "        767.13892732, 1050.34736798, 1906.16942049,  898.13806741,\n",
-      "       1990.18507432,  945.85633913, 1302.31620776,  882.07038052,\n",
-      "       1406.45875706, 1073.71561694, 1873.81366764, 1377.40227561,\n",
-      "        522.64070908, 1039.63783662, 1187.98585246,  240.        ,\n",
-      "       4838.21973581,  921.85384184, 1730.95107703, 2351.83407965,\n",
-      "        761.81759828,  499.52418096,  240.        ,  495.        ,\n",
-      "       1303.76006754, 1252.2610135 ,  584.66725062,  520.        ,\n",
-      "       2822.93097496, 1222.45565394,  840.68569066, 1521.02019868,\n",
-      "        609.11981794, 1459.42368326,  895.        , 1828.58183229,\n",
-      "        520.        ,  793.17679536, 1495.82568072,  379.50358809,\n",
-      "        378.18385827, 1086.24599782, 1409.68539709, 1209.3515807 ,\n",
-      "       1668.11459029, 1041.95949286,  818.74086509,  518.41093515,\n",
-      "        542.10219158, 1827.70236745,  517.85709359,  519.23415699,\n",
-      "        840.        ,  620.12854161,  268.51342095,  874.109239  ,\n",
-      "       1256.42829261,  587.47418979,  494.52860264, 1498.76849327,\n",
-      "        260.        , 5051.20581922,  752.66733669,  986.36970186,\n",
-      "        895.08123435,  566.33866641, 2146.47231516,  260.        ,\n",
-      "        658.10944971,  942.86156036,  744.37652361, 1053.78816877,\n",
-      "       1187.68320799, 1626.22407242, 2050.64684186, 1305.8357221 ,\n",
-      "        260.        ,  766.41154802, 1583.39803319, 1138.79242003,\n",
-      "       1245.37775361, 1063.45852823,  906.17023417,  503.40306359,\n",
-      "        890.60236465,  917.42009487,  895.        , 1037.86691647,\n",
-      "       1088.32809637, 1104.62495603,  846.0734868 , 2245.49260959,\n",
-      "        949.67584159, 2212.60213851, 2042.94086899,  877.19142753,\n",
-      "        495.        ,  724.0461846 , 1035.85042127, 1486.38027164,\n",
-      "       3315.57777303,  240.        , 1734.06002997, 1805.40989991,\n",
-      "       1255.01045845, 1053.18259426,  612.18134834,  891.07049603,\n",
-      "        961.71380872,  260.        , 2623.89276767, 4194.261653  ,\n",
-      "       2239.96304477,  525.72489324,  258.81063421,  850.97964066,\n",
-      "       1520.41677302,  953.2507763 ,  240.        ,  622.99192598,\n",
-      "        555.09085967, 2328.90541479, 1063.50956369, 1121.442325  ,\n",
-      "        275.13704976, 1399.88880921, 1090.54441687, 2186.5534567 ,\n",
-      "        847.3143667 , 1383.40229104, 1298.79468911,  520.        ,\n",
-      "       2252.48640617, 1128.30626532, 1190.44336306, 1244.67131131,\n",
-      "        814.81698506, 1117.98893697, 1887.15118671,  655.51341742,\n",
-      "       1088.13376262,  900.1489574 ,  260.        ,  863.73221755,\n",
-      "        533.42069603,  593.32428425,  704.41735648,  512.58191541,\n",
-      "       1580.34154865, 1392.31319483, 1383.62720905,  260.        ,\n",
-      "       2538.19306451,  240.        , 1492.69343248, 1132.96218217,\n",
-      "        465.7854361 ,  505.05532433, 1224.12014165, 1884.8608837 ,\n",
-      "       1332.79618824,  916.31183191,  996.41202974,  668.33604055,\n",
-      "        425.19161663, 2083.7561065 , 1685.67447544, 3225.95405588,\n",
-      "        240.        ,  253.62862993, 1626.69119953, 1202.50054283,\n",
-      "        840.        ,  530.8645309 , 1845.14064349, 1401.10882095,\n",
-      "        807.69390956, 1330.56518059, 1138.82222762, 2022.72175378,\n",
-      "       2034.27292937,  536.04108544, 1685.62621056,  556.28265647,\n",
-      "       3116.00691809, 2459.10167773,  824.01071   , 1300.05154623,\n",
-      "        268.66465532,  555.61693513, 1058.38562367,  520.9490918 ,\n",
-      "        651.39771796,  541.55745539,  697.62190383, 3618.18012396,\n",
-      "        895.        , 1562.36650831, 1228.91437177, 2028.23272354,\n",
-      "        895.08123435,  757.9427266 , 1173.18778735, 1207.26907465,\n",
-      "        944.77204682,  415.4814357 , 1942.77144779, 1512.60254658,\n",
-      "        684.5095417 ,  520.        ,  895.        , 2226.69658203,\n",
-      "        894.91807673,  954.25068572,  895.        ,  809.88661897,\n",
-      "       1218.44278683,  839.66165328,  449.77875716,  601.69501325,\n",
-      "       1393.27691738,  898.27862963, 1053.08892678,  240.        ,\n",
-      "       1554.46619193,  765.98632   ,  268.39151903, 1194.80957487,\n",
-      "       1918.24476303,  840.        , 1456.68063724,  940.4523371 ,\n",
-      "       1138.74146098, 2272.98590984,  849.9945267 ,  520.        ,\n",
-      "       3199.59779171, 1903.34551284, 1468.10940438,  840.        ,\n",
-      "        599.05280629, 1456.3345952 , 1456.58289252,  961.45651681,\n",
-      "        845.74327418, 1401.00978846,  895.08123435, 1555.50588551,\n",
-      "        872.06942983, 1374.0993432 ,  589.71958347,  806.28406007,\n",
-      "       1288.2455443 ,  691.10361968,  797.75219463,  580.24613406,\n",
-      "       1482.21881865,  478.45909897, 1810.23523083, 2229.95114061,\n",
-      "       1839.06501509, 2666.42895305,  931.22180512,  942.41890886,\n",
-      "        586.3134362 ,  942.59280759, 1367.67626805, 1036.60968212,\n",
-      "        684.08961847,  240.        ,  339.52442239,  865.05181057,\n",
-      "       1117.20657557,  240.        , 1663.10258865, 1211.9061618 ,\n",
-      "       1567.40197647,  631.73160356,  871.80771207,  240.        ,\n",
-      "       1276.75644102,  747.19200286,  881.61453964,  572.80483928,\n",
-      "        541.55745539, 1657.50169091,  840.5329318 ,  259.79200465,\n",
-      "        911.27679964, 1586.5114065 , 1811.59673391, 1091.72320051,\n",
-      "        951.02708198, 2652.99705868,  542.28977998,  240.        ,\n",
-      "        520.        ,  675.27736898,  733.62707065, 1627.1874573 ,\n",
-      "        522.46094457, 1307.28180815, 1001.20672873, 1920.23161184,\n",
-      "       1189.26018034,  994.54898783, 3489.84513237, 1575.1967053 ,\n",
-      "        692.74774655, 1832.80213357, 1700.12955678, 1504.2829088 ,\n",
-      "        743.68297295,  520.66374994,  260.        , 1034.67518735,\n",
-      "       1133.78157892, 1964.91438803, 1191.71654876,  240.        ,\n",
-      "       1009.4327052 , 1737.36777148, 2862.89023489, 1932.33869479,\n",
-      "       1176.88755855, 1342.41373369, 1023.53469015, 1729.8106111 ,\n",
-      "        592.56223397,  856.62168755,  240.        , 1340.92195353,\n",
-      "        812.60066723, 1465.58815613, 4609.28097923, 1367.71567169,\n",
-      "       1370.25056192,  520.        , 1428.72257391, 1434.33862435,\n",
-      "        800.7882962 ,  948.11439637, 1914.0959053 ,  840.5329318 ,\n",
-      "       1347.37776754, 2155.16159735, 1637.61593944, 1365.24810531,\n",
-      "       1102.17519356,  949.067896  , 1394.77181556,  552.48916278,\n",
-      "       1730.45952145, 1541.45416631, 4377.00154956,  240.        ,\n",
-      "       1485.24810991,  921.52628818, 1514.72823887, 1420.52809609,\n",
-      "        633.4993816 ,  885.27308792, 2488.30413801,  895.        ,\n",
-      "       1687.03867314, 1667.15351157, 1103.60583097, 1772.00166859,\n",
-      "        533.22132571, 2160.94584851,  932.10895463, 1712.65080784,\n",
-      "        992.41890103, 1526.5744924 ,  268.30379586,  520.        ,\n",
-      "       1136.05515981,  841.83536427,  240.        , 1860.72345213,\n",
-      "       1687.44045054,  800.51818206,  497.07751947,  762.31447179,\n",
-      "        893.32084686,  610.16621204, 2246.32977765, 1428.12538312,\n",
-      "        945.6979479 , 1136.51475415, 1316.79953956, 4792.87236015,\n",
-      "        608.22085157,  624.53259848, 1053.20855822,  975.37297648,\n",
-      "       3853.0134223 , 2313.48088428,  499.38861572,  639.61950033,\n",
-      "        887.5538597 ,  788.41409268,  523.75398508,  632.64110231,\n",
-      "       1052.03681108,  543.78141501,  621.62258597, 1630.01032484,\n",
-      "       2447.91151105, 1096.9718159 ,  685.70999296, 1714.51388695,\n",
-      "        519.87963383, 1854.07584404,  259.58417506, 1324.66267973,\n",
-      "        499.62906124, 1518.56054012, 1131.49281251,  942.58955569,\n",
-      "        912.10409409,  857.53855258,  901.99033586,  886.24259759,\n",
-      "       2082.22400799, 1340.5439433 ,  319.21083003,  540.34747789,\n",
-      "       1407.26846277, 2432.13037238, 2379.61788194,  910.45517352,\n",
-      "        736.49535247, 1984.28393677,  527.02972445,  240.        ,\n",
-      "        484.12402324,  496.2210185 , 1748.44262287, 1104.24974624,\n",
-      "       1959.40890949, 1184.73205741,  736.61322517,  774.28412815,\n",
-      "        616.42473224,  920.5943251 ,  999.01918188, 1500.5816131 ,\n",
-      "       1394.77181556, 1686.53685347, 1220.80206301, 1278.51908078,\n",
-      "        240.        ,  271.9766794 , 1175.73795193, 1086.32841753,\n",
-      "       1401.029229  ,  613.90328888,  706.33403638,  885.59035908,\n",
-      "       1620.96453974,  522.76948478,  755.40073211, 2166.75846531,\n",
-      "       1798.76620193, 1097.04648392, 1636.30436128,  520.        ,\n",
-      "        883.83306517, 1250.55488334,  259.79200465,  697.79260255,\n",
-      "        849.87865499,  802.52517425, 1035.7487592 ,  843.33289705,\n",
-      "       1105.21936718,  519.74386584, 1457.8465321 , 1586.73827779,\n",
-      "        502.93518229,  837.36020953, 2197.82234654,  895.        ,\n",
-      "        995.44364052, 6976.95682715, 6976.95542209, 1212.06599168,\n",
-      "        942.95393746,  259.79200465,  899.97546839,  819.73773677,\n",
-      "        698.89992626,  821.81659839,  533.22132571,  579.61428855,\n",
-      "        955.88915556, 1577.75119041, 1267.7785787 ,  533.9535687 ,\n",
-      "        885.2870701 , 1391.93907798,  820.92048462, 1378.08843167,\n",
-      "        910.99294328, 1661.51228683,  788.70334697,  896.19466248,\n",
-      "        240.        ,  838.12403717, 2655.79301623,  867.6394347 ,\n",
-      "        272.39109852,  718.21704248, 1193.82936311, 1171.21231545,\n",
-      "       2383.42468517, 1165.31811908, 1241.69179855, 2362.09694188,\n",
-      "       1473.43326234,  845.74327418, 1028.7596982 , 1705.37308805,\n",
-      "       2509.03092702, 2190.26191388, 1010.80369525, 1237.14267688,\n",
-      "        306.70109189, 1116.70319069, 1605.94796576, 1112.72245703,\n",
-      "        699.23842977, 3020.00749188,  521.9870682 , 3728.91516394,\n",
-      "       1047.50035727,  495.        , 1831.96201482, 2231.64702847,\n",
-      "        895.        , 1250.60711794,  912.21762647,  260.        ,\n",
-      "       1741.4798027 , 1135.89324127, 1085.48732431,  874.28039163,\n",
-      "       1852.97601858,  658.19576621,  839.96301564,  981.39119502,\n",
-      "        900.62917746, 1190.65453853, 1818.73446674,  466.7273135 ,\n",
-      "       1630.29523398, 1948.20244764, 3652.8881082 ,  893.9355868 ,\n",
-      "       1020.37855499, 1125.35548982, 1728.79685381, 1521.87705614,\n",
-      "       1270.35776954,  714.993502  ,  980.74137129, 1032.53274938,\n",
-      "        744.79954793, 1250.53653614,  621.56963433,  416.17865094,\n",
-      "       1367.56256677, 4792.87236015,  777.69797108, 2065.40882159,\n",
-      "        259.62403807,  259.58417506,  495.        , 2517.82511134,\n",
-      "        520.        , 1562.78600898, 1897.6403179 ,  809.66803197,\n",
-      "       1374.50532444,  240.        , 1249.65716405,  895.        ,\n",
-      "        547.160492  ,  565.38282834, 1122.31798125,  893.16613416,\n",
-      "        716.19485231, 1138.99156825,  497.90202306, 1343.63242164,\n",
-      "       1338.6274727 ,  525.07586276, 1811.10389878,  260.        ,\n",
-      "        520.        ,  976.57904482, 1109.8470097 , 1422.65251265,\n",
-      "       2908.9763878 , 3020.01239752, 1420.95286885,  814.66509559,\n",
-      "       1106.61054788, 2334.35037637,  884.54420095,  579.14455289,\n",
-      "       1163.76132178,  624.39285619,  532.66677458,  260.        ,\n",
-      "        930.80416205, 1677.0935882 ,  872.89278294, 1619.80867534,\n",
-      "        629.69706369,  816.46274998, 1097.81894698, 2098.02577043,\n",
-      "       1221.49899463,  746.66328958, 1067.79252025,  968.16721765,\n",
-      "        525.92189869, 1937.90553339,  802.49789024,  260.        ,\n",
-      "       1183.6176017 ,  910.11094439,  562.42591186, 3040.89281221,\n",
-      "       1050.00732804, 1348.60971709, 2946.22033627, 1256.90523988,\n",
-      "        856.19889251, 1232.18075569, 3618.18012396,  840.        ,\n",
-      "        702.82180591,  922.01459688,  413.53489029, 3912.61045288,\n",
-      "        909.64249485, 1021.86839983,  496.58895325, 2320.64506648,\n",
-      "        860.2881407 , 1334.86841894,  913.26431671, 1270.75212408,\n",
-      "        575.09857194, 2187.41082366,  496.25770669, 1672.54960143,\n",
-      "       1084.44449498,  849.9945267 ,  260.25194826, 1052.18343534,\n",
-      "        287.20334496, 1654.4424884 , 1183.39611317, 2547.03169215,\n",
-      "       1677.74852901,  536.20488872, 1867.42585674,  840.01136845,\n",
-      "       2159.36930356, 1301.66166201,  992.77898109, 1153.8953619 ,\n",
-      "        723.43031913,  940.45721318, 1095.55045256,  664.9625642 ,\n",
-      "       1682.61352407, 2535.83559754, 1143.91054848,  516.17118118,\n",
-      "       1394.19382857,  849.45567641,  928.67546462,  774.01712693,\n",
-      "       1115.00685157,  886.91192089, 1995.87767886, 1580.56691824,\n",
-      "       1274.99592742, 1625.15468797, 2578.22324964, 1611.25719125,\n",
-      "        623.00575163, 1053.47738168, 1682.97878986, 2446.24678263,\n",
-      "       2395.39273374,  887.91097471,  894.43257492,  677.37718446,\n",
-      "        704.55067163,  542.64483721, 1832.0010421 ,  543.28071852,\n",
-      "        895.        , 1093.50138098, 1466.59970571,  260.        ,\n",
-      "       1678.44458033, 1682.78618082, 1709.87633846, 2109.26445907,\n",
-      "       1134.02300144,  523.02638396, 1202.28591128,  520.7443196 ,\n",
-      "       1177.09792636,  895.        , 1227.88082153,  754.76702404,\n",
-      "       1134.78231617, 1296.20203299, 1367.74372073,  261.73376514,\n",
-      "        240.        ,  519.74386584,  259.79200465, 2324.91213264,\n",
-      "       1841.09126636,  982.08674832, 1301.02366072,  495.        ,\n",
-      "        520.        , 1750.79781179,  787.26156372,  889.27706473,\n",
-      "       1408.79188693,  383.98342996,  759.52144678,  478.10406887,\n",
-      "       1483.96708642, 1529.40530721,  695.41339795,  711.64712742,\n",
-      "       3330.09091181,  520.12591794, 1062.54007306, 2258.18489529,\n",
-      "       2499.03568087,  953.91381309, 4319.95258806,  520.        ,\n",
-      "       2039.2999595 ,  505.05532433, 1281.24534549,  580.40790981,\n",
-      "        969.94603119, 1139.63717968, 1434.72940637,  827.82609218,\n",
-      "       2894.83336793,  523.02638396,  520.61339436,  240.        ,\n",
-      "        495.24396359,  784.00704712, 3398.28439785,  866.20478222,\n",
-      "        903.87641576,  520.        ,  895.        , 1278.13471176,\n",
-      "       1121.7674802 , 1158.10864506,  880.30693079,  840.5329318 ,\n",
-      "        895.        ,  855.17938856,  685.18637882, 1550.34651756,\n",
-      "        528.67821057,  260.        ,  845.97568248,  496.2210185 ,\n",
-      "        668.03024257,  736.75607523, 1987.62989301, 1461.84191017,\n",
-      "       1713.75375997,  944.18904603,  895.        ,  527.54915947,\n",
-      "       2607.0059239 ,  320.88688573,  520.21168095,  922.33306206,\n",
-      "        584.30932613,  496.18938795,  518.06031733,  510.10335126,\n",
-      "        240.23798292, 1374.28840431,  520.66374994,  520.        ,\n",
-      "       1474.60770946,  591.12602329,  628.92899765,  519.74386584,\n",
-      "        750.62940597, 2107.9553265 , 1258.88561255, 1396.06434529,\n",
-      "       1193.60849343, 1224.50594284,  795.95519098,  260.        ,\n",
-      "        837.00698384, 1546.75220947,  273.79175528,  259.58417506,\n",
-      "       1347.14436699,  520.        , 1384.55908909,  428.91883988,\n",
-      "       1713.16833755,  849.78326286, 2488.23293123,  527.86381196,\n",
-      "       3723.01748945, 2342.39461269,  524.61791865, 1115.23217243,\n",
-      "        724.98484238,  948.07184603,  778.51117275, 2212.4380112 ,\n",
-      "       1918.78316199,  895.        ,  263.46259125,  698.17996259,\n",
-      "        575.4250496 ,  520.        , 2823.14097203,  510.82457787,\n",
-      "       1336.06382905, 3290.80347328,  728.79776116,  260.        ,\n",
-      "       1972.99879122,  895.3249816 , 1329.10515538,  909.14379775])}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
-      "  warnings.warn(\n",
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
-      "  warnings.warn(\n",
-      "c:\\Users\\claytonc\\Desktop\\Uni-Year-3\\headlights-main\\aai-ml\\Lib\\site-packages\\sklearn\\pipeline.py:62: FutureWarning: This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.\n",
-      "  warnings.warn(\n"
+      "Pipeline(steps=[('preprocessor',\n",
+      "                 ColumnTransformer(transformers=[('num',\n",
+      "                                                  Pipeline(steps=[('imputer',\n",
+      "                                                                   SimpleImputer(strategy='median')),\n",
+      "                                                                  ('scaler',\n",
+      "                                                                   RobustScaler())]),\n",
+      "                                                  ['InjuryPrognosis',\n",
+      "                                                   'GeneralRest',\n",
+      "                                                   'SpecialTherapy',\n",
+      "                                                   'SpecialEarningsLoss',\n",
+      "                                                   'SpecialAssetDamage',\n",
+      "                                                   'GeneralFixed',\n",
+      "                                                   'SpecialLoanerVehicle',\n",
+      "                                                   'SpecialJourneyExpenses',\n",
+      "                                                   'SpecialUsageLoss',\n",
+      "                                                   'DaysBetweenAcc...\n",
+      "                                                       'RandomForest': RandomForestRegressor(random_state=42),\n",
+      "                                                       'Ridge': Ridge()},\n",
+      "                                               param_grids={'GradientBoostingRegressor': {'learning_rate': [0.01,\n",
+      "                                                                                                            0.1,\n",
+      "                                                                                                            0.2],\n",
+      "                                                                                          'max_depth': [3,\n",
+      "                                                                                                        5,\n",
+      "                                                                                                        7],\n",
+      "                                                                                          'n_estimators': [50,\n",
+      "                                                                                                           100,\n",
+      "                                                                                                           200]},\n",
+      "                                                            'LinearRegression': {},\n",
+      "                                                            'RandomForestRegressor': {'max_depth': [None,\n",
+      "                                                                                                    10,\n",
+      "                                                                                                    20],\n",
+      "                                                                                      'min_samples_split': [2,\n",
+      "                                                                                                            5],\n",
+      "                                                                                      'n_estimators': [50,\n",
+      "                                                                                                       100,\n",
+      "                                                                                                       200]},\n",
+      "                                                            'Ridge': {'alpha': [0.01,\n",
+      "                                                                                0.1,\n",
+      "                                                                                1.0,\n",
+      "                                                                                10.0,\n",
+      "                                                                                100.0]}}))])\n"
      ]
     }
    ],
@@ -9511,7 +9160,7 @@
     "    print(\"----------------------\")\n",
     "\n",
     "    # Save the best model based on lowest RMSE, highest R^2, lowest RMSE_GBP, and lowest MAE_GBP\n",
-    "    best_model = results_pipeline\n",
+    "    best_model = pipeline\n",
     "    best_score = {\n",
     "        'RMSE': results_pipeline['RMSE'],\n",
     "        'R^2': results_pipeline['R^2'],\n",
@@ -9520,14 +9169,14 @@
     "    }\n",
     "\n",
     "    if results_pipeline_tuned['RMSE'] < best_score['RMSE'] and results_pipeline_tuned['R^2'] > best_score['R^2'] and results_pipeline_tuned['RMSE_GBP'] < best_score['RMSE_GBP'] and results_pipeline_tuned['MAE_GBP'] < best_score['MAE_GBP']:\n",
-    "        best_model = results_pipeline_tuned\n",
+    "        best_model = pipeline_tuned\n",
     "        best_score['RMSE'] = results_pipeline_tuned['RMSE']\n",
     "        best_score['R^2'] = results_pipeline_tuned['R^2']\n",
     "        best_score['RMSE_GBP'] = results_pipeline_tuned['RMSE_GBP']\n",
     "        best_score['MAE_GBP'] = results_pipeline_tuned['MAE_GBP']\n",
     "\n",
     "    if results_best_pipeline['RMSE'] < best_score['RMSE'] and results_best_pipeline['R^2'] > best_score['R^2'] and results_best_pipeline['RMSE_GBP'] < best_score['RMSE_GBP'] and results_best_pipeline['MAE_GBP'] < best_score['MAE_GBP']:\n",
-    "        best_model = results_best_pipeline\n",
+    "        best_model = best_pipeline\n",
     "        best_score['RMSE'] = results_best_pipeline['RMSE']\n",
     "        best_score['R^2'] = results_best_pipeline['R^2']\n",
     "        best_score['RMSE_GBP'] = results_best_pipeline['RMSE_GBP']\n",
@@ -9556,7 +9205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Accidentally saved the output of `evaluate_model` which is a dict of results to `.pkl` instead of the actual best performant pipeline.