### PR TITLE
Administrators approve ai engineers on registration

### DIFF
--- a/desd/settings.py
+++ b/desd/settings.py
@@ -147,6 +147,11 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 LOGIN_REDIRECT_URL = "/"
 
+AUTHENTICATION_BACKENDS = [
+    'myapp.auth_backends.AllowInactiveLoginBackend',
+    'django.contrib.auth.backends.ModelBackend',
+]
+
 # Temporary email redirect, this puts password reset emails into the console logs.
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 

--- a/desd/urls.py
+++ b/desd/urls.py
@@ -19,10 +19,12 @@ from django.urls import path, include
 from django.views.generic import RedirectView
 from django.conf import settings
 from django.conf.urls.static import static
+from django.contrib.auth import views as auth_views
 
 from desd.settings import DEBUG
 from myapp.views.EngineerDashboardView import EngineerDashboardView
 from myapp.views.ErrorView import Error_400, Error_403, Error_404, Error_500
+from myapp.forms.CustomAuthenticationForm import CustomAuthenticationForm
 
 handler400 = Error_400.as_view()
 handler403 = Error_403.as_view()
@@ -30,7 +32,42 @@ handler404 = Error_404.as_view()
 handler500 = Error_500.as_view()
 
 urlpatterns = [
-    path("accounts/", include("django.contrib.auth.urls")),
+    # LOGIN/LOGOUT
+    path('accounts/login/', auth_views.LoginView.as_view(
+        template_name='registration/login.html', 
+        authentication_form=CustomAuthenticationForm
+    ), name='login'),
+    
+    path('accounts/logout/', auth_views.LogoutView.as_view(
+        template_name='registration/logged_out.html'
+    ), name='logout'),
+
+    # PASSWORD CHANGE (requires user to be logged in)
+    path('accounts/password_change/', auth_views.PasswordChangeView.as_view(
+        template_name='registration/password_change_form.html'
+    ), name='password_change'),
+    
+    path('accounts/password_change/done/', auth_views.PasswordChangeDoneView.as_view(
+        template_name='registration/password_change_done.html'
+    ), name='password_change_done'),
+
+    # PASSWORD RESET (email-based)
+    path('accounts/password_reset/', auth_views.PasswordResetView.as_view(
+        template_name='registration/password_reset_form.html'
+    ), name='password_reset'),
+    
+    path('accounts/password_reset/done/', auth_views.PasswordResetDoneView.as_view(
+        template_name='registration/password_reset_done.html'
+    ), name='password_reset_done'),
+    
+    path('accounts/reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(
+        template_name='registration/password_reset_confirm.html'
+    ), name='password_reset_confirm'),
+    
+    path('accounts/reset/done/', auth_views.PasswordResetCompleteView.as_view(
+        template_name='registration/password_reset_complete.html'
+    ), name='password_reset_complete'),
+
     path("admin/", admin.site.urls),
     
     # Root redirects to app/

--- a/myapp/auth_backends.py
+++ b/myapp/auth_backends.py
@@ -1,0 +1,5 @@
+from django.contrib.auth.backends import ModelBackend
+
+class AllowInactiveLoginBackend(ModelBackend):
+    def user_can_authenticate(self, user):
+        return True

--- a/myapp/forms/CustomAuthenticationForm.py
+++ b/myapp/forms/CustomAuthenticationForm.py
@@ -1,0 +1,10 @@
+from django import forms
+from django.contrib.auth.forms import AuthenticationForm
+
+class CustomAuthenticationForm(AuthenticationForm):
+    def confirm_login_allowed(self, user):
+        if not user.is_active:
+            raise forms.ValidationError(
+                "Your account is inactive. Please contact support.",
+                code='inactive',
+            )

--- a/myapp/models.py
+++ b/myapp/models.py
@@ -286,12 +286,23 @@ class UserProfile(models.Model):
                        ) -> SimpleResultWithPayload:   
         result = SimpleResultWithPayload()
         
+        groupID = int(groupID)
+
         result.add_messages_from_result_and_mark_unsuccessful_if_error_found(UserProfile.validate_unique_username(username))
         if not result.success:
             return result
         
         with transaction.atomic():
-            newUserAuth = User.objects.create_user(username=username, email=email, password=password)
+            user_kwargs = {
+                'username': username,
+                'email': email,
+                'password': password,
+            }
+
+            if groupID == UserProfile.GroupIDs.ENGINEER_ID:
+                user_kwargs['is_active'] = False
+
+            newUserAuth = User.objects.create_user(**user_kwargs)
             
             # All users should have end user/customer permissions
             endUserGroup = Group.objects.get(id=UserProfile.GroupIDs.END_USER_ID)

--- a/myapp/tests/test_CustomAuthForm.py
+++ b/myapp/tests/test_CustomAuthForm.py
@@ -1,0 +1,51 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from myapp.forms.CustomAuthenticationForm import CustomAuthenticationForm
+from django.contrib.auth import authenticate
+
+class CustomAuthenticationFormTest(TestCase):
+
+    def setUp(self):
+        # Create a user with inactive status
+        self.inactive_user = User.objects.create_user(username="inactiveuser", password="testpassword")
+        self.inactive_user.is_active = False
+        self.inactive_user.save()
+
+        # Create a user with active status
+        self.active_user = User.objects.create_user(username="activeuser", password="testpassword")
+        self.active_user.is_active = True
+        self.active_user.save()
+
+    def test_inactive_user_login(self):
+        # Test that the form raises an error for inactive users
+        form_data = {
+            'username': 'inactiveuser',
+            'password': 'testpassword',
+        }
+        form = CustomAuthenticationForm(data=form_data)
+
+        # Check if the form is not valid
+        self.assertFalse(form.is_valid())
+        
+        # Ensure the error message is specific to inactive users
+        self.assertEqual(form.errors['__all__'][0], 'Your account is inactive. Please contact support.')
+
+    def test_active_user_login(self):
+        # Test that the form works for an active user
+        form_data = {
+            'username': 'activeuser',
+            'password': 'testpassword',
+        }
+        form = CustomAuthenticationForm(data=form_data)
+
+        # Check if the form is valid
+        self.assertTrue(form.is_valid())
+
+        user = authenticate(username='activeuser', password='testpassword')
+        self.assertIsNotNone(user)
+        self.assertTrue(user.is_active)
+
+    def tearDown(self):
+        # Clean up users after tests
+        self.inactive_user.delete()
+        self.active_user.delete()

--- a/myapp/tests/views/test_AccountCreationPage.py
+++ b/myapp/tests/views/test_AccountCreationPage.py
@@ -13,8 +13,10 @@ class AccountCreationTest(BaseViewTest, TestCase):
     def setUp(self):
         end_user_group = Group.objects.create(pk=UserProfile.GroupIDs.END_USER_ID, name="end user")
         finance_group = Group.objects.create(pk=UserProfile.GroupIDs.FINANCE_ID, name="finance")
+        engineer_group = Group.objects.create(pk=UserProfile.GroupIDs.ENGINEER_ID, name="engineer")
         end_user_group.save()
         finance_group.save()
+        engineer_group.save()
         
         return BaseViewTest.setUp(self)
 
@@ -46,3 +48,10 @@ class AccountCreationTest(BaseViewTest, TestCase):
         response_context = response.context.pop()
         print(response_context)
         self.assertEqual(len(response_context['error_messages']), 1)
+
+        #Creating an AI engineer account will default to is_active=false, returns to home
+        unique_engineer = TestData.NAME+"ENGINEER_TEST"
+        payload = {"username": unique_engineer, "email": TestData.EMAIL, "password": TestData.PASSWORD, "userType": UserProfile.GroupIDs.ENGINEER_ID}
+        response = BaseViewTest._test_post_view_response(self, payload=payload)
+        self.assertEqual(response.templates[0].name, Templates.HOME)
+        self.client.logout()

--- a/myapp/views/AccountManagementView.py
+++ b/myapp/views/AccountManagementView.py
@@ -48,7 +48,7 @@ class AccountCreationView(View):
         if (userProfile.auth_id.groups.filter(id=UserProfile.GroupIDs.FINANCE_ID).exists() and is_owner):
             result = Company.create_new_company(userProfile, company_name)
         
-        login(request, userProfile.auth_id)
+        login(request, userProfile.auth_id, backend='django.contrib.auth.backends.ModelBackend')
         return redirect("index")
 
     def __render_account_creation_page(self, request, error_messages: list[Message]) -> HttpResponse:

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -3,9 +3,25 @@
 {% block content %}
 {% load widget_tweaks %}
 
+    <!-- {% if form.errors %}
+        <h1> {{form.errors}}</h1>
+    {% endif %} -->
+
     {% if form.errors %}
-        <h1> You have entered an incorrect username or password. Please try again.</h1>
+        <div class="alert alert-danger">
+            <ul>
+                {% for field in form %}
+                    {% for error in field.errors %}
+                        <li>{{ error }}</li>
+                    {% endfor %}
+                {% endfor %}
+                {% for error in form.non_field_errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        </div>
     {% endif %}
+
 
     {% if next %}
         {% if user.is_authenticated %}


### PR DESCRIPTION
This creates the AI engineer user with `is_active = False`  as default. Additionally, a custom auth backend and authentication form has been added to return a verbose error when logging in with an inactive account. This retains the behaviour of the default django auth.