### PR TITLE
Added back STATICFILES_DIRS

### DIFF
--- a/desd/settings.py
+++ b/desd/settings.py
@@ -129,7 +129,10 @@ USE_TZ = True
 
 # Change these paths
 STATIC_URL = "static/"
-STATIC_ROOT = os.path.join(BASE_DIR, "static")
+if DEBUG:
+    STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
+else:
+    STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # Media files (uploaded files)
 MEDIA_URL = '/media/'


### PR DESCRIPTION
Added back STATICFILES_DIRS
It seems django doesn't use the static_root to serve static files, only deployment servers use that i guess?
Django doesn't like both of these settings being active at the same time so we switch which one is set based on DEBUG.